### PR TITLE
2020 Delaware State House Districts

### DIFF
--- a/analyses/DE_hd_2020/01_prep_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/01_prep_DE_hd_2020.R
@@ -27,9 +27,6 @@ unzip(here(path_enacted), exdir = here(dirname(path_enacted), "DE_enacted"))
 file.remove(path_enacted)
 path_enacted <- "data-raw/DE/DE_enacted/Enacted-House.shp" # TODO use actual SHP
 
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
-
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -63,7 +60,6 @@ if (!file.exists(here(shp_path))) {
             geo_match(de_shp, cd_shp, method = "area")],
         .after = cd_2010)
 
-    # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redist.prep.polsbypopper(shp = de_shp,
@@ -71,7 +67,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         de_shp <- rmapshaper::ms_simplify(de_shp, keep = 0.05,
             keep_shapes = TRUE) %>%
@@ -81,7 +76,6 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     de_shp$adj <- redist.adjacency(de_shp)
 
-    # TODO any custom adjacency graph edits here
 
     de_shp <- de_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/DE_hd_2020/01_prep_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/01_prep_DE_hd_2020.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `DE_hd_2020` analysis
+# © ALARM Project, February 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg DE_hd_2020}")
+
+path_data <- download_redistricting_file("DE", "data-raw/DE")
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/de_2020_state_lower_2021-11-02_2031-06-30.zip"
+path_enacted <- "data-raw/DE/DE_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "DE_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/DE/DE_enacted/de_2020_state_lower_2021-11-07_2031-06-30.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/DE_2020/shp_vtd.rds"
+perim_path <- "data-out/DE_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong DE} shapefile")
+    # read in redistricting data
+    de_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$DE)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("DE", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("DE"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("DE", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("DE"), vtd),
+                  cd_2010 = as.integer(cd))
+    de_shp <- left_join(de_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    de_shp <- de_shp %>%
+        mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+            geo_match(de_shp, cd_shp, method = "area")],
+            .after = cd_2010)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = de_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        de_shp <- rmapshaper::ms_simplify(de_shp, keep = 0.05,
+                                         keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    de_shp$adj <- redist.adjacency(de_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    de_shp <- de_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(de_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    de_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong DE} shapefile")
+}
+

--- a/analyses/DE_hd_2020/02_setup_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/02_setup_DE_hd_2020.R
@@ -4,7 +4,7 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg DE_hd_2020}")
 
-map <- redist_map(de_shp, pop_tol = 0.005,
+map <- redist_map(de_shp, pop_tol = 0.05,
     existing_plan = cd_2020, adj = de_shp$adj)
 
 # Add an analysis name attribute

--- a/analyses/DE_hd_2020/02_setup_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/02_setup_DE_hd_2020.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `DE_hd_2020`
+# © ALARM Project, February 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg DE_hd_2020}")
+
+map <- redist_map(de_shp, pop_tol = 0.005,
+    existing_plan = cd_2020, adj = de_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "DE_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/DE_2020/DE_hd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -1,0 +1,49 @@
+###############################################################################
+# Simulate plans for `DE_hd_2020`
+# © ALARM Project, February 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg DE_hd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/DE_2020/DE_hd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg DE_hd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/DE_2020/DE_hd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -7,8 +7,12 @@
 cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 
 # TODO any pre-computation (VRA targets, etc.)
-# constr <- redist_constr(map) %>%
-#    add_constr_grp_hinge(6, vap_black, total_pop = vap, tgts_group = c(0.52))
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(
+        strength = 1,
+        group_pop = vap_black,
+        total_pop = vap
+    )
 
 # TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
@@ -19,7 +23,7 @@ cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 #  - If the sampler freezes, try turning off the county split constraint to see
 #  if that's the problem.
 #  - Ask for help!
-plans <- redist_smc(map, nsims = 5e3, pop_temper = 0.05, final_infl = 2)
+plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05, final_infl = 4)
 
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
@@ -49,11 +53,12 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    # VRA
-    redist.plot.distr_qtys(plans, vap_black/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+    redist.plot.distr_qtys(plans, (vap_black)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
-        labs(title = "Delaware Proposed Plan versus Simulations")
+        labs(title = "Wisconsin Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2010 = "black")) +
+        ggredist::theme_r21()
 }

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -7,8 +7,8 @@
 cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 
 # TODO any pre-computation (VRA targets, etc.)
-constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(6, vap_black, vap)
+# constr <- redist_constr(map) %>%
+#    add_constr_grp_hinge(6, vap_black, total_pop = vap, tgts_group = c(0.52))
 
 # TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
@@ -19,7 +19,7 @@ constr <- redist_constr(map) %>%
 #  - If the sampler freezes, try turning off the county split constraint to see
 #  if that's the problem.
 #  - Ask for help!
-plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05)
+plans <- redist_smc(map, nsims = 5e3, pop_temper = 0.05, final_infl = 2)
 
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -6,7 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
 constr <- redist_constr(map) %>%
     add_constr_grp_hinge(
         strength = 1,
@@ -14,15 +13,6 @@ constr <- redist_constr(map) %>%
         total_pop = vap
     )
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05, final_infl = 4)
 
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
@@ -31,7 +21,6 @@ plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05, f
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/DE_2020/DE_hd_2020_plans.rds"), compress = "xz")
@@ -48,17 +37,16 @@ save_summary_stats(plans, "data-out/DE_2020/DE_hd_2020_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
     redist.plot.distr_qtys(plans, (vap_black)/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
-        labs(title = "Wisconsin Proposed Plan versus Simulations") +
+        labs(title = "Delaware Proposed Plan versus Simulations") +
         scale_color_manual(values = c(cd_2010 = "black")) +
         ggredist::theme_r21()
 }

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -7,6 +7,8 @@
 cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 
 # TODO any pre-computation (VRA targets, etc.)
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(6, vap_black, vap)
 
 # TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
@@ -17,7 +19,8 @@ cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 #  - If the sampler freezes, try turning off the county split constraint to see
 #  if that's the problem.
 #  - Ask for help!
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05)
+
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 
@@ -46,4 +49,11 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
+    # VRA
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Delaware Proposed Plan versus Simulations")
 }

--- a/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
+++ b/analyses/DE_hd_2020/03_sim_DE_hd_2020.R
@@ -8,12 +8,12 @@ cli_process_start("Running simulations for {.pkg DE_hd_2020}")
 
 constr <- redist_constr(map) %>%
     add_constr_grp_hinge(
-        strength = 1,
+        strength = 6,
         group_pop = vap_black,
         total_pop = vap
     )
 
-plans <- redist_smc(map, nsims = 5e3, constraints = constr, pop_temper = 0.05, final_infl = 4)
+plans <- redist_smc(map, nsims = 5e3, constraints = constr)
 
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!

--- a/analyses/DE_hd_2020/doc_DE_hd_2020.md
+++ b/analyses/DE_hd_2020/doc_DE_hd_2020.md
@@ -20,4 +20,4 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Delaware. 
-We apply a hinge Gibbs constraint of strength 6 to encourage drawing majority black districts.
+We apply a hinge Gibbs constraint of strength 1 to encourage drawing majority black districts.

--- a/analyses/DE_hd_2020/doc_DE_hd_2020.md
+++ b/analyses/DE_hd_2020/doc_DE_hd_2020.md
@@ -1,0 +1,22 @@
+# 2020 Delaware House of Representatives Districts
+
+## Redistricting requirements
+In Delaware, districts must:
+
+1. be contiguous (29 Del. C. § 804).
+1. be nearly equal in population (29 Del. C. § 804)
+1. be bounded by major roads, streams or other natural boundaries (29 Del. C. § 804)
+1. not be created so as to unduly favor any person or political party (29 Del. C. § 804)
+1. count currently incarcerated individuals who were residents of Delaware before incarceration at their last recorded address, rather than at the prison they currently inhabit (29 Del. C. § 804A)
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Delaware comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2021 Delaware House of Representatives district maps comes from the [Delaware General Assembly](https://legis.delaware.gov/Redistricting/2022FinalHouseDistricts).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Delaware. No special techniques were needed to produce the sample.

--- a/analyses/DE_hd_2020/doc_DE_hd_2020.md
+++ b/analyses/DE_hd_2020/doc_DE_hd_2020.md
@@ -19,4 +19,5 @@ Data for Delaware comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Delaware. No special techniques were needed to produce the sample.
+We sample 5,000 districting plans for Delaware. 
+We apply a hinge Gibbs constraint of strength 6 to encourage drawing majority black districts.


### PR DESCRIPTION
# 2020 Delaware House of Representatives Districts

## Redistricting requirements
In Delaware, districts must:

1. be contiguous (29 Del. C. § 804).
1. be nearly equal in population (29 Del. C. § 804)
1. be bounded by major roads, streams or other natural boundaries (29 Del. C. § 804)
1. not be created so as to unduly favor any person or political party (29 Del. C. § 804)
1. count currently incarcerated individuals who were residents of Delaware before incarceration at their last recorded address, rather than at the prison they currently inhabit (29 Del. C. § 804A)

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Delaware comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2021 Delaware House of Representatives district maps comes from the [Delaware General Assembly](https://legis.delaware.gov/Redistricting/2022FinalHouseDistricts).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Delaware. 
We apply a hinge Gibbs constraint of strength 1 to encourage drawing majority black districts.

## Validation
![validation_20220225_1223](https://user-images.githubusercontent.com/46555283/155771989-b161df5d-88d7-468f-881f-10eb9339d620.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [ ] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes
![ef47d08a-c053-4906-87a7-b86e44ccab0a](https://user-images.githubusercontent.com/46555283/155771822-235c5487-0b46-4140-a974-fe89677e195c.png)

Noting that there is a lot of plan diversity stuck at 0, that the enacted plan is consistently more compact than the simulations, and that the compactness boxes appear very tight. Simulations also tend to get stuck on the last two iterations very frequently. Also, the Redistricting Hub now has a spreadsheet showing the prison-adjusted population for each census block in Delaware, which was used by the state in redistricting — should we use those numbers instead?