### PR TITLE
2020 Massachusetts Congressional Districts

### DIFF
--- a/analyses/MA_cd_2020/01_prep_MA_cd_2020.R
+++ b/analyses/MA_cd_2020/01_prep_MA_cd_2020.R
@@ -1,0 +1,75 @@
+###############################################################################
+# Download and prepare data for `MA_cd_2020` analysis
+# © ALARM Project, December 2021
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MA_cd_2020}")
+
+path_data <- download_redistricting_file("MA", "data-raw/MA")
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MA_2020/shp_vtd.rds"
+perim_path <- "data-out/MA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MA} shapefile")
+    # read in redistricting data
+    ma_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$MA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MA", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("MA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MA", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("MA"), vtd),
+            cd_2010 = as.integer(cd))
+    ma_shp <- left_join(ma_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    dists <- read_sf("https://redistricting.lls.edu/wp-content/uploads/ma_2020_congress_2021-11-05_2031-06-30.json")
+
+    ma_shp$cd_2020 <- as.numeric(dists$Districts)[geo_match(from = ma_shp, to = dists, method = "area")]
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = ma_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ma_shp <- rmapshaper::ms_simplify(ma_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ma_shp$adj <- redist.adjacency(ma_shp)
+
+    ma_shp <- ma_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ma_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ma_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MA} shapefile")
+}

--- a/analyses/MA_cd_2020/02_setup_MA_cd_2020.R
+++ b/analyses/MA_cd_2020/02_setup_MA_cd_2020.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `MA_cd_2020`
+# © ALARM Project, December 2021
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MA_cd_2020}")
+
+map <- redist_map(ma_shp, pop_tol = 0.005,
+    existing_plan = cd_2020, adj = ma_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MA_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MA_2020/MA_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MA_cd_2020/03_sim_MA_cd_2020.R
+++ b/analyses/MA_cd_2020/03_sim_MA_cd_2020.R
@@ -1,0 +1,26 @@
+###############################################################################
+# Simulate plans for `MA_cd_2020`
+# © ALARM Project, December 2021
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MA_cd_2020}")
+
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MA_2020/MA_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MA_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MA_2020/MA_cd_2020_stats.csv")
+
+cli_process_done()

--- a/analyses/MA_cd_2020/doc_MA_cd_2020.md
+++ b/analyses/MA_cd_2020/doc_MA_cd_2020.md
@@ -1,0 +1,21 @@
+# 2020 Massachusetts Congressional Districts
+
+## Redistricting requirements
+In Massachusetts, districts must:
+
+1. be contiguous
+1. have equal populations
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+We use the basic algorithmic county constraint applied to pseudo counties, as Congressional plans in MA do seem to follow county and municipal boundaries, despite no legal constraint. Pseudo counties are constructed by following municipal boundaries in counties larger than a district and county lines.
+
+## Data Sources
+Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Massachusetts.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Massachusetts, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use the basic algorithmic county constraint applied to pseudo counties, as Congressional plans in MA do seem to follow county and municipal boundaries, despite no legal constraint. Pseudo counties are constructed by following municipal boundaries in counties larger than a district and county lines.

## Data Sources
Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Massachusetts.
No special techniques were needed to produce the sample.


## Validation

![image](https://user-images.githubusercontent.com/28026893/145615437-b4547c4e-266a-441f-80aa-8f400b0acffb.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan