### PR TITLE
2020 New Hampshire Congressional Districts

### DIFF
--- a/analyses/NH_cd_2020/01_prep_NH_cd_2020.R
+++ b/analyses/NH_cd_2020/01_prep_NH_cd_2020.R
@@ -49,6 +49,19 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2010, .after = county)
 
+    # add enacted ----
+    # build from hand from this pdf:
+    # https://www.courts.nh.gov/sites/g/files/ehbemt471/files/documents/2022-05/052722norellivsos-plan.pdf
+    en <- c(1, 2, 3, 5, 6, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 18, 19,
+        20, 21, 22, 23, 24, 25, 26, 28, 29, 30, 32, 33, 34, 35, 152,
+        157, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177,
+        179, 225, 238, 240, 241, 242, 243, 244, 245, 246, 247, 248, 250,
+        251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263,
+        264, 265, 266, 268, 269, 270, 271, 272, 273, 274, 275, 277, 278,
+        279, 280, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
+        293, 294, 295, 296, 297, 298, 298, 299, 300, 301, 302, 303, 304,
+        305, 306, 307, 308, 309)
+
     # add proposed ----
     # built from hand from this pdf:
     # http://gencourt.state.nh.us/house/committees/committee_websites/Redistricting_2021/plans/HB%2052%20-%20Congressional%20Districts%20%20Adopted.pdf
@@ -72,12 +85,13 @@ if (!file.exists(here(shp_path))) {
         304, 305, 306, 307, 308, 309)
     nh_shp <- nh_shp %>%
         mutate(rn = row_number(),
-            cd_2020 = if_else(rn %in% r, 1L, 2L),
+            cd_2020 = if_else(rn %in% en, 1L, 2L),
+            rep_prop = if_else(rn %in% r, 1L, 2L),
             dem_prop = if_else(rn %in% d, 1L, 2L),
             .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = nh_shp,
+    redistmetrics::prep_perims(shp = nh_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/NH_cd_2020/03_sim_NH_cd_2020.R
+++ b/analyses/NH_cd_2020/03_sim_NH_cd_2020.R
@@ -6,15 +6,13 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NH_cd_2020}")
 
-plans <- redist_smc(map %>% merge_by(mcd), nsims = 5e3, counties = county)
+set.seed(2020)
+plans <- redist_smc(map %>% merge_by(mcd), nsims = 2500, runs = 2L, counties = county) %>%
+    pullback()
+attr(plans, "prec_pop") <- map$pop
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-plans <- plans %>%
-    pullback() %>%
-    add_reference(map$dem_prop, "dem_prop")
-attr(plans, "prec_pop") <- map$pop
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NH_2020/NH_cd_2020_plans.rds"), compress = "xz")

--- a/analyses/NH_cd_2020/doc_NH_cd_2020.md
+++ b/analyses/NH_cd_2020/doc_NH_cd_2020.md
@@ -16,5 +16,5 @@ Data for New Hampshire comes from the ALARM Project's [2020 Redistricting Data F
 Precincts are merged by minor civil division, as the enacted has 0 minor civil division splits.
 
 ## Simulation Notes
-We sample 5,000 districting plans for New Hampshire.
+We sample 5,000 districting plans for New Hampshire across two independent runs of the SMC algorithm.
 We use a standard county algorithmic constraint.


### PR DESCRIPTION
## Redistricting requirements
In New Hampshire, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for New Hampshire comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Precincts are merged by minor civil division, as the enacted has 0 minor civil division splits.

## Simulation Notes
We sample 5,000 districting plans for New Hampshire across two independent runs of the SMC algorithm.
We use a standard county algorithmic constraint.


## Validation

![validation_20220608_1601](https://user-images.githubusercontent.com/28026893/172710127-264d254f-b8d6-410e-ad77-888f874cba54.png)

```
SMC: 5,000 sampled plans of 2 districts on 326 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.053 to 0.690

R-hat values for summary statistics:
     total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian      pop_asian       pop_nhpi 
     1.0015040      1.0003098      0.9998450      1.0025972      1.0016529      1.0011292      1.0026232      1.0011117      1.0011278      1.0006511 
     pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0014433      1.0001805      1.0016546      1.0016236      1.0027424      1.0008691      1.0012943      1.0010704      1.0017850      1.0000164 
pre_16_rep_tru pre_16_dem_cli uss_16_rep_ayo uss_16_dem_has gov_16_rep_sun gov_16_dem_van gov_18_rep_sun gov_18_dem_kel pre_20_dem_bid pre_20_rep_tru 
     1.0003445      1.0008508      1.0001813      1.0012175      1.0003300      1.0012758      1.0001225      1.0011858      1.0004056      1.0001858 
uss_20_dem_sha uss_20_rep_mes gov_20_dem_fel gov_20_rep_sun         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20 
     1.0006695      1.0002538      1.0011141      1.0001775      1.0002685      1.0010855      1.0001225      1.0011858      1.0001363      1.0007667 
           ndv            nrv        ndshare          e_dvs         pr_dem          e_dem           egap 
     1.0009884      1.0000820      0.9999972      1.0000045      1.0006911      1.0013752      1.0009857 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,484 (99.3%)      3.2%        0.17 1,580 (100%)      5 
Resample    2,439 (97.6%)       NA%        0.17 1,529 ( 97%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,484 (99.4%)      3.3%        0.16 1,574 (100%)      5 
Resample    2,441 (97.6%)       NA%        0.16 1,572 ( 99%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
