### PR TITLE
Re-run 2020 New Jersey Congressional Districts

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -66,7 +66,7 @@ validate_analysis <- function(plans, map) {
         labs(title = "Minority VAP share") +
         theme_bw()
 
-    draws <- sample(ncol(as.matrix(subset_sampled(plans))), 3)
+    draws <- sample(levels(subset_sampled(plans)$draw), 3)
     p_ex1 <- redist.plot.plans(plans, draws[1], map)
     p_ex2 <- redist.plot.plans(plans, draws[2], map)
     p_ex3 <- redist.plot.plans(plans, draws[3], map)

--- a/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
+++ b/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
@@ -11,7 +11,7 @@ plans <- redist_smc(map, nsims = 8e3, runs = 2L, ncores =8, counties = pseudo_co
 plans <- match_numbers(plans, "cd_2020")
 plans <- plans %>%
     group_by(chain) %>%
-    filter(is.na(as.integer(draw)) | as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
 cli_process_done()

--- a/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
+++ b/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
@@ -7,7 +7,7 @@
 cli_process_start("Running simulations for {.pkg NJ_cd_2020}")
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = 8e3, runs = 2L, ncores =8, counties = pseudo_county)
+plans <- redist_smc(map, nsims = 8e3, runs = 2L, counties = pseudo_county)
 plans <- match_numbers(plans, "cd_2020")
 plans <- plans %>%
     group_by(chain) %>%

--- a/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
+++ b/analyses/NJ_cd_2020/03_sim_NJ_cd_2020.R
@@ -6,7 +6,13 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NJ_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 8e3, runs = 2L, ncores =8, counties = pseudo_county)
+plans <- match_numbers(plans, "cd_2020")
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(is.na(as.integer(draw)) | as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/NJ_cd_2020/doc_NJ_cd_2020.md
+++ b/analyses/NJ_cd_2020/doc_NJ_cd_2020.md
@@ -17,7 +17,7 @@ Data for New Jersey comes from the ALARM Project's [2020 Redistricting Data File
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for New Jersey.
+We sample 16,000 districting plans for New Jersey across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.
 We use a pseudo-county constraint to limit the county and municipality splits.
 Municipality lines are used in Bergen County, Burlington County, Camden County, Essex County, Hudson County, Mercer County, Middlesex County, Monmouth County, Morris County, Ocean County, Passaic County, Somerset County, and Union County.
 These are larger than 40% the target population for a district.


### PR DESCRIPTION
## Redistricting requirements
In New Jersey, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.

## Data Sources
Data for New Jersey comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 16,000 districting plans for New Jersey across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.
We use a pseudo-county constraint to limit the county and municipality splits.
Municipality lines are used in Bergen County, Burlington County, Camden County, Essex County, Hudson County, Mercer County, Middlesex County, Monmouth County, Morris County, Ocean County, Passaic County, Somerset County, and Union County.
These are larger than 40% the target population for a district.
No special techniques were needed to produce the sample.

## Validation

![validation_20220608_1011](https://user-images.githubusercontent.com/28026893/172639438-db630b0b-11a6-487a-bc32-9bc0cd2687c1.png)

```
SMC: 5,000 sampled plans of 12 districts on 6,361 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.63 to 0.85

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
     1.0035864      1.0087301      1.0167908      1.0107225      1.0035371      1.0163931 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0018425      1.0014160      1.0103803      1.0016870      1.0044949      1.0009903 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0079852      1.0143741      1.0018536      1.0004703      1.0098548      1.0017825 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_18_dem_men 
     1.0081040      1.0043097      1.0071391      1.0100985      1.0011570      1.0167878 
uss_18_rep_hug         arv_16         adv_16         arv_18         adv_18  county_splits 
     1.0020698      1.0011570      1.0100985      1.0020698      1.0167878      1.0039065 
   muni_splits            ndv            nrv        ndshare        e_dvs.x       pr_dem.x 
     1.0039987      1.0128944      1.0025180      1.0077083      1.0078550      0.9998153 
       e_dem.x        pbias.x         egap.x        e_dvs.y       pr_dem.y        e_dem.y 
     1.0080124      1.0023517      1.0129795      1.0078550      0.9998153      1.0080124 
       pbias.y         egap.y 
     1.0023517      1.0129795 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    7,822 (312.9%)     17.5%        0.30 5,007 (317%)     10 
Split 2    7,670 (306.8%)     25.7%        0.42 5,019 (318%)      6 
Split 3    7,530 (301.2%)     31.7%        0.50 4,997 (316%)      4 
Split 4    7,439 (297.5%)     33.8%        0.54 4,975 (315%)      3 
Split 5    7,299 (292.0%)     37.3%        0.58 4,896 (310%)      2 
Split 6    7,215 (288.6%)     35.0%        0.61 4,868 (308%)      2 
Split 7    7,154 (286.1%)     26.4%        0.61 4,832 (306%)      3 
Split 8    7,231 (289.2%)     25.1%        0.59 4,789 (303%)      3 
Split 9    7,238 (289.5%)     28.3%        0.57 4,724 (299%)      2 
Split 10   7,274 (291.0%)     22.6%        0.56 4,503 (285%)      2 
Split 11   7,167 (286.7%)      8.4%        0.58 3,958 (250%)      2 
Resample   4,386 (175.4%)       NA%        0.59 4,481 (284%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    7,823 (312.9%)     16.2%        0.30 5,037 (319%)     11 
Split 2    7,676 (307.0%)     22.2%        0.42 5,088 (322%)      7 
Split 3    7,520 (300.8%)     26.9%        0.50 5,038 (319%)      5 
Split 4    7,402 (296.1%)     20.5%        0.54 4,944 (313%)      6 
Split 5    7,341 (293.6%)     25.9%        0.57 4,926 (312%)      4 
Split 6    7,325 (293.0%)     28.2%        0.59 4,844 (307%)      3 
Split 7    7,233 (289.3%)     14.8%        0.60 4,742 (300%)      6 
Split 8    7,202 (288.1%)     20.2%        0.60 4,789 (303%)      4 
Split 9    7,162 (286.5%)     18.2%        0.60 4,658 (295%)      4 
Split 10   7,177 (287.1%)     18.1%        0.60 4,552 (288%)      3 
Split 11   7,158 (286.3%)      6.7%        0.59 3,997 (253%)      3 
Resample   4,647 (185.9%)       NA%        0.60 4,440 (281%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

