### PR TITLE
Re-run 2020 Rhode Island Congressional Districts

### DIFF
--- a/analyses/RI_cd_2020/03_sim_RI_cd_2020.R
+++ b/analyses/RI_cd_2020/03_sim_RI_cd_2020.R
@@ -13,9 +13,12 @@ cons <- redist_constr(map) %>%
         total_pop = vap
     )
 
-plans <- redist_smc(map, nsims = 5e3,
+set.seed(2020)
+plans <- redist_smc(map, nsims = 2e3,
+    runs = 2L,
     counties = sd_2020,
     constraints = cons)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/RI_cd_2020/doc_RI_cd_2020.md
+++ b/analyses/RI_cd_2020/doc_RI_cd_2020.md
@@ -20,5 +20,5 @@ Data for Rhode Island comes from the ALARM Project's [2020 Redistricting Data Fi
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Rhode Island.
+We sample 4,000 districting plans for Rhode Island across two independent runs of the SMC algorithm.
 We assigned state senate districts to act like counties so that the simulations minimize the number of senate district splits.


### PR DESCRIPTION
## Redistricting requirements
In Rhode Island, according to the [Rhode Island Laws, Chapter 100, Section 2](http://webserver.rilin.state.ri.us/PublicLaws/law11/law11100.htm) districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve state senate district boundaries as much as possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We add a VRA constraint targeting one minority opportunity district.

## Data Sources
Data for Rhode Island comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 Rhode Island enacted congressional map comes from the [American Redistricting Project](https://thearp.org/state/rhode-island/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 4,000 districting plans for Rhode Island across two independent runs of the SMC algorithm.
We assigned state senate districts to act like counties so that the simulations minimize the number of senate district splits.

## Validation

![image](https://user-images.githubusercontent.com/55368740/170847548-c85df131-930e-4c21-9e6f-f8fc90baf72e.png)

```
SMC: 4,000 sampled plans of 2 districts on 423 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.20 to 0.68

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0002211      0.9998211      0.9998659      1.0008597      1.0014708      1.0000349      1.0008539      1.0020751      1.0017603 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     0.9998908      1.0011210      1.0007205      0.9998433      1.0000432      1.0006585      1.0022942      1.0015060      0.9997551 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_18_dem_whi uss_18_rep_fla gov_18_dem_rai gov_18_rep_fun 
     1.0009925      1.0010116      0.9998871      1.0008663      1.0011520      1.0014873      1.0012704      1.0007371      1.0015074 
atg_18_dem_ner sos_18_dem_gor sos_18_rep_cor pre_20_dem_bid pre_20_rep_tru uss_20_dem_ree uss_20_rep_wat         arv_16         adv_16 
     1.0003375      1.0020025      1.0014117      1.0008009      1.0012553      1.0013810      1.0010706      1.0011520      1.0008663 
        arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv        ndshare 
     1.0014773      1.0028082      1.0011903      1.0015904      0.9997836      0.9997949      1.0015852      1.0012078      1.0018675 
         e_dvs          e_dem           egap 
     1.0019352      0.9997886      1.0000074 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,916 (95.8%)      6.2%        0.33 1,267 (100%)      6 
Resample    1,677 (83.9%)       NA%        0.40 1,202 ( 95%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,909 (95.5%)      6.2%        0.34 1,280 (101%)      6 
Resample    1,655 (82.7%)       NA%        0.41 1,194 ( 94%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Validation plot for number of state senate district splits.
![image](https://user-images.githubusercontent.com/55368740/170847599-263b7c39-981f-4522-aa43-32a75d68bbe9.png)

@CoryMcCartan
