### PR TITLE
use GEOID to avoid VTD non-uniqueness

### DIFF
--- a/R/template/01_prep.R
+++ b/R/template/01_prep.R
@@ -40,7 +40,7 @@ if (!file.exists(here(shp_path))) {
         mutate(GEOID = paste0(censable::match_fips("``STATE``"), vtd)) %>%
         select(-vtd)
     d_cd <- make_from_baf("``STATE``", "CD", "VTD")  %>%
-        transmute(GEOID = paste0(censable::match_fips("CO"), vtd),
+        transmute(GEOID = paste0(censable::match_fips("``STATE``"), vtd),
                   cd_2010 = as.integer(cd))
     ``state``_shp <- left_join(``state``_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by="GEOID") %>%


### PR DESCRIPTION
Fix #6 by using `GEOID` over `vtd` which is (rarely?) unique at the state level.

cc: @kuriwaki 

