### PR TITLE
2020 Louisiana Congressional Districts

### DIFF
--- a/analyses/LA_cd_2020/01_prep_LA_cd_2020.R
+++ b/analyses/LA_cd_2020/01_prep_LA_cd_2020.R
@@ -1,0 +1,87 @@
+###############################################################################
+# Download and prepare data for `LA_cd_2020` analysis
+# © ALARM Project, March 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg LA_cd_2020}")
+
+path_data <- download_redistricting_file("LA", "data-raw/LA")
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/louisiana/>
+# url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+# path_enacted <- "data-raw/LA/LA_enacted.zip"
+# download(url, here(path_enacted))
+# unzip(here(path_enacted), exdir = here(dirname(path_enacted), "LA_enacted"))
+# file.remove(path_enacted)
+# path_enacted <- "data-raw/LA/LA_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/LA_2020/shp_vtd.rds"
+perim_path <- "data-out/LA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong LA} shapefile")
+    # read in redistricting data
+    la_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) %>%
+        join_vtd_shapefile() %>%
+        st_transform(EPSG$LA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("LA", "INCPLACE_CDP", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("LA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("LA", "CD", "VTD")  %>%
+        transmute(GEOID = paste0(censable::match_fips("LA"), vtd),
+            cd_2010 = as.integer(cd))
+    la_shp <- left_join(la_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2010, .after = county)
+
+    # add the enacted plan
+    # cd_shp <- st_read(here(path_enacted))
+    # la_shp <- la_shp %>%
+    #     mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
+    #         geo_match(la_shp, cd_shp, method = "area")],
+    #         .after = cd_2010)
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = la_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    la_shp$adj <- redist.adjacency(la_shp)
+
+    la_shp <- la_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(la_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    la_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong LA} shapefile")
+}

--- a/analyses/LA_cd_2020/02_setup_LA_cd_2020.R
+++ b/analyses/LA_cd_2020/02_setup_LA_cd_2020.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `LA_cd_2020`
+# © ALARM Project, March 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_2020}")
+
+map <- redist_map(la_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = la_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map))) %>%
+    mutate(core_id = redist.identify.cores(adj, cd_2010, boundary = 2))
+map_m <- merge_by(map, core_id)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "LA_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/LA_2020/LA_cd_2020_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/LA_cd_2020/03_sim_LA_cd_2020.R
+++ b/analyses/LA_cd_2020/03_sim_LA_cd_2020.R
@@ -1,0 +1,57 @@
+###############################################################################
+# Simulate plans for `LA_cd_2020`
+# © ALARM Project, March 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_cd_2020}")
+
+constr <- redist_constr(map_m) %>%
+    add_constr_grp_hinge(40, vap_black, vap, tgts_group = 0.55)
+
+plans <- redist_smc(map_m, nsims = 6e3,
+    counties = pseudo_county, constraints = constr) %>%
+    pullback(map)
+attr(plans, "prec_pop") <- map$pop
+
+plans <- plans %>%
+    mutate(vap_minority = group_frac(map, vap - vap_white, vap)) %>%
+    group_by(draw) %>%
+    mutate(vap_minority = sum(vap_minority > 0.5)) %>%
+    ungroup() %>%
+    filter(vap_minority >= 1 | draw == "cd_2010") %>%
+    slice(1:(5001*attr(map, "ndists"))) %>%
+    select(-vap_minority)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_2020/LA_cd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_cd_2020}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_2020/LA_cd_2020_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Louisiana Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        ggredist::theme_r21()
+
+}

--- a/analyses/LA_cd_2020/doc_LA_cd_2020.md
+++ b/analyses/LA_cd_2020/doc_LA_cd_2020.md
@@ -17,7 +17,7 @@ We enforce a maximum population deviation of 0.5%. We add a VRA constraint targe
 Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
 
 ## Simulation Notes
 We sample 6,000 districting plans for Louisiana and subset to 5,000 which contain at least one majority-minority district. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

--- a/analyses/LA_cd_2020/doc_LA_cd_2020.md
+++ b/analyses/LA_cd_2020/doc_LA_cd_2020.md
@@ -1,0 +1,23 @@
+# 2020 Louisiana Congressional Districts
+
+## Redistricting requirements
+In Louisiana, according to [Louisiana Joint Rule No. 21](https://www.legis.la.gov/Legis/Law.aspx?d=1238755) districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve parish and municipality boundaries as much as possible
+5. preserve the cores of traditional district alignments
+
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%. We add a VRA constraint targeting one majority-minority district.
+
+## Data Sources
+Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 6,000 districting plans for Louisiana and subset to 5,000 which contain at least one majority-minority district. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Louisiana, according to [Louisiana Joint Rule No. 21](https://www.legis.la.gov/Legis/Law.aspx?d=1238755) districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve parish and municipality boundaries as much as possible
5. preserve the cores of traditional district alignments


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We add a VRA constraint targeting one majority-minority district.

## Data Sources
Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.

## Simulation Notes
We sample 6,000 districting plans for Louisiana and subset to 5,000 which contain at least one majority-minority district. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

## Validation

![validation_20220312_1716_final](https://user-images.githubusercontent.com/55368740/158037249-446bf716-f61c-4ae1-90d4-a38cc77670fd.png)

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [ ] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Performance plot for BVAP.
![la_performance_bvap](https://user-images.githubusercontent.com/55368740/158037259-1aaa05e6-bfbe-4548-875b-036cad74977d.png)


@tylersimko
