### PR TITLE
2020 Connecticut Congressional Districts

### DIFF
--- a/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
@@ -20,13 +20,12 @@ cli_process_start("Downloading files for {.pkg CT_cd_2020}")
 path_data <- download_redistricting_file("CT", "data-raw/CT")
 
 # download the enacted plan.
-# url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+url <- "https://redistrictingdatahub.org/download/?datasetid=33952&document=%2Fweb_ready_stage%2Flegislative%2F2021_adopted_plans%2Fct_cong_adopted_2022.zip"
+#  Downloading the above .zip file requires that one first create and log into their account with Redistricting Data Hub
 # path_enacted <- "data-raw/CT/CT_enacted.zip"
-# download(url, here(path_enacted))
 # unzip(here(path_enacted), exdir = here(dirname(path_enacted), "CT_enacted"))
 # file.remove(path_enacted)
-# path_enacted <- "data-raw/CT/CT_enacted/XXXXXXX.shp"
-
+path_enacted <- "data-raw/CT/CT_enacted/Districts_1 2022-02-14.shp"
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -54,11 +53,13 @@ if (!file.exists(here(shp_path))) {
         relocate(muni, county_muni, cd_2010, .after = county)
 
     # add the enacted plan
-    # cd_shp <- st_read(here(path_enacted))
-    # ct_shp <- ct_shp %>%
-    #    mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
-    #        geo_match(ct_shp, cd_shp, method = "area")],
-    #        .after = cd_2010)
+    cd_shp <- st_read(here(path_enacted)) %>%
+        st_transform(EPSG$CT) %>%
+        st_make_valid()
+    ct_shp <- ct_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ct_shp, cd_shp, method = "area")],
+            .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = ct_shp,

--- a/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
@@ -21,7 +21,7 @@ path_data <- download_redistricting_file("CT", "data-raw/CT")
 
 # download the enacted plan.
 url <- "https://redistrictingdatahub.org/download/?datasetid=33952&document=%2Fweb_ready_stage%2Flegislative%2F2021_adopted_plans%2Fct_cong_adopted_2022.zip"
-#  Downloading the above .zip file requires that one first create and log into their account with Redistricting Data Hub
+# Downloading the above .zip file requires that one first create and log into their account with Redistricting Data Hub
 # path_enacted <- "data-raw/CT/CT_enacted.zip"
 # unzip(here(path_enacted), exdir = here(dirname(path_enacted), "CT_enacted"))
 # file.remove(path_enacted)
@@ -59,7 +59,12 @@ if (!file.exists(here(shp_path))) {
     ct_shp <- ct_shp %>%
         mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
             geo_match(ct_shp, cd_shp, method = "area")],
-            .after = cd_2010)
+        .after = cd_2010)
+    # A few of the VTDs in the south which encompass mostly-to-only water are not assigned to a district in the final plan.
+    # According to the Report and Plan of the Special Master (2022, page 13), these "water blocks" were left
+    # "largely as they are under the current plan." Hence, we assign these VTDs with missing district assignment to the same
+    # district assignments they had in 2010.
+    ct_shp$cd_2020[is.na(ct_shp$cd_2020)] <- ct_shp$cd_2010[is.na(ct_shp$cd_2020)]
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = ct_shp,

--- a/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/01_prep_CT_cd_2020.R
@@ -1,0 +1,96 @@
+###############################################################################
+# Download and prepare data for `CT_cd_2020` analysis
+# © ALARM Project, December 2021
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CT_cd_2020}")
+
+path_data <- download_redistricting_file("CT", "data-raw/CT")
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/connecticut/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+path_enacted <- "data-raw/CT/CT_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "CT_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/CT/CT_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CT_2020/shp_vtd.rds"
+perim_path <- "data-out/CT_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CT} shapefile")
+    # read in redistricting data
+    ct_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$CT)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("CT", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("CT"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("CT", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("CT"), vtd),
+                  cd_2010 = as.integer(cd))
+    ct_shp <- left_join(ct_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ct_shp <- ct_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ct_shp, cd_shp, method = "area")],
+            .after = cd_2010)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = ct_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ct_shp <- rmapshaper::ms_simplify(ct_shp, keep = 0.05,
+                                         keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ct_shp$adj <- redist.adjacency(ct_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ct_shp <- ct_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ct_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ct_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CT} shapefile")
+}
+

--- a/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
@@ -1,0 +1,25 @@
+###############################################################################
+# Set up redistricting simulation for `CT_cd_2020`
+# © ALARM Project, December 2021
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CT_cd_2020}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ct_shp, pop_tol = 0.005,
+    existing_plan = cd_2020, adj = ct_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CT_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CT_2020/CT_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
@@ -4,18 +4,8 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg CT_cd_2020}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ct_shp, pop_tol = 0.005,
-    existing_plan = cd_2020, adj = ct_shp$adj)
-
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+    existing_plan = cd_2010, adj = ct_shp$adj)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CT_2020"

--- a/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
@@ -7,6 +7,11 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg CT_cd_2020}")
 map <- redist_map(ct_shp, pop_tol = 0.005,
     existing_plan = cd_2020, adj = ct_shp$adj)
 
+# make pseudo counties with 40% of target size
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = 0.4*get_target(map)))
+
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CT_2020"
 

--- a/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/02_setup_CT_cd_2020.R
@@ -5,7 +5,7 @@
 cli_process_start("Creating {.cls redist_map} object for {.pkg CT_cd_2020}")
 
 map <- redist_map(ct_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = ct_shp$adj)
+    existing_plan = cd_2020, adj = ct_shp$adj)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CT_2020"

--- a/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
@@ -7,7 +7,7 @@
 cli_process_start("Running simulations for {.pkg CT_cd_2020}")
 
 
-plans <- redist_smc(map, nsims = 5e3)
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
@@ -1,0 +1,47 @@
+###############################################################################
+# Simulate plans for `CT_cd_2020`
+# © ALARM Project, December 2021
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CT_cd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CT_2020/CT_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CT_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CT_2020/CT_cd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
@@ -6,23 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CT_cd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+plans <- redist_smc(map, nsims = 5e3)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/CT_2020/CT_cd_2020_plans.rds"), compress = "xz")
@@ -38,10 +26,4 @@ save_summary_stats(plans, "data-out/CT_2020/CT_cd_2020_stats.csv")
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}
+validate_analysis(plans, map)

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -1,16 +1,10 @@
 # 2020 Connecticut Congressional Districts
 
 ## Redistricting requirements
-In Connecticut, districts must:
-
-1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
+In Connecticut, there are no state law requirements for congressional districts
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.05%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.
 
 ## Data Sources
 Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -8,6 +8,7 @@ We enforce a maximum population deviation of 0.5%, which is in line with the low
 
 ## Data Sources
 Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Connecticut's 2020 congressional district map comes from [Redistricting Data Hub](https://redistrictingdatahub.org/dataset/2022-connecticut-congressional-districts-approved-plan/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -4,7 +4,7 @@
 In Connecticut, there are no state law requirements for congressional districts
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.05%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.
+We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.
 
 ## Data Sources
 Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -1,0 +1,23 @@
+# 2020 Connecticut Congressional Districts
+
+## Redistricting requirements
+In Connecticut, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Interpretation of requirements
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Connecticut.
+No special techniques were needed to produce the sample.

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -5,6 +5,7 @@ In Connecticut, there are no state law requirements for congressional districts
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.
+We use a pseudo-county constraint described below which attempts to mimic the norms in Connecticut of generally preserving county and municipal boundaries.
 
 ## Data Sources
 Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -15,4 +16,6 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Connecticut.
+We use a pseudo-county constraint to limit the county and municipality splits.
+Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all countied with populations larger than 40% the target population for a district.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Connecticut, there are no state law requirements for congressional districts

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.

## Data Sources
Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Connecticut.
No special techniques were needed to produce the sample.

## Validation

![validation_20220110_1407](https://user-images.githubusercontent.com/90931177/148846726-2caabaab-5ebe-45d6-a4de-cc5d1181a460.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
