### PR TITLE
2020 Mississippi Congressional Districts

### DIFF
--- a/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
@@ -36,63 +36,27 @@ perim_path <- "data-out/MS_2020/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong MS} shapefile")
     # read in redistricting data
-    # custom tabulation from NYT Upshot data
-    state <- "MS"
-    nyt <- geojsonsf::geojson_sf("data-raw/precincts-with-results.geojson") %>%
-        mutate(state = str_sub(GEOID, 1, 2)) %>%
-        filter(state == "28")
-
-    block <- censable::build_dec("block", state, year = 2010)
-    match_list <- geo_match(from = block, to = nyt, method = "area")
-    elec_at_2010 <- tibble(GEOID = block$GEOID) %>%
-        mutate(pre_20_rep_tru = estimate_down(value = nyt$votes_rep, wts = block[["vap"]], group = match_list),
-            pre_20_dem_bid = estimate_down(value = nyt$votes_dem, wts = block[["vap"]], group = match_list)
-        )
-
-    vest_cw <- cvap::vest_crosswalk(state)
-    rt <- PL94171::pl_retally(elec_at_2010, crosswalk = vest_cw)
-
-    tract <- rt %>%
-        censable::breakdown_geoid() %>%
-        censable::construct_geoid("tract") %>%
-        select(GEOID, starts_with("pre_")) %>%
-        group_by(GEOID) %>%
-        summarize(across(.fns = sum)) %>%
-        mutate(ndv = pre_20_dem_bid, adv_20 = pre_20_dem_bid,
-            nrv = pre_20_rep_tru, arv_20 = pre_20_rep_tru)
-
-    ms_shp <- censable::build_dec("tract", state) %>%
-        left_join(tract, by = "GEOID")
-    ms_shp <- ms_shp %>%
-        censable::breakdown_geoid() %>%
-        mutate(state = "28")
-
-    ms_shp <- ms_shp %>%
+    ms_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
         st_transform(EPSG$MS)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # add municipalities
-    d_muni <- PL94171::pl_get_baf("MS")$INCPLACE_CDP %>%
-        censable::breakdown_geoid("BLOCKID") %>%
-        censable::construct_geoid("tract") %>%
-        group_by(GEOID) %>%
-        summarize(muni = Mode(PLACEFP))
-    d_cd <- PL94171::pl_get_baf("MS")$CD %>%
-        censable::breakdown_geoid("BLOCKID") %>%
-        censable::construct_geoid("tract") %>%
-        group_by(GEOID) %>%
-        summarize(cd_2010 = Mode(DISTRICT))
+    d_muni <- make_from_baf("MS", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("MS"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MS", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("MS"), vtd),
+                  cd_2010 = as.integer(cd))
     ms_shp <- left_join(ms_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2010, .after = county)
 
-    ms_shp <- ms_shp %>% filter(!st_is_empty(geometry))
-
     # add enacted ----
     cd_shp <- st_read(here(path_shp))
     ms_shp <- ms_shp %>%
-        mutate(cd_2020_prop = as.integer(cd_shp$DISTRICT)[
+        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
             geo_match(ms_shp, cd_shp, method = "area")],
             .after = cd_2010)
 

--- a/analyses/MS_cd_2020/02_setup_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/02_setup_MS_cd_2020.R
@@ -5,7 +5,7 @@
 cli_process_start("Creating {.cls redist_map} object for {.pkg MS_cd_2020}")
 
 map <- redist_map(ms_shp, pop_tol = 0.005,
-    existing_plan = cd_2020_prop, adj = ms_shp$adj)
+    existing_plan = cd_2020, adj = ms_shp$adj)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MS_2020"

--- a/analyses/MS_cd_2020/03_sim_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/03_sim_MS_cd_2020.R
@@ -14,8 +14,6 @@ plans <- redist_smc(map, nsims = 5e3, counties = county, constraints = cons)
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/MS_2020/MS_cd_2020_plans.rds"), compress = "xz")
 cli_process_done()
@@ -41,7 +39,7 @@ if (interactive()) {
                            size = 0.5, alpha = 0.5) +
         scale_y_continuous('Percent Black by VAP') +
         labs(title = 'Mississippi Proposed Plan versus Simulations') +
-        scale_color_manual(values = c(cd_2020_prop = 'black')) +
+        scale_color_manual(values = c(cd_2020 = 'black')) +
         ggredist::theme_r21()
 
 }

--- a/analyses/MS_cd_2020/doc_MS_cd_2020.md
+++ b/analyses/MS_cd_2020/doc_MS_cd_2020.md
@@ -15,7 +15,7 @@ We enforce a maximum population deviation of 0.5%.
 We ensure that there is a majority minority district with at least 55% VAP.
 
 ## Data Sources
-Data for Mississippi comes from the [The Upshot Presidential Precinct Map data](https://github.com/TheUpshot/presidential-precinct-map-2020) and are estimated to 2020 Census tracts.
+Data for Mississippi comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.


### PR DESCRIPTION
## Redistricting requirements
In Mississippi, [under Mississippi Code 5-3-123](https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=d062935b-fafc-45ea-a1f4-dc1ba2a3377c&nodeid=AAEAACAAFAAC&nodepath=%2FROOT%2FAAE%2FAAEAAC%2FAAEAACAAF%2FAAEAACAAFAAC&level=4&haschildren=&populated=false&title=%C2%A7+5-3-123.+Preparation+of+plan+to+redistrict+congressional+districts.&config=00JABhZDIzMTViZS04NjcxLTQ1MDItOTllOS03MDg0ZTQxYzU4ZTQKAFBvZENhdGFsb2f8inKxYiqNVSihJeNKRlUp&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A8P6B-7XD2-8T6X-701X-00008-00&ecomp=_g1_kkk&prid=4f3abbc9-f98b-4883-a5ce-fcb4020b7438) and [Committee agreement](https://www.dropbox.com/s/z36sc17c3m1cewv/MississippiLegislativeAndCongressionalRedistrictingCommitteeMinutes2012-04-05.pdf), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. comply with the Voting Rights Act of 1965


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We ensure that there is a majority minority district with at least 55% VAP.

## Data Sources
Data for Mississippi comes from the [The Upshot Presidential Precinct Map data](https://github.com/TheUpshot/presidential-precinct-map-2020) and are estimated to 2020 Census tracts.

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Mississippi.
We apply a hinge Gibbs constraint of strength 25 to encourage drawing a majority black district.


## Validation

![image](https://user-images.githubusercontent.com/28026893/145702692-292ff457-3c67-4ee5-9c1f-6e5041de7348.png)


## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes
- Compares to `cd_2010` while awaiting final plan
- There is a legislature committee which can adopt rules. This will require a double check once a map is enacted to ensure that no new rules are added beyond last decade's basic rules.