### PR TITLE
Re-Run 2020 Utah Congressional Districts

### DIFF
--- a/analyses/UT_cd_2020/03_sim_UT_cd_2020.R
+++ b/analyses/UT_cd_2020/03_sim_UT_cd_2020.R
@@ -6,8 +6,12 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg UT_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3,
-    counties = pseudo_county)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 3e3,
+    runs = 2L, counties = pseudo_county)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/UT_cd_2020/doc_UT_cd_2020.md
+++ b/analyses/UT_cd_2020/doc_UT_cd_2020.md
@@ -15,9 +15,9 @@ In Utah, districts must, under [legislation code 20A-20-302](https://le.utah.gov
     f. prohibit the purposeful or undue favoring or disfavoring of incumbents, candidates or prospective candidates, and political parties
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.5% (which ensures that the total population deviation as defined by Utah legistlation does not exceed 1%).
+We enforce a maximum population deviation of 0.5% (which ensures that the total population deviation as defined by Utah legislation does not exceed 1%).
 We constrain the number of "pseudo-county" divisions (see below for an explanation of pseudo-county).
-We perform cores-based simulations, thereby preserving cores of prior districs.
+We perform cores-based simulations, thereby preserving cores of prior districts.
 
 ## Data Sources
 Data for Utah comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -29,5 +29,5 @@ To preserve the cores of prior districts, we merge all precincts which are more 
 
 
 ## Simulation Notes
-We sample 5,000 districting plans for Utah. 
+We sample 6,000 districting plans for Utah across two independent runs of the SMC algorithm. 
 To balance county and municipality splits, we create pseudo-counties as described above.


### PR DESCRIPTION
## Redistricting requirements
In Utah, districts must, under [legislation code 20A-20-302](https://le.utah.gov/xcode/Title20A/Chapter20/20A-20-S302.html):

1. have a total population deviation of less than 1% (where total population deviation is calculated by adding together the percentage deviation of both the most populous and least populous districts from the average, or "ideal," district)
2. not be drawn with race used as a predominant factor
3. be contiguous and reasonably compact
4. to the extent practicable
    a. preserve communities of interest
    b. follow natural, geographic, or man-made features, boundaries, or barriers
    c. preserve cores of prior districts
    d. minimize the division of municipalities and counties across multiple districts
    e. achieve boundary agreement among different types of districts
    f. prohibit the purposeful or undue favoring or disfavoring of incumbents, candidates or prospective candidates, and political parties

### Interpretation of requirements
We enforce a maximum population deviation of 0.5% (which ensures that the total population deviation as defined by Utah legislation does not exceed 1%).
We constrain the number of "pseudo-county" divisions (see below for an explanation of pseudo-county).
We perform cores-based simulations, thereby preserving cores of prior districts.

## Data Sources
Data for Utah comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for the 2021 Utah Congressional adopted plans come from Utah Legislative Redistricting Committee's [MyDistricting site](https://citygate.utleg.gov/legdistricting/utah/comment_links#)

## Pre-processing Notes
We create pseudo-counties by splitting counties with a total population higher than the target district population into county-municipality combinations (in the end, this affects only Salt Lake County, which has a total population well above 1 million). 
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2010 plan.


## Simulation Notes
We sample 6,000 districting plans for Utah across two independent runs of the SMC algorithm. 
To balance county and municipality splits, we create pseudo-counties as described above.


## Validation
![validation_20220531_0956](https://user-images.githubusercontent.com/90931177/171231222-ff47d612-a96c-4d62-9462-876d5ac9dd9b.png)

```
SMC: 6,000 sampled plans of 4 districts on 988 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5      
`est_label_mult`=1 • `pop_temper`=0           
ℹ Computing summary statistics for UT_cd_2020
Plan diversity 80% range: 0.38 to 0.77        
ℹ Computing summary statistics for UT_cd_2020
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0083204      1.0005884      1.0079228      1.0007615      1.0046959      1.0024017      1.0003921      1.0004010      1.0011338 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0012128      1.0001643      1.0006612      1.0021998      1.0013406      1.0000265      1.0003879      1.0008010      1.0004620 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_lee uss_16_dem_sno gov_16_rep_her gov_16_dem_wei 
     0.9998978      1.0008898      1.0013852      1.0006695      1.0031878      1.0029926      1.0037294      1.0026725      1.0036335 
atg_16_rep_rey atg_16_dem_har uss_18_rep_rom uss_18_dem_wil pre_20_rep_tru pre_20_dem_bid gov_20_rep_cox gov_20_dem_pet atg_20_rep_rey 
     1.0029426      1.0015664      1.0028869      1.0038331      0.9998859      1.0033426      1.0023919      1.0034205      1.0012572 
atg_20_dem_sko         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits 
     1.0028632      1.0029997      1.0032498      1.0028869      1.0038331      1.0016890      1.0031085      1.0067909      1.0031132 
           ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
     1.0034188      1.0027173      1.0001793      1.0002068      0.9999529      1.0037000      1.0004299      1.0005480 

Sampling diagnostics for SMC run 1 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,797 (93.2%)      7.5%        0.55 1,908 (101%)     10 
Split 2     2,801 (93.4%)      8.2%        0.45 1,814 ( 96%)      6 
Split 3     2,732 (91.1%)      3.8%        0.56 1,522 ( 80%)      4 
Resample    1,883 (62.8%)       NA%        0.55 1,688 ( 89%)     NA 

Sampling diagnostics for SMC run 2 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,795 (93.2%)      6.9%        0.54 1,910 (101%)     11 
Split 2     2,785 (92.8%)      6.8%        0.46 1,805 ( 95%)      7 
Split 3     2,621 (87.4%)      3.3%        0.63 1,493 ( 79%)      5 
Resample    1,461 (48.7%)       NA%        0.63 1,657 ( 87%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
@christopherkenny
@kuriwaki 