### PR TITLE
2020 Arkansas Congressional Districts

### DIFF
--- a/analyses/AR_cd_2020/01_prep_AR_cd_2020.R
+++ b/analyses/AR_cd_2020/01_prep_AR_cd_2020.R
@@ -1,0 +1,89 @@
+###############################################################################
+# Download and prepare data for `AR_cd_2020` analysis
+# © ALARM Project, January 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AR_cd_2020}")
+
+path_data <- download_redistricting_file("AR", "data-raw/AR")
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ar_2020_congress_2022-01-14_2031-06-30.zip"
+path_enacted <- "data-raw/AR/AR_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AR_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/AR/AR_enacted/ar_2020_congress_2022-01-14_2031-06-30.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AR_2020/shp_vtd.rds"
+perim_path <- "data-out/AR_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AR} shapefile")
+    # read in redistricting data
+    ar_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$AR)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AR", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("AR"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("AR", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("AR"), vtd),
+            cd_2010 = as.integer(cd))
+    ar_shp <- left_join(ar_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    cd_shp <- cd_shp %>%
+        st_transform(EPSG$AR) %>%
+        st_make_valid()
+    ar_shp <- ar_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$Districts)[
+            geo_match(ar_shp, cd_shp, method = "area")],
+        .after = cd_2010)
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = ar_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ar_shp <- rmapshaper::ms_simplify(ar_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ar_shp$adj <- redist.adjacency(ar_shp)
+
+    ar_shp <- ar_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ar_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ar_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AR} shapefile")
+}

--- a/analyses/AR_cd_2020/02_setup_AR_cd_2020.R
+++ b/analyses/AR_cd_2020/02_setup_AR_cd_2020.R
@@ -1,0 +1,16 @@
+###############################################################################
+# Set up redistricting simulation for `AR_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AR_cd_2020}")
+
+
+map <- redist_map(ar_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ar_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "AR_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/AR_2020/AR_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AR_cd_2020/03_sim_AR_cd_2020.R
+++ b/analyses/AR_cd_2020/03_sim_AR_cd_2020.R
@@ -1,0 +1,26 @@
+###############################################################################
+# Simulate plans for `AR_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AR_cd_2020}")
+
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AR_2020/AR_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AR_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AR_2020/AR_cd_2020_stats.csv")
+
+cli_process_done()

--- a/analyses/AR_cd_2020/doc_AR_cd_2020.md
+++ b/analyses/AR_cd_2020/doc_AR_cd_2020.md
@@ -1,0 +1,19 @@
+# 2020 Arkansas Congressional Districts
+
+## Redistricting requirements
+In Arkansas, there are no state law requirements for congressional districts.
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
+We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.
+
+## Data Sources
+Data for Arkansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Arkansas' 2020 congressional district map comes from All About Redistricting's [Maps for Download](https://redistricting.lls.edu/mapdownload/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Arkansas.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Arkansas, there are no state law requirements for congressional districts.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.

## Data Sources
Data for Arkansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for Arkansas' 2020 congressional district map comes from All About Redistricting's [Maps for Download](https://redistricting.lls.edu/mapdownload/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Arkansas.
No special techniques were needed to produce the sample.

## Validation
![validation_20220131_1035](https://user-images.githubusercontent.com/90931177/151855618-acf8960a-c5bb-4173-9f32-179206f4f96c.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny
