### PR TITLE
Patch new `redist` version

### DIFF
--- a/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
+++ b/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
@@ -6,11 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MI_cd_2020}")
 
+constr = redist_constr(map) %>%
+    add_constr_grp_hinge(50, vap - vap_white, vap, 0.60)
+
 plans <- redist_smc(map, nsims = 8e3, counties = pseudocounty,
-    constraints = list(hinge = list(strength = 50, tgts_min = 0.60,
-        min_pop = vap - vap_white,
-        tot_pop = vap)),
-    seq_alpha = 0.4, verbose = FALSE) %>%
+    constraints = constr, seq_alpha = 0.4, verbose = FALSE) %>%
     subset_sampled()
 
 cli_process_done()

--- a/analyses/MI_cd_2020/doc_MI_cd_2020.md
+++ b/analyses/MI_cd_2020/doc_MI_cd_2020.md
@@ -15,7 +15,6 @@ Based on the current plan, two districts should be majority-minority in order to
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
 We apply a county/municipality constraint, as described below. 
-We apply a competitiveness constraint, which discourages disproportionality.
 We target 60% minority share in two districts, and discard any simulations which fail to reach 50% share in two districts.
 
 ## Data Sources


### PR DESCRIPTION
the MI code was written before the new constraint interface and needs to be updated.

This PR also contains a separate correction to the documentation