### PR TITLE
2020 Wisconsin Congressional Districts

### DIFF
--- a/analyses/WI_cd_2020/01_prep_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/01_prep_WI_cd_2020.R
@@ -1,0 +1,87 @@
+###############################################################################
+# Download and prepare data for `WI_cd_2020` analysis
+# © ALARM Project, February 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WI_cd_2020}")
+
+path_data <- download_redistricting_file("WI", "data-raw/WI")
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/wisconsin/>
+# url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+# path_enacted <- "data-raw/WI/WI_enacted.zip"
+# download(url, here(path_enacted))
+# unzip(here(path_enacted), exdir = here(dirname(path_enacted), "WI_enacted"))
+# file.remove(path_enacted)
+# path_enacted <- "data-raw/WI/WI_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WI_2020/shp_vtd.rds"
+perim_path <- "data-out/WI_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WI} shapefile")
+    # read in redistricting data
+    wi_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$WI)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("WI", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("WI"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("WI", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("WI"), vtd),
+            cd_2010 = as.integer(cd))
+    wi_shp <- left_join(wi_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    # cd_shp <- st_read(here(path_enacted))
+    # wi_shp <- wi_shp %>%
+    #     mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+    #         geo_match(wi_shp, cd_shp, method = "area")],
+    #         .after = cd_2010)
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = wi_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wi_shp <- rmapshaper::ms_simplify(wi_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    wi_shp$adj <- redist.adjacency(wi_shp)
+
+    wi_shp <- wi_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(wi_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    wi_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WI} shapefile")
+}

--- a/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
@@ -4,14 +4,26 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg WI_cd_2020}")
 
-# TODO change to 2020
 map <- redist_map(wi_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = wi_shp$adj)
+    existing_plan = cd_2020, adj = wi_shp$adj)
 
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
         pop_muni = get_target(map)))
+
+# make cores
+map <- map %>%
+    mutate(core_id = redist.identify.cores(adj, cd_2010, boundary = 2),
+        core_id_lump = forcats::fct_lump_n(as.character(core_id), max(cd_2010)),
+        core_id = if_else(is_county_split(core_id_lump, pseudo_county),
+            str_c(pseudo_county, "_", core_id),
+            as.character(core_id))) %>%
+    select(-core_id_lump)
+
+map_merge <- map %>%
+    `attr<-`("existing_col", NULL) %>%
+    merge_by(core_id, cd_2010, by_existing = FALSE)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "WI_2020"

--- a/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
@@ -1,0 +1,21 @@
+###############################################################################
+# Set up redistricting simulation for `WI_cd_2020`
+# © ALARM Project, February 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WI_cd_2020}")
+
+# TODO change to 2020
+map <- redist_map(wi_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = wi_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WI_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WI_2020/WI_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -55,10 +55,6 @@ if (interactive()) {
     pl_renum <- plans %>%
         match_numbers(plan = map$cd_2010)
 
-    pl_renum <- pl_renum %>%
-        group_by(draw) %>%
-        mutate(mean_overlap = mean(pop_overlap))
-
-    hist(pl_renum, mean_overlap, bins = 30) +
+    hist(pl_renum, pop_overlap, bins = 30) +
         ggredist::theme_r21()
 }

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -6,10 +6,21 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WI_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+# TODO any pre-computation (VRA targets, etc.)
+
+cons <- redist_constr(map) %>%
+    add_constr_grp_hinge(
+        strength = 100,
+        group_pop = vap - vap_white,
+        total_pop = vap
+    )
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county,
+                    constraints = cons)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/WI_2020/WI_cd_2020_plans.rds"), compress = "xz")
@@ -24,3 +35,19 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/WI_2020/WI_cd_2020_stats.csv")
 
 cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    redist.plot.distr_qtys(plans, (total_vap - vap_white) / total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, '#3D77BB', '#B25D4C'),
+                           size = 0.5, alpha = 0.5) +
+        scale_y_continuous('Percent Black by VAP') +
+        labs(title = 'Wisconsin Proposed Plan versus Simulations') +
+        scale_color_manual(values = c(cd_2010 = 'black')) +
+        ggredist::theme_r21()
+}

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -19,7 +19,7 @@ plans <- redist_smc(map_merge, nsims = 5e3, counties = county_muni,
     constraints = cons) %>%
     pullback() %>%
     add_reference(ref_plan = map$cd_2020)
-
+attr(plans, "prec_pop") <- map$pop
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
@@ -30,7 +30,7 @@ cli_process_done()
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg WI_cd_2020}")
 
-attr(plans, "prec_pop") <- map$pop
+
 plans <- add_summary_stats(plans, map)
 
 # Output the summary statistics. Do not edit this path.

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -15,7 +15,7 @@ cons <- redist_constr(map) %>%
         total_pop = vap
     )
 plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county,
-                    constraints = cons)
+    constraints = cons)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -42,12 +42,12 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    redist.plot.distr_qtys(plans, (total_vap - vap_white) / total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, '#3D77BB', '#B25D4C'),
-                           size = 0.5, alpha = 0.5) +
-        scale_y_continuous('Percent Black by VAP') +
-        labs(title = 'Wisconsin Proposed Plan versus Simulations') +
-        scale_color_manual(values = c(cd_2010 = 'black')) +
+    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Wisconsin Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2010 = "black")) +
         ggredist::theme_r21()
 }

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -1,0 +1,26 @@
+###############################################################################
+# Simulate plans for `WI_cd_2020`
+# © ALARM Project, February 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WI_cd_2020}")
+
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WI_2020/WI_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WI_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WI_2020/WI_cd_2020_stats.csv")
+
+cli_process_done()

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -4,17 +4,18 @@
 In Wisconsin, districts must:
 
 1. have equal populations
+2. retain cores of existing districts
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
 We add a county/municipality constraint as described below.
-Due to a WI Supreme Court ruling, we retain the cores of existing districts.
+Due to the WI Supreme Court ruling in [Johnson v. Wisconsin Elections Commission](https://www.wicourts.gov/sc/opinion/DisplayDocument.pdf?content=pdf&seqNo=459269), we retain the cores of existing districts and apply a status quo constraint, as described below.
 
 ## Data Sources
 Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-We use a hybrid boundary-1 cores constraint, so any pieces more than 1 VTD from the boundary are frozen as a core. Pseudocounties which contain any of the non-frozen VTDs are frozen into remainder portions, separate from their district core. This avoids adding additional county splits. For the pseudocounties used in freezing cores, municipality lines are used within Milwukee County, which is larger than a congressional district in population.
+We use a hybrid boundary-2 cores constraint, based on the 2010 map. Any VTDs more than 2 VTD from the boundary are frozen as a core. Pseudocounties which contain any of the non-frozen VTDs are frozen into remainder portions, separate from their district core. This avoids adding additional county splits. For the pseudocounties used in freezing cores, municipality lines are used within Milwaukee County, which is larger than a congressional district in population.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Wisconsin.

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -8,13 +8,16 @@ In Wisconsin, districts must:
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
 We add a county/municipality constraint as described below.
+Due to a WI Supreme Court ruling, we retain the cores of existing districts.
 
 ## Data Sources
 Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We use a hybrid boundary-1 cores constraint, so any pieces more than 1 VTD from the boundary are frozen as a core. Pseudocounties which contain any of the non-frozen VTDs are frozen into remainder portions, separate from their district core. This avoids adding additional county splits. For the pseudocounties used in freezing cores, municipality lines are used within Milwukee County, which is larger than a congressional district in population.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Wisconsin.
-We create pseudocounties for use in the county constraint to match norms in the state of having low county and municipality splits, despite no rules regarding this. Municipality lines are used within Milwukee County, which is larger than a congressional district in population.
+We use municipalities for use in the county constraint (or counties if a VTD is not assigned to a municipality) to match norms in the state of having low county and municipality splits, despite no rules regarding this. 
+We use a status quo constraint to encourage simulated plans to be similar to the 2010 map.
+We use a weak county split Gibbs constraint to keep county splits comparable to the enacted map.

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -1,0 +1,20 @@
+# 2020 Wisconsin Congressional Districts
+
+## Redistricting requirements
+In Wisconsin, districts must:
+
+1. have equal populations
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+We add a county/municipality constraint as described below.
+
+## Data Sources
+Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Wisconsin.
+We create pseudocounties for use in the county constraint to match norms in the state of having low county and municipality splits, despite no rules regarding this. Municipality lines are used within Milwukee County, which is larger than a congressional district in population.


### PR DESCRIPTION
## Redistricting requirements
In Wisconsin, districts must:

1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We add a county/municipality constraint as described below.

## Data Sources
Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Wisconsin.
We create pseudocounties for use in the county constraint to match norms in the state of having low county and municipality splits, despite no rules regarding this. Municipality lines are used within Milwukee County, which is larger than a congressional district in population.

## Validation

![validation_20220202_2130](https://user-images.githubusercontent.com/28026893/152271717-44e31df6-d3c6-4acd-b675-d7be369eea86.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@CoryMcCartan

## Additional Notes
![image](https://user-images.githubusercontent.com/28026893/152271579-b6d4a29d-ee1c-4338-b5a1-b60a9ef6ed98.png)

