### PR TITLE
NC remedial map update

### DIFF
--- a/analyses/NC_cd_2020/01_prep_NC_cd_2020.R
+++ b/analyses/NC_cd_2020/01_prep_NC_cd_2020.R
@@ -19,12 +19,12 @@ cli_process_start("Downloading files for {.pkg NC_cd_2020}")
 
 path_data <- download_redistricting_file("NC", "data-raw/NC")
 
-path_enacted <- here("data-raw", "NC", "SL 2021-174 Congress.shp")
-if (!file.exists(path_enacted)) {
-    url <- "https://s3.amazonaws.com/dl.ncsbe.gov/ShapeFiles/USCongress/2021-11-04%20US_Congress_SL_2021-174.zip"
-    download(url, paste0(dirname(path_enacted), "/nc.zip"))
-    unzip(paste0(dirname(path_enacted), "/nc.zip"), exdir = dirname(path_enacted))
-}
+url <- "https://www.ncleg.gov/Files/GIS/Plans_Main/Congress_2022_Court/2022%20Interim%20Congressional%20-%20Shapefile.zip"
+path_enacted <- "data-raw/NC/NC_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NC_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NC/NC_enacted/Interim Congressional.shp"
 
 cli_process_done()
 

--- a/analyses/NC_cd_2020/doc_NC_cd_2020.md
+++ b/analyses/NC_cd_2020/doc_NC_cd_2020.md
@@ -15,7 +15,7 @@ We add a county constraint.
 We add a VRA constraint targeting two majority-minority districts.
 
 ## Data Sources
-Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2021 North Carolina ratified congressional map comes from the [North Carolina State Board of Elections](https://www.ncsbe.gov/results-data/voting-maps-redistricting).
+Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 North Carolina ratified congressional map comes from the [North Carolina General Assembly](https://www.ncleg.gov/Redistricting).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.


### PR DESCRIPTION
Swapped out reference plan in 2020 North Carolina congressional redistricting simulations with the remedial map imposed on 2/23/2022. Data for the remedial plan comes from the [North Carolina General Assembly](https://www.ncleg.gov/Redistricting).

Updated validation plot:
![validation_20220224_1920_newplan](https://user-images.githubusercontent.com/55368740/155630306-ecb721ca-20b5-4119-88c4-7261581f7595.png)


@CoryMcCartan
