### PR TITLE
Need stricter package releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ Authors@R: c(
 Description: Redistricting analysis for all 50 U.S. states.
 Imports: 
     dplyr (>= 1.0.7),
-    geomander (>= 1.1.0),
-    PL94171,
+    geomander (>= 1.1.0.9000),
+    PL94171 (>= 1.0.0),
     purrr,
     tidyr,
     readr,


### PR DESCRIPTION
geomander 1.1.0 is not sufficient for get_vest

It also seemed my version of PL94171 was too old and didn't have a function, though I don't remember which one.

Any other packages that require a minimum version