### PR TITLE
Re-run 2020 Oregon Congressional Districts

### DIFF
--- a/R/template/03_sim.R
+++ b/R/template/03_sim.R
@@ -17,9 +17,11 @@ cli_process_start("Running simulations for {.pkg ``SLUG``}")
 #  - If the sampler freezes, try turning off the county split constraint to see
 #  if that's the problem.
 #  - Ask for help!
+set.seed(``YEAR``)
 plans <- redist_smc(map, nsims = 5e3, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_``YEAR``")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/OR_cd_2020/01_prep_OR_cd_2020.R
+++ b/analyses/OR_cd_2020/01_prep_OR_cd_2020.R
@@ -21,6 +21,7 @@ url <- "https://raw.githubusercontent.com/alarm-redist/census-2020/main/census-v
 path_data <- "data-raw/OR/or_2020_block.csv"
 download(url, here(path_data))
 
+# updated link: manual download from https://geo.maps.arcgis.com/home/item.html?id=b43a1bf5997d4863a45023bfe7a047b1
 url <- "https://oregon-redistricting.esriemcs.com/portal/sharing/rest/content/items/4ebcfc87b06c4e79b65685135329513c/data"
 path_enacted <- "data-raw/OR/or_enacted.zip"
 download(url, here(path_enacted))

--- a/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
+++ b/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
@@ -6,7 +6,7 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudocounty)
+plans <- redist_smc(map, nsims = 3e3, runs = 2L, counties = pseudocounty)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
+++ b/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
@@ -6,7 +6,12 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_cd_2020}")
 
-plans <- redist_smc(map, nsims = 3e3, runs = 2L, counties = pseudocounty)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 3e3, runs = 2L, counties = pseudocounty) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/OR_cd_2020/doc_OR_cd_2020.md
+++ b/analyses/OR_cd_2020/doc_OR_cd_2020.md
@@ -26,7 +26,7 @@ As described above, counties not linked by a state or federal highway were manua
 The full list of these counties can be found in the `01_prep_OR_cd_2020.R` file.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Oregon.
+We sample 6,000 districting plans for Oregon across two independent runs of the SMC algorithm.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well.
 Multnomah county were chosen since it is necessarily split by congressional districts.

--- a/fifty-states.Rproj
+++ b/fifty-states.Rproj
@@ -18,5 +18,6 @@ LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
## Redistricting requirements
In Oregon, districts must, under Or. Rev. Stat. § 188.010:

1. be contiguous
1. be of equal population
1. utilize existing geographic or political boundaries
1. not divide communities of common interest
1. be connected by transportation links

Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.
To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway.

## Data Sources
Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Oregon does not submit precinct boundaries to the Census Bureau.
The base shapefile consists of tracts, but where tracts are split by the enacted congressional districts, we create separate sub-tracts.
As described above, counties not linked by a state or federal highway were manually disconnected.
The full list of these counties can be found in the `01_prep_OR_cd_2020.R` file.

## Simulation Notes
We sample 6,000 districting plans for Oregon across two independent runs of the SMC algorithm.
To balance county and municipality splits, we create pseudocounties for use in the county constraint.
These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well.
Multnomah county were chosen since it is necessarily split by congressional districts.

## Validation

![image](https://user-images.githubusercontent.com/2958471/170559598-478f78d1-f694-4b20-9f57-b929685113aa.png)

```
SMC: 6,000 sampled plans of 6 districts on 1,081 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.39 to 0.70

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
       1.00798        0.99997        1.00032        1.00608        1.00188        1.00286        1.00270 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
       1.00190        1.00477        1.00652        1.00109        1.00050        1.00421        1.00300 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
       1.00288        1.00188        1.00513        1.00585        1.00133        1.00008        1.00113 
pre_16_dem_cli pre_16_rep_tru uss_16_dem_wyd uss_16_rep_cal gov_16_dem_bro gov_16_rep_pie atg_16_dem_ros 
       1.00236        1.00089        1.00230        1.00082        1.00212        1.00100        1.00163 
atg_16_rep_cro sos_16_dem_ava sos_16_rep_ric gov_18_dem_bro gov_18_rep_bue pre_20_dem_bid pre_20_rep_tru 
       1.00105        1.00214        1.00076        1.00241        1.00081        1.00242        1.00116 
uss_20_dem_mer uss_20_rep_per atg_20_dem_ros atg_20_rep_cro sos_20_dem_fag sos_20_rep_tha         arv_16 
       1.00249        1.00108        1.00244        1.00098        1.00244        1.00100        1.00084 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits 
       1.00247        1.00081        1.00241        1.00110        1.00246        1.00087        1.00160 
           ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
       1.00249        1.00095        1.00180        1.00177        1.00572        1.00330        1.00071 
          egap 
       1.00290 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,940 (98.0%)      8.7%        0.28 1,905 (100%)      6 
Split 2     2,763 (92.1%)     12.6%        0.47 1,865 ( 98%)      4 
Split 3     2,507 (83.6%)     12.2%        0.71 1,758 ( 93%)      4 
Split 4     2,583 (86.1%)     14.8%        0.70 1,681 ( 89%)      3 
Split 5     2,672 (89.1%)      4.9%        0.63 1,528 ( 81%)      3 
Resample    1,809 (60.3%)       NA%        0.63 1,658 ( 87%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,937 (97.9%)      8.6%        0.28 1,876 ( 99%)      6 
Split 2     2,718 (90.6%)     12.5%        0.51 1,863 ( 98%)      4 
Split 3     2,582 (86.1%)     12.3%        0.68 1,751 ( 92%)      4 
Split 4     2,613 (87.1%)     15.2%        0.67 1,680 ( 89%)      3 
Split 5     2,662 (88.7%)      6.9%        0.63 1,601 ( 84%)      2 
Resample    1,743 (58.1%)       NA%        0.63 1,644 ( 87%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny