### PR TITLE
2020 Kansas Congressional Districts

### DIFF
--- a/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
@@ -1,0 +1,93 @@
+###############################################################################
+# Download and prepare data for `KS_cd_2020` analysis
+# © ALARM Project, January 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg KS_cd_2020}")
+
+path_data <- download_redistricting_file("KS", "data-raw/KS")
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/kansas/>
+# url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+# path_enacted <- "data-raw/KS/KS_enacted.zip"
+# download(url, here(path_enacted))
+# unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KS_enacted"))
+# file.remove(path_enacted)
+# path_enacted <- "data-raw/KS/KS_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/KS_2020/shp_vtd.rds"
+perim_path <- "data-out/KS_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong KS} shapefile")
+    # read in redistricting data
+    ks_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$KS)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("KS", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("KS"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("KS", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("KS"), vtd),
+                  cd_2010 = as.integer(cd))
+    ks_shp <- left_join(ks_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    # cd_shp <- st_read(here(path_enacted))
+    # ks_shp <- ks_shp %>%
+    #     mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+    #         geo_match(ks_shp, cd_shp, method = "area")],
+    #         .after = cd_2010)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = ks_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
+                                         keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ks_shp$adj <- redist.adjacency(ks_shp)
+
+    ks_shp <- ks_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ks_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ks_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong KS} shapefile")
+}
+

--- a/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
@@ -20,16 +20,12 @@ cli_process_start("Downloading files for {.pkg KS_cd_2020}")
 path_data <- download_redistricting_file("KS", "data-raw/KS")
 
 # download the enacted plan.
-# TODO try to find a download URL at <https://redistricting.lls.edu/state/kansas/>
-# url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
-# path_enacted <- "data-raw/KS/KS_enacted.zip"
-# download(url, here(path_enacted))
-# unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KS_enacted"))
-# file.remove(path_enacted)
-# path_enacted <- "data-raw/KS/KS_enacted/XXXXXXX.shp" # TODO use actual SHP
-
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
+url <- "https://thearp.org/documents/718/KS_CD_Enacted02092022.zip"
+path_enacted <- "data-raw/KS/KS_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KS_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/KS/KS_enacted/KS_CD_enacted02092022.shp"
 
 cli_process_done()
 
@@ -58,13 +54,12 @@ if (!file.exists(here(shp_path))) {
         relocate(muni, county_muni, cd_2010, .after = county)
 
     # add the enacted plan
-    # cd_shp <- st_read(here(path_enacted))
-    # ks_shp <- ks_shp %>%
-    #     mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
-    #         geo_match(ks_shp, cd_shp, method = "area")],
-    #         .after = cd_2010)
-
-    # TODO any additional columns or data you want to add should go here
+    cd_shp <- st_read(here(path_enacted))
+    cd_shp <- st_transform(cd_shp, st_crs(ks_shp))
+    ks_shp <- ks_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$district)[
+            geo_match(ks_shp, cd_shp, method = "area")],
+            .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = ks_shp,

--- a/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/01_prep_KS_cd_2020.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("KS", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("KS"), vtd),
-                  cd_2010 = as.integer(cd))
+            cd_2010 = as.integer(cd))
     ks_shp <- left_join(ks_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2010, .after = county)
 
@@ -59,17 +59,17 @@ if (!file.exists(here(shp_path))) {
     ks_shp <- ks_shp %>%
         mutate(cd_2020 = as.integer(cd_shp$district)[
             geo_match(ks_shp, cd_shp, method = "area")],
-            .after = cd_2010)
+        .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = ks_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
-                                         keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
@@ -85,4 +85,3 @@ if (!file.exists(here(shp_path))) {
     ks_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong KS} shapefile")
 }
-

--- a/analyses/KS_cd_2020/02_setup_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/02_setup_KS_cd_2020.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `KS_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg KS_cd_2020}")
+
+map <- redist_map(ks_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ks_shp$adj)
+
+map <- map %>%
+    mutate(cores = make_cores(boundary = 2))
+map_m <- merge_by(map, cores)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "KS_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/KS_2020/KS_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/KS_cd_2020/02_setup_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/02_setup_KS_cd_2020.R
@@ -5,10 +5,10 @@
 cli_process_start("Creating {.cls redist_map} object for {.pkg KS_cd_2020}")
 
 map <- redist_map(ks_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = ks_shp$adj)
+    existing_plan = cd_2020, adj = ks_shp$adj)
 
 map <- map %>%
-    mutate(cores = make_cores(boundary = 2))
+    mutate(cores = redist.identify.cores(map$adj, map$cd_2010, boundary = 3))
 map_m <- merge_by(map, cores)
 
 # Add an analysis name attribute

--- a/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
@@ -1,0 +1,49 @@
+###############################################################################
+# Simulate plans for `KS_cd_2020`
+# © ALARM Project, January 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg KS_cd_2020}")
+
+# constr <- redist_constr(map_m) %>%
+#     add_constr_splits(10)
+
+# merge_idx <- attr(map_m, "merge_idx")
+# constr <- redist_constr(map_m) %>%
+#     add_constr_custom(4.0, function(plan, i) {
+#         sum(tapply(map$county, plan[merge_idx] == i, n_distinct) - 1L)
+#     })
+
+plans <- redist_smc(map_m, nsims = 5e3,
+                    counties = county,
+                    constraints = constr) %>%
+    pullback(map)
+attr(plans, "prec_pop") <- map$pop
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/KS_2020/KS_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg KS_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/KS_2020/KS_cd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
@@ -6,14 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg KS_cd_2020}")
 
-# constr <- redist_constr(map_m) %>%
-#     add_constr_splits(10)
-
-# merge_idx <- attr(map_m, "merge_idx")
-# constr <- redist_constr(map_m) %>%
-#     add_constr_custom(4.0, function(plan, i) {
-#         sum(tapply(map$county, plan[merge_idx] == i, n_distinct) - 1L)
-#     })
+merge_idx <- attr(map_m, "merge_idx")
+constr <- redist_constr(map_m) %>%
+    add_constr_custom(1.0, function(plan, i) {
+        sum(tapply(map$county, plan[merge_idx] == i, n_distinct) - 1L)
+    })
 
 plans <- redist_smc(map_m, nsims = 5e3,
                     counties = county,
@@ -23,8 +20,6 @@ attr(plans, "prec_pop") <- map$pop
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/KS_2020/KS_cd_2020_plans.rds"), compress = "xz")
@@ -39,11 +34,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/KS_2020/KS_cd_2020_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
+++ b/analyses/KS_cd_2020/03_sim_KS_cd_2020.R
@@ -13,8 +13,8 @@ constr <- redist_constr(map_m) %>%
     })
 
 plans <- redist_smc(map_m, nsims = 5e3,
-                    counties = county,
-                    constraints = constr) %>%
+    counties = county,
+    constraints = constr) %>%
     pullback(map)
 attr(plans, "prec_pop") <- map$pop
 

--- a/analyses/KS_cd_2020/doc_KS_cd_2020.md
+++ b/analyses/KS_cd_2020/doc_KS_cd_2020.md
@@ -1,0 +1,24 @@
+# 2020 Kansas Congressional Districts
+
+## Redistricting requirements
+In Kansas, according to the [Kansas Legislative Research Department Guidelines and Criteria for Congressional Redistricting](http://www.kslegislature.org/li_2012/b2011_12/committees/misc/ctte_h_redist_1_20120109_01_other.pdf) districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of social, cultural, racial, ethnic, and economic interest to the extent possible
+
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
+
+## Simulation Notes
+We sample 5,000 districting plans for Kansas.
+No special techniques were needed to produce the sample.

--- a/analyses/KS_cd_2020/doc_KS_cd_2020.md
+++ b/analyses/KS_cd_2020/doc_KS_cd_2020.md
@@ -1,23 +1,24 @@
 # 2020 Kansas Congressional Districts
 
 ## Redistricting requirements
-In Kansas, according to the [Kansas Legislative Research Department Guidelines and Criteria for Congressional Redistricting](http://www.kslegislature.org/li_2012/b2011_12/committees/misc/ctte_h_redist_1_20120109_01_other.pdf) districts must:
+In Kansas, according to the [Proposed Guidelines and Criteria for 2022 Kansas Congressional Redistricting](https://redistricting.lls.edu/wp-content/uploads/KS-Proposed-redistricting-guidelines.pdf) districts must:
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. preserve communities of social, cultural, racial, ethnic, and economic interest to the extent possible
+5. preserve the cores of existing districts
+6. preserve communities of social, cultural, racial, ethnic, and economic interest to the extent possible
 
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We add a county constraint.
 
 ## Data Sources
 Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
+To preserve the cores of prior districts, we merge all precincts which are more than three precincts away from a district border, under the 2010 plan.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Kansas.

--- a/analyses/KS_cd_2020/doc_KS_cd_2020.md
+++ b/analyses/KS_cd_2020/doc_KS_cd_2020.md
@@ -15,7 +15,7 @@ In Kansas, according to the [Proposed Guidelines and Criteria for 2022 Kansas Co
 We enforce a maximum population deviation of 0.5%. We add a county constraint.
 
 ## Data Sources
-Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 Kansas enacted congressional map comes from the [American Redistricting Project](https://thearp.org/state/kansas/).
 
 ## Pre-processing Notes
 To preserve the cores of prior districts, we merge all precincts which are more than three precincts away from a district border, under the 2010 plan.


### PR DESCRIPTION
## Redistricting requirements
In Kansas, according to the [Proposed Guidelines and Criteria for 2022 Kansas Congressional Redistricting](https://redistricting.lls.edu/wp-content/uploads/KS-Proposed-redistricting-guidelines.pdf) districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve the cores of existing districts
6. preserve communities of social, cultural, racial, ethnic, and economic interest to the extent possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We add a county constraint.

## Data Sources
Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 Kansas enacted congressional map comes from the [American Redistricting Project](https://thearp.org/state/kansas/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than three precincts away from a district border, under the 2010 plan.

## Simulation Notes
We sample 5,000 districting plans for Kansas.
No special techniques were needed to produce the sample.

## Validation

![validation_20220218_2134_cd2020custom1 3](https://user-images.githubusercontent.com/55368740/154882339-da702911-d8b5-4ab8-8ab8-5fb58c7690dc.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
