### PR TITLE
2020 Tennessee Congressional Districts

### DIFF
--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -58,6 +58,16 @@ if (!file.exists(here(shp_path))) {
                              `27740` = "Franklin",
                              `33280` = "Hendersonville",
                              `40000` = "Knoxville",
+                             `08280` = "Brentwood",
+                             `28960` = "Germantown",
+                             `41200` = "La Vergne",
+                             `69420` = "Smyrna",
+                             `70580` = "Spring Hill",
+                             `28540` = "Gallatin",
+                             `15400` = "Cleveland",
+                             `39560` = "Kingsport",
+                             `03440` = "Bartlett",
+                             `16420` = "Collierville",
                              .default = NA_character_))
 
     d_cd <- make_from_baf("TN", "CD", "VTD")  %>%

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -1,0 +1,96 @@
+###############################################################################
+# Download and prepare data for `TN_cd_2020` analysis
+# © ALARM Project, January 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg TN_cd_2020}")
+
+path_data <- download_redistricting_file("TN", "data-raw/TN")
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/tennessee/>
+url <- "https://opendata.arcgis.com/datasets/90e4742978674ef4aaf08eb9f9f845bb_2.zip"
+path_enacted <- "data-raw/TN/TN_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "TN_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/TN/TN_enacted/TN_Congressional_Districts.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/TN_2020/shp_vtd.rds"
+perim_path <- "data-out/TN_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong TN} shapefile")
+    # read in redistricting data
+    tn_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$TN)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("TN", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("TN"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("TN", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("TN"), vtd),
+                  cd_2010 = as.integer(cd))
+    tn_shp <- left_join(tn_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    tn_shp <- tn_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+            geo_match(tn_shp, cd_shp, method = "area")],
+            .after = cd_2010)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = tn_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
+                                         keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    tn_shp$adj <- redist.adjacency(tn_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    tn_shp <- tn_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(tn_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    tn_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong TN} shapefile")
+}
+

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -48,33 +48,33 @@ if (!file.exists(here(shp_path))) {
         mutate(GEOID = paste0(censable::match_fips("TN"), vtd)) %>%
         select(-vtd) %>%
         mutate(muni = recode(muni,
-                             `48000` = "Memphis",
-                             `52006` = "Nashville",
-                             `38320` = "JohnsonCity",
-                             `51560` = "Murfreesboro",
-                             `14000` = "Chattanooga",
-                             `15160` = "Clarksville",
-                             `37640` = "Jackson",
-                             `27740` = "Franklin",
-                             `33280` = "Hendersonville",
-                             `40000` = "Knoxville",
-                             `08280` = "Brentwood",
-                             `28960` = "Germantown",
-                             `41200` = "La Vergne",
-                             `69420` = "Smyrna",
-                             `70580` = "Spring Hill",
-                             `28540` = "Gallatin",
-                             `15400` = "Cleveland",
-                             `39560` = "Kingsport",
-                             `03440` = "Bartlett",
-                             `16420` = "Collierville",
-                             .default = NA_character_))
+            `48000` = "Memphis",
+            `52006` = "Nashville",
+            `38320` = "JohnsonCity",
+            `51560` = "Murfreesboro",
+            `14000` = "Chattanooga",
+            `15160` = "Clarksville",
+            `37640` = "Jackson",
+            `27740` = "Franklin",
+            `33280` = "Hendersonville",
+            `40000` = "Knoxville",
+            `08280` = "Brentwood",
+            `28960` = "Germantown",
+            `41200` = "La Vergne",
+            `69420` = "Smyrna",
+            `70580` = "Spring Hill",
+            `28540` = "Gallatin",
+            `15400` = "Cleveland",
+            `39560` = "Kingsport",
+            `03440` = "Bartlett",
+            `16420` = "Collierville",
+            .default = NA_character_))
 
     d_cd <- make_from_baf("TN", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("TN"), vtd),
-                  cd_2010 = as.integer(cd))
+            cd_2010 = as.integer(cd))
     tn_shp <- left_join(tn_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni, sep = "_"))) %>%
         relocate(muni, county_muni, cd_2010, .after = county)
 
@@ -83,19 +83,19 @@ if (!file.exists(here(shp_path))) {
     tn_shp <- tn_shp %>%
         mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
             geo_match(tn_shp, cd_shp, method = "area")],
-            .after = cd_2010)
+        .after = cd_2010)
 
     # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = tn_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
-                                         keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
@@ -111,4 +111,3 @@ if (!file.exists(here(shp_path))) {
     tn_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong TN} shapefile")
 }
-

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -46,10 +46,10 @@ if (!file.exists(here(shp_path))) {
     d_muni <- make_from_baf("TN", "INCPLACE_CDP", "VTD")  %>%
         mutate(GEOID = paste0(censable::match_fips("TN"), vtd)) %>%
         select(-vtd) %>%
-        mutate(muni = recode(muni,
+        mutate(muni_name = recode(muni,
             `48000` = "Memphis",
             `52006` = "Nashville",
-            `38320` = "JohnsonCity",
+            `38320` = "Johnson City",
             `51560` = "Murfreesboro",
             `14000` = "Chattanooga",
             `15160` = "Clarksville",
@@ -74,8 +74,8 @@ if (!file.exists(here(shp_path))) {
             cd_2010 = as.integer(cd))
     tn_shp <- left_join(tn_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
-        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni, sep = "_"))) %>%
-        relocate(muni, county_muni, cd_2010, .after = county)
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni_name, sep = "_"))) %>%
+        relocate(muni_name, county_muni, cd_2010, .after = county)
 
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
@@ -83,8 +83,6 @@ if (!file.exists(here(shp_path))) {
         mutate(cd_2020 = as.integer(cd_shp$district)[
             geo_match(tn_shp, cd_shp, method = "area")],
         .after = cd_2010)
-
-    # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = tn_shp,

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -58,7 +58,7 @@ if (!file.exists(here(shp_path))) {
                              `27740` = "Franklin",
                              `33280` = "Hendersonville",
                              `40000` = "Knoxville",
-                             .default = NA))
+                             .default = NA_character_))
 
     d_cd <- make_from_baf("TN", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("TN"), vtd),

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -21,13 +21,12 @@ path_data <- download_redistricting_file("TN", "data-raw/TN")
 
 # download the enacted plan.
 # TODO try to find a download URL at <https://redistricting.lls.edu/state/tennessee/>
-url <- "https://opendata.arcgis.com/datasets/90e4742978674ef4aaf08eb9f9f845bb_2.zip"
+url <- "https://thearp.org/documents/941/TN_CD_Enacted02062022.zip"
 path_enacted <- "data-raw/TN/TN_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "TN_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/TN/TN_enacted/TN_Congressional_Districts.shp" # TODO use actual SHP
-
+path_enacted <- "data-raw/TN/TN_enacted/TN_CD_Enacted_02060222.shp" # TODO use actual SHP
 
 cli_process_done()
 
@@ -81,7 +80,7 @@ if (!file.exists(here(shp_path))) {
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
     tn_shp <- tn_shp %>%
-        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+        mutate(cd_2020 = as.integer(cd_shp$district)[
             geo_match(tn_shp, cd_shp, method = "area")],
         .after = cd_2010)
 

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -66,14 +66,14 @@ if (!file.exists(here(shp_path))) {
             `39560` = "Kingsport",
             `03440` = "Bartlett",
             `16420` = "Collierville",
-            .default = ""))
+            .default = NA_character_))
 
     d_cd <- make_from_baf("TN", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("TN"), vtd),
             cd_2010 = as.integer(cd))
     tn_shp <- left_join(tn_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
-        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni_name, sep = "_"))) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni_name, sep = " - "))) %>%
         relocate(muni_name, county_muni, cd_2010, .after = county)
 
     # add the enacted plan

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -66,7 +66,7 @@ if (!file.exists(here(shp_path))) {
             `39560` = "Kingsport",
             `03440` = "Bartlett",
             `16420` = "Collierville",
-            .default = NA_character_))
+            .default = ""))
 
     d_cd <- make_from_baf("TN", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("TN"), vtd),

--- a/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/01_prep_TN_cd_2020.R
@@ -20,7 +20,6 @@ cli_process_start("Downloading files for {.pkg TN_cd_2020}")
 path_data <- download_redistricting_file("TN", "data-raw/TN")
 
 # download the enacted plan.
-# TODO try to find a download URL at <https://redistricting.lls.edu/state/tennessee/>
 url <- "https://thearp.org/documents/941/TN_CD_Enacted02062022.zip"
 path_enacted <- "data-raw/TN/TN_enacted.zip"
 download(url, here(path_enacted))

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -7,7 +7,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2020}")
 # TODO any pre-computation (usually not necessary)
 
 map <- redist_map(tn_shp, pop_tol = 0.005,
-    existing_plan = cd_2020, adj = tn_shp$adj)
+    existing_plan = cd_2010, adj = tn_shp$adj)
 
 # TODO any filtering, cores, merging, etc.
 

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -12,6 +12,11 @@ map <- redist_map(
     adj = tn_shp$adj)
 
 
+# add muni county with top 10 munis
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_2020"
 

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -1,0 +1,25 @@
+###############################################################################
+# Set up redistricting simulation for `TN_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2020}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(tn_shp, pop_tol = 0.005,
+    existing_plan = cd_2020, adj = tn_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "TN_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/TN_2020/TN_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -12,10 +12,13 @@ map <- redist_map(
     adj = tn_shp$adj)
 
 
-# add muni county with top 10 munis
+# add muni county with top 20 munis
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+    mutate(pseudo_county = pick_county_muni(
+        map,
+        counties = county,
+        munis = muni,
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_2020"

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -4,11 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2020}")
 
+cd_pop <- tn_shp %>% as_tibble() %>% count(cd_2020, wt = pop) %>% pull(n)
+tol_existing <- max((cd_pop - mean(cd_pop)) / mean(cd_pop))
 
 map <- redist_map(
     tn_shp,
-    pop_tol = 0.005,
-    existing_plan = cd_2010,
+    pop_tol = tol_existing,
+    existing_plan = cd_2020,
     adj = tn_shp$adj)
 
 
@@ -17,7 +19,7 @@ map <- map %>%
     mutate(pseudo_county = pick_county_muni(
         map,
         counties = county,
-        munis = muni,
+        munis = muni_name,
         pop_muni = get_target(map)))
 
 # Add an analysis name attribute

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -4,12 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2020}")
 
-# TODO any pre-computation (usually not necessary)
 
-map <- redist_map(tn_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = tn_shp$adj)
+map <- redist_map(
+    tn_shp,
+    pop_tol = 0.005,
+    existing_plan = cd_2010,
+    adj = tn_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_2020"

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -4,12 +4,9 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2020}")
 
-cd_pop <- tn_shp %>% as_tibble() %>% count(cd_2020, wt = pop) %>% pull(n)
-tol_existing <- max((cd_pop - mean(cd_pop)) / mean(cd_pop))
-
 map <- redist_map(
     tn_shp,
-    pop_tol = tol_existing,
+    pop_tol = 0.005,
     existing_plan = cd_2020,
     adj = tn_shp$adj)
 

--- a/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/02_setup_TN_cd_2020.R
@@ -11,12 +11,6 @@ map <- redist_map(tn_shp, pop_tol = 0.005,
 
 # TODO any filtering, cores, merging, etc.
 
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_2020"
 

--- a/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
@@ -29,7 +29,6 @@ save_summary_stats(plans, "data-out/TN_2020/TN_cd_2020_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
@@ -25,10 +25,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/TN_2020/TN_cd_2020_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
@@ -6,18 +6,8 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg TN_cd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
@@ -1,0 +1,47 @@
+###############################################################################
+# Simulate plans for `TN_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg TN_cd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/TN_2020/TN_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg TN_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/TN_2020/TN_cd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
+++ b/analyses/TN_cd_2020/03_sim_TN_cd_2020.R
@@ -12,8 +12,6 @@ plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/TN_2020/TN_cd_2020_plans.rds"), compress = "xz")
 cli_process_done()

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -5,11 +5,11 @@ In Tennessee, there are no rules for redistricting Congressional districts ([NCS
 
 ### Interpretation of requirements
 
-Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities that comes with our default tigris call, and only 2 of the 20 largest municipalities. That said, the 2020 map will reportedly split the city of Nashville, splitting its county into three CDs, showing that these practices are not set in stone.
+Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities in our data, and only 2 of the 20 largest municipalities. That said, the 2020 map split the city of Nashville, splitting its county into three CDs, showing that these practices are not set in stone.
 
 Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of these pseudo-counties.
 
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of roughly 2.7%, which is what the enacted 2020 plan does.
 
 ## Data Sources
 Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -1,23 +1,25 @@
 # 2020 Tennessee Congressional Districts
 
 ## Redistricting requirements
-In Tennessee, districts must:
-
-1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
+In Tennessee, there are no rules for redistricting Congressional districts ([NCSL](https://www.ncsl.org/research/redistricting/redistricting-criteria.aspx)).
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of X.X%.
+
+Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities that comes with our default tigris call, and only 2 of the 20 largest municipalities. However, the 2020 map will reportedly split the city of Nashville, splitting its county into three CDs. 
+
+To enforce some county splitting avoidence, we labelled the 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of thse pseudo-counties.
+
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
+As of 2022-02-02, the 2022 plans have reached the Governor's desk but are not signed. The plots now show 2010 enacted.
+
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+See pseudo-county definition above.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Tennessee.
+Pseudo-counties created as above and used as a hard SMC constraint.
 No special techniques were needed to produce the sample.

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -5,9 +5,9 @@ In Tennessee, there are no rules for redistricting Congressional districts ([NCS
 
 ### Interpretation of requirements
 
-Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities in our data, and only 2 of the 20 largest municipalities. That said, the 2020 map split the city of Nashville, splitting its county into three CDs, showing that these practices are not set in stone.
+Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities in our data, and only 2 of the 20 largest municipalities. That said, the 2020 map split the city of Nashville, splitting its county into three congressional districts, showing that these practices are not set in stone.
 
-Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of these pseudo-counties.
+Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 8 of these pseudo-counties.
 
 We enforce a maximum population deviation of 0.5 percent.
 

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -1,0 +1,23 @@
+# 2020 Tennessee Congressional Districts
+
+## Redistricting requirements
+In Tennessee, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Interpretation of requirements
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Tennessee.
+No special techniques were needed to produce the sample.

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -5,9 +5,9 @@ In Tennessee, there are no rules for redistricting Congressional districts ([NCS
 
 ### Interpretation of requirements
 
-Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities that comes with our default tigris call, and only 2 of the 20 largest municipalities. However, the 2020 map will reportedly split the city of Nashville, splitting its county into three CDs. 
+Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities that comes with our default tigris call, and only 2 of the 20 largest municipalities. That said, the 2020 map will reportedly split the city of Nashville, splitting its county into three CDs, showing that these practices are not set in stone.
 
-To enforce some county splitting avoidence, we labelled the 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of thse pseudo-counties.
+Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of these pseudo-counties.
 
 We enforce a maximum population deviation of 0.5%.
 

--- a/analyses/TN_cd_2020/doc_TN_cd_2020.md
+++ b/analyses/TN_cd_2020/doc_TN_cd_2020.md
@@ -9,12 +9,11 @@ Although there are no rules, in practice, the state does avoid splitting its bou
 
 Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 9 - 1 number of these pseudo-counties.
 
-We enforce a maximum population deviation of roughly 2.7%, which is what the enacted 2020 plan does.
+We enforce a maximum population deviation of 0.5 percent.
 
 ## Data Sources
-Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). The 2022 boundary comes from the [American Redistricting Project](https://thearp.org).
 
-As of 2022-02-02, the 2022 plans have reached the Governor's desk but are not signed. The plots now show 2010 enacted.
 
 ## Pre-processing Notes
 See pseudo-county definition above.


### PR DESCRIPTION
## Redistricting requirements
In Tennessee, there are no rules for redistricting Congressional districts ([NCSL](https://www.ncsl.org/research/redistricting/redistricting-criteria.aspx)).

### Interpretation of requirements

Although there are no rules, in practice, the state does avoid splitting its boundaries. The 2010 map split 8 of its 95 counties, and split only 4 of the 228 municipalities that comes with our default tigris call, and only 2 of the 20 largest municipalities. That said, the 2020 split the city of Nashville, splitting its county into three CDs, showing that these practices are not set in stone.

Therefore, to enforce some county splitting avoidance, we took 20 largest cities in Tennessee (each with a population of at least 40,000) and concatenated them with counties so that these "pseudo-counties" were smaller units of geography that delineated major cities as well as counties. We then allowed the simulation to split at most 8 of these pseudo-counties.

We enforce a maximum population deviation of 0.5 percent.

## Data Sources
Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). The 2022 boundary comes from the [American Redistricting Project](https://thearp.org).


## Pre-processing Notes
See pseudo-county definition above.

## Simulation Notes
We sample 5,000 districting plans for Tennessee.
Pseudo-counties created as above and used as a hard SMC constraint.
No special techniques were needed to produce the sample.


## Validation

![image](https://user-images.githubusercontent.com/8290417/153265034-9754075c-8cfc-483d-b003-9bc2cebb9fe6.png)



## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
