### PR TITLE
Re-run 2020 Michigan Congressional Districts

### DIFF
--- a/R/template/dataverse_addendum.md
+++ b/R/template/dataverse_addendum.md
@@ -12,7 +12,7 @@ Both the `redist_plans` and `redist_map` object are intended to be used with the
 * `draw`: unique identifier for each sample. Non-numeric draw names are real-world plans, e.g., `cd_2010` for an enacted 2010 plan.
 * `district`: a district identifier. District numbers are functionally assigned at random and do not correspond to real-world plans.
 * `chain`: a number identifying the run of the redistricting algorithm used to produce this draw. Used for diagnostic purposes.
-* `pop_overlap`: a number indicating the fraction of people in this district who reside in the same-numbered district in the enacted plan.
+* `pop_overlap`: a number indicating the fraction of people in this plan who reside in the same-numbered district in the enacted plan.
 * `total_pop`: the total population of each district.
 * `total_vap`: the total voting-aged population of each district.
 * `pop_*`, `vap_*`: total (voting-aged) population within racial and ethnic groups for each district. Variable codes documented [here](https://github.com/alarm-redist/census-2020#data-format).

--- a/analyses/MI_cd_2020/02_setup_MI_cd_2020.R
+++ b/analyses/MI_cd_2020/02_setup_MI_cd_2020.R
@@ -6,7 +6,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg MI_cd_2020}")
 
 map <- redist_map(mi_shp, pop_tol = 0.005,
     existing_plan = cd_2020, adj = mi_shp$adj) %>%
-    mutate(pseudocounty = if_else(str_detect(county, "(Wayne|Oakland|Macomb)"),
+    mutate(pseudo_county = if_else(str_detect(county, "(Wayne|Oakland|Macomb)"),
         county_muni, county))
 
 # Add an analysis name attribute ----

--- a/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
+++ b/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
@@ -7,11 +7,19 @@
 cli_process_start("Running simulations for {.pkg MI_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(50, vap - vap_white, vap, 0.60)
+    add_constr_grp_hinge(13, vap - vap_white, vap, 0.52) %>%
+    add_constr_grp_hinge(-13, vap - vap_white, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(8, vap - vap_white, vap, 0.62)
 
-plans <- redist_smc(map, nsims = 8e3, counties = pseudocounty,
-    constraints = constr, seq_alpha = 0.4, verbose = FALSE) %>%
-    subset_sampled()
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 12e3, runs = 4, counties = pseudo_county,
+    constraints = constr, pop_temper = 0.02, seq_alpha = 0.9) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, map$cd_2020)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -28,7 +36,6 @@ if (sum(vra_ok) < 5e3) {
         mutate(draw = as.factor(as.integer(draw)))
 }
 
-plans <- add_reference(plans, map$cd_2020)
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/MI_2020/MI_cd_2020_plans.rds"), compress = "xz")
@@ -43,3 +50,15 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/MI_2020/MI_cd_2020_stats.csv")
 
 cli_process_done()
+
+if (FALSE) {
+    library(ggplot2)
+
+    redist.plot.distr_qtys(plans, 1 - vap_white/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.1) +
+        scale_y_continuous("Percent Minority by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020_prop = "black"))
+}

--- a/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
+++ b/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
@@ -60,5 +60,5 @@ if (FALSE) {
         size = 0.1) +
         scale_y_continuous("Percent Minority by VAP") +
         labs(title = "Approximate Performance") +
-        scale_color_manual(values = c(cd_2020_prop = "black"))
+        scale_color_manual(values = c(cd_2020 = "black"))
 }

--- a/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
+++ b/analyses/MI_cd_2020/03_sim_MI_cd_2020.R
@@ -55,9 +55,9 @@ if (FALSE) {
     library(ggplot2)
 
     redist.plot.distr_qtys(plans, 1 - vap_white/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.1) +
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.1) +
         scale_y_continuous("Percent Minority by VAP") +
         labs(title = "Approximate Performance") +
         scale_color_manual(values = c(cd_2020_prop = "black"))

--- a/analyses/MI_cd_2020/doc_MI_cd_2020.md
+++ b/analyses/MI_cd_2020/doc_MI_cd_2020.md
@@ -15,7 +15,7 @@ Based on the current plan, two districts should be majority-minority in order to
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
 We apply a county/municipality constraint, as described below. 
-We target 60% minority share in two districts, and discard any simulations which fail to reach 50% share in two districts.
+We target a 52-62% minority share in two districts.
 
 ## Data Sources
 Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -25,5 +25,5 @@ To meet contiguity requirements, we removed precincts with more water area than 
 We then manually connected any disconnected islands with the nearest precinct on the mainland and in the same county: precincts 26029029017 and 26029029016 in Charlevoix county, and precincts 26047047022 and 26097097010 for the Upper Peninsula.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Michigan.
+We sample 40,000 districting plans for Michigan across four independent runs of the SMC algorithm, then filter down to 5,000 total plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Wayne, Macomb, and Oakland counties. Within these counties, municipalities are each their own pseudocounty as well.  These counties were chosen since they are necessarily split by congressional districts.  Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.

--- a/analyses/MI_cd_2020/doc_MI_cd_2020.md
+++ b/analyses/MI_cd_2020/doc_MI_cd_2020.md
@@ -25,5 +25,5 @@ To meet contiguity requirements, we removed precincts with more water area than 
 We then manually connected any disconnected islands with the nearest precinct on the mainland and in the same county: precincts 26029029017 and 26029029016 in Charlevoix county, and precincts 26047047022 and 26097097010 for the Upper Peninsula.
 
 ## Simulation Notes
-We sample 40,000 districting plans for Michigan across four independent runs of the SMC algorithm, then filter down to 5,000 total plans.
+We sample 48,000 districting plans for Michigan across four independent runs of the SMC algorithm, then filter down to 5,000 total plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Wayne, Macomb, and Oakland counties. Within these counties, municipalities are each their own pseudocounty as well.  These counties were chosen since they are necessarily split by congressional districts.  Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.


### PR DESCRIPTION
## Redistricting requirements
In Michigan, districts must:

1. be contiguous (Mich. Const. art. IV, § 6(13)(b)). Island areas are considered to be contiguous by land to the county of which they are a part.
1. have equal populations (Mich. Const. art. IV, § 6(13)(a))
1. be geographically compact (Mich. Const. art. IV, § 6(13)(g))
1. reflect consideration of county, city, and township boundaries (Mich. Const. art. IV, § 6(13)(f))
1. not provide a disproportionate advantage to any political party, determined using accepted measures of partisan fairness (Mich. Const. art. IV, § 6(13)(d))

Based on the current plan, two districts should be majority-minority in order to comply with the Voting Rights Act.


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below. 
We target a 52-62% minority share in two districts.

## Data Sources
Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To meet contiguity requirements, we removed precincts with more water area than land area and no population.
We then manually connected any disconnected islands with the nearest precinct on the mainland and in the same county: precincts 26029029017 and 26029029016 in Charlevoix county, and precincts 26047047022 and 26097097010 for the Upper Peninsula.

## Simulation Notes
We sample 40,000 districting plans for Michigan across four independent runs of the SMC algorithm, then filter down to 5,000 total plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Wayne, Macomb, and Oakland counties. Within these counties, municipalities are each their own pseudocounty as well.  These counties were chosen since they are necessarily split by congressional districts.  Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.


## Validation

![image](https://user-images.githubusercontent.com/2958471/174165270-0511f6ac-9d8a-4d84-b241-69f3f0d2dd16.png)

```
SMC: 5,000 sampled plans of 13 districts on 4,767 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.9
`est_label_mult`=1 • `pop_temper`=0.02

Plan diversity 80% range: 0.68 to 0.91

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby 
        1.0100         1.0157         1.0103         1.0029         1.0240 
      pop_hisp      pop_white      pop_black       pop_aian      pop_asian 
        1.0390         1.0138         1.0503         1.0332         1.0240 
      pop_nhpi      pop_other        pop_two       vap_hisp      vap_white 
        1.0103         1.0077         1.0159         1.0398         1.0243 
     vap_black       vap_aian      vap_asian       vap_nhpi      vap_other 
        1.0508         1.0316         1.0194         1.0380         1.0155 
       vap_two pre_16_dem_cli pre_16_rep_tru uss_18_rep_jam uss_18_dem_sta 
        1.0481         1.0129         1.0241         1.0277         1.0102 
gov_18_rep_sch gov_18_dem_whi atg_18_rep_leo atg_18_dem_nes sos_18_rep_lan 
        1.0292         1.0123         1.0299         1.0085         1.0272 
sos_18_dem_ben pre_20_rep_tru pre_20_dem_bid uss_20_rep_jam uss_20_dem_pet 
        1.0086         1.0294         1.0052         1.0202         1.0095 
        arv_16         adv_16         arv_18         adv_18         arv_20 
        1.0241         1.0129         1.0274         1.0135         1.0257 
        adv_20  county_splits    muni_splits            ndv            nrv 
        1.0070         1.0181         1.0186         1.0099         1.0269 
       ndshare          e_dvs          e_dem          pbias           egap 
        1.0172         1.0172         1.0063         1.0102         1.0067 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 4 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     7,609 (63.4%)     17.9%        0.46 7,627 (101%)     10 
Split 2     7,064 (58.9%)     26.2%        0.48 6,500 ( 86%)      6 
Split 3     6,666 (55.6%)     33.4%        0.56 6,454 ( 85%)      4 
Split 4     5,904 (49.2%)     31.1%        0.63 6,337 ( 84%)      4 
Split 5     5,636 (47.0%)     29.1%        0.66 6,171 ( 81%)      4 
Split 6     5,449 (45.4%)     33.0%        0.67 5,982 ( 79%)      3 
Split 7     5,434 (45.3%)     30.7%        0.64 5,977 ( 79%)      3 
Split 8     5,207 (43.4%)     27.7%        0.62 5,902 ( 78%)      3 
Split 9     5,387 (44.9%)     13.5%        0.58 5,869 ( 77%)      6 
Split 10    5,144 (42.9%)     16.6%        0.57 5,830 ( 77%)      4 
Split 11    5,471 (45.6%)     16.4%        0.56 5,547 ( 73%)      3 
Split 12    3,891 (32.4%)      5.6%        0.56 5,198 ( 69%)      3 
Resample    3,375 (28.1%)       NA%        1.57 4,953 ( 65%)     NA 

Sampling diagnostics for SMC run 2 of 4 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     7,634 (63.6%)     16.5%        0.46 7,590 (100%)     11 
Split 2     7,065 (58.9%)     15.7%        0.48 6,545 ( 86%)     10 
Split 3     5,746 (47.9%)     20.4%        0.57 6,354 ( 84%)      7 
Split 4     5,281 (44.0%)     25.8%        0.65 6,229 ( 82%)      5 
Split 5     5,901 (49.2%)     29.2%        0.66 6,054 ( 80%)      4 
Split 6     5,852 (48.8%)     19.0%        0.66 6,043 ( 80%)      6 
Split 7     4,810 (40.1%)     24.6%        0.66 6,038 ( 80%)      4 
Split 8     5,246 (43.7%)     27.8%        0.63 5,854 ( 77%)      3 
Split 9     5,403 (45.0%)     24.7%        0.60 5,910 ( 78%)      3 
Split 10    5,602 (46.7%)     20.7%        0.54 5,805 ( 77%)      3 
Split 11    5,982 (49.8%)     20.8%        0.54 5,669 ( 75%)      2 
Split 12    3,855 (32.1%)      5.5%        0.55 5,215 ( 69%)      3 
Resample    3,433 (28.6%)       NA%        1.62 4,866 ( 64%)     NA 

Sampling diagnostics for SMC run 3 of 4 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     7,576 (63.1%)     15.0%        0.46 7,598 (100%)     12 
Split 2     7,024 (58.5%)     22.5%        0.47 6,517 ( 86%)      7 
Split 3     6,221 (51.8%)     27.9%        0.56 6,415 ( 85%)      5 
Split 4     5,961 (49.7%)     30.9%        0.63 6,285 ( 83%)      4 
Split 5     5,818 (48.5%)     29.0%        0.66 6,175 ( 81%)      4 
Split 6     5,202 (43.3%)     16.1%        0.66 5,970 ( 79%)      7 
Split 7     4,563 (38.0%)     24.8%        0.66 5,825 ( 77%)      4 
Split 8     5,317 (44.3%)     27.9%        0.61 5,863 ( 77%)      3 
Split 9     4,892 (40.8%)     19.6%        0.59 5,879 ( 78%)      4 
Split 10    4,829 (40.2%)     11.1%        0.55 5,757 ( 76%)      6 
Split 11    5,725 (47.7%)     12.3%        0.54 5,644 ( 74%)      4 
Split 12    2,839 (23.7%)      5.5%        0.53 5,239 ( 69%)      3 
Resample    2,249 (18.7%)       NA%        1.51 4,752 ( 63%)     NA 

Sampling diagnostics for SMC run 4 of 4 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     7,569 (63.1%)     14.9%        0.46 7,571 (100%)     12 
Split 2     6,831 (56.9%)     22.7%        0.49 6,494 ( 86%)      7 
Split 3     6,462 (53.8%)     28.0%        0.56 6,406 ( 84%)      5 
Split 4     6,022 (50.2%)     30.7%        0.63 6,222 ( 82%)      4 
Split 5     5,973 (49.8%)     17.4%        0.67 6,125 ( 81%)      7 
Split 6     5,564 (46.4%)     22.2%        0.68 6,063 ( 80%)      5 
Split 7     5,512 (45.9%)     24.5%        0.65 6,010 ( 79%)      4 
Split 8     5,156 (43.0%)     27.7%        0.63 5,962 ( 79%)      3 
Split 9     5,365 (44.7%)     32.1%        0.60 5,870 ( 77%)      2 
Split 10    5,671 (47.3%)     21.4%        0.58 5,721 ( 75%)      3 
Split 11    5,832 (48.6%)     15.5%        0.56 5,635 ( 74%)      3 
Split 12    3,356 (28.0%)      4.1%        0.56 5,240 ( 69%)      4 
Resample    2,579 (21.5%)       NA%        1.53 4,772 ( 63%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than
1%), large std. devs. of the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low
plan diversity or bottlenecks as well, address those issues first.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@christopherkenny