### PR TITLE
2020 Georgia Congressional Districts

### DIFF
--- a/analyses/GA_cd_2020/01_prep_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/01_prep_GA_cd_2020.R
@@ -1,0 +1,79 @@
+###############################################################################
+# Download and prepare data for `GA_cd_2020` analysis
+# © ALARM Project, October 2021
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg GA_cd_2020}")
+
+path_data <- download_redistricting_file("GA", "data-raw/GA")
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/GA_2020/shp_vtd.rds"
+perim_path <- "data-out/GA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong GA} shapefile")
+    # read in redistricting data
+    ga_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$GA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("GA", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("GA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("GA", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("GA"), vtd),
+            cd_2010 = as.integer(cd))
+    ga_shp <- left_join(ga_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = ga_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ga_shp$adj <- redist.adjacency(ga_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ga_shp <- ga_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ga_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ga_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong GA} shapefile")
+}

--- a/analyses/GA_cd_2020/01_prep_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/01_prep_GA_cd_2020.R
@@ -65,7 +65,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
             keep_shapes = TRUE) %>%
@@ -74,8 +73,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     ga_shp$adj <- redist.adjacency(ga_shp)
-
-    # TODO any custom adjacency graph edits here
 
     ga_shp <- ga_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
@@ -14,6 +14,10 @@ map <- redist_map(ga_shp, pop_tol = 0.005,
 # Add an analysis name attribute ----
 attr(map, "analysis_name") <- "GA_2020"
 
+# Make pseudo counties with default settings ----
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni))
+
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/GA_2020/GA_cd_2020_map.rds", compress = "xz")
 cli_process_done()

--- a/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
@@ -4,12 +4,8 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2020}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ga_shp, pop_tol = 0.005,
     existing_plan = cd_2020, adj = ga_shp$adj)
-
-# TODO any filtering, cores, merging, etc.
 
 # Add an analysis name attribute ----
 attr(map, "analysis_name") <- "GA_2020"

--- a/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `GA_cd_2020`
+# © ALARM Project, October 2021
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2020}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ga_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ga_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# Add an analysis name attribute ----
+attr(map, "analysis_name") <- "GA_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/GA_2020/GA_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/02_setup_GA_cd_2020.R
@@ -7,7 +7,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2020}")
 # TODO any pre-computation (usually not necessary)
 
 map <- redist_map(ga_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = ga_shp$adj)
+    existing_plan = cd_2020, adj = ga_shp$adj)
 
 # TODO any filtering, cores, merging, etc.
 

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -1,0 +1,56 @@
+###############################################################################
+# Simulate plans for `GA_cd_2020`
+# © ALARM Project, October 2021
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg GA_cd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+
+ga_prop <- sum(ga_shp$vap_black) / sum(ga_shp$vap)
+
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+
+# plans_vra_100 <- redist_smc(map, nsims = 5e3, counties = county,
+#                             constraints = list(vra = list(strength = 100,
+#                                                           tgt_vra_min = 0.55,
+#                                                           tgt_vra_other = ga_prop)))
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/GA_2020/GA_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg GA_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/GA_2020/GA_cd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+}

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -6,29 +6,13 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg GA_cd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-ga_black_prop <- sum(ga_shp$vap_black)/sum(ga_shp$vap)
-
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(20, vap_black, vap, tgts_group = c(0.55, ga_black_prop))
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
+    add_constr_grp_hinge(20, vap_black, vap, tgts_group = 0.55)
 
 plans <- redist_smc(map, nsims = 5e3, counties = county, constraints = constr)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/GA_2020/GA_cd_2020_plans.rds"), compress = "xz")
@@ -45,7 +29,6 @@ save_summary_stats(plans, "data-out/GA_2020/GA_cd_2020_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
@@ -60,4 +43,5 @@ if (interactive()) {
         labs(title = 'Approximate Performance') +
         scale_color_manual(values = c(cd_2020_prop = 'black')) +
         ggredist::theme_r21()
+    ggsave("figs/performance.pdf", height = 7, width = 7)
 }

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -8,6 +8,11 @@ cli_process_start("Running simulations for {.pkg GA_cd_2020}")
 
 # TODO any pre-computation (VRA targets, etc.)
 
+ga_black_prop <- sum(ga_shp$vap_black) / sum(ga_shp$vap)
+
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(30, vap_black, vap, tgts_group = c(0.55, ga_black_prop))
+
 # TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
 #  `pop_temper=0.01` and nudging upward from there. Monitor the output for
@@ -18,9 +23,9 @@ cli_process_start("Running simulations for {.pkg GA_cd_2020}")
 #  if that's the problem.
 #  - Ask for help!
 
-ga_prop <- sum(ga_shp$vap_black) / sum(ga_shp$vap)
-
 plans <- redist_smc(map, nsims = 5e3, counties = county)
+plans_vra <- redist_smc(map, nsims = 5e3, counties = county,
+                        constraints = constr)
 
 # plans_vra_100 <- redist_smc(map, nsims = 5e3, counties = county,
 #                             constraints = list(vra = list(strength = 100,
@@ -40,6 +45,7 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg GA_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
+plans_vra <- add_summary_stats(plans_vra, map)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/GA_2020/GA_cd_2020_stats.csv")
@@ -52,5 +58,5 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    validate_analysis(plans, map)
+    validate_analysis(plans_vra, map)
 }

--- a/analyses/GA_cd_2020/doc_GA_cd_2020.md
+++ b/analyses/GA_cd_2020/doc_GA_cd_2020.md
@@ -1,0 +1,23 @@
+# 2020 Georgia Congressional Districts
+
+## Redistricting requirements
+In Georgia, districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of interest as much as possible
+
+### Interpretation of requirements
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Georgia.
+No special techniques were needed to produce the sample.

--- a/analyses/GA_cd_2020/doc_GA_cd_2020.md
+++ b/analyses/GA_cd_2020/doc_GA_cd_2020.md
@@ -1,16 +1,16 @@
 # 2020 Georgia Congressional Districts
 
 ## Redistricting requirements
-In Georgia, districts must:
+In Georgia, districts must, under the 2021-22 State House and Senate Reapportionment Committee guidelines:
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. preserve communities of interest as much as possible
+5. "efforts should be made to avoid the unnecessary pairing of incumbents"
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -20,4 +20,5 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Georgia.
-No special techniques were needed to produce the sample.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.
+We apply a hinge Gibbs constraint of strength 20 to encourage drawing majority black districts.


### PR DESCRIPTION
## Redistricting requirements
In Georgia, districts must, under the 2021-22 State House and Senate Reapportionment Committee guidelines:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. "efforts should be made to avoid the unnecessary pairing of incumbents"

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Georgia.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.
We apply a hinge Gibbs constraint of strength 20 to encourage drawing majority black districts.

## Validation

![validation_20220302_1503](https://user-images.githubusercontent.com/26680063/156440774-82c35459-488b-4dfa-8f6d-342647e25372.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@kuriwaki
