### PR TITLE
2020 Georgia Congressional Districts

### DIFF
--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -10,12 +10,13 @@ constr <- redist_constr(map) %>%
     add_constr_grp_hinge(20, vap_black, vap, 0.52) %>%
     add_constr_grp_hinge(-20, vap_black, vap, 0.45) %>%
     add_constr_grp_inv_hinge(10, vap_black, vap, 0.62)
-    # add_constr_grp_hinge(20, vap_black, vap, tgts_group = 0.55)
-    # add_constr_grp_hinge(5, vap_black, vap, tgts_group = 0.55)
 
 set.seed(2020)
 plans <- redist_smc(map, nsims = 1e4, runs = 2L, counties = county, constraints = constr,
-                    pop_temper = 0.01)
+                    pop_temper = 0.01, ncores = 8) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
 plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -7,9 +7,16 @@
 cli_process_start("Running simulations for {.pkg GA_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(20, vap_black, vap, tgts_group = 0.55)
+    add_constr_grp_hinge(20, vap_black, vap, 0.52) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, 0.45) %>%
+    add_constr_grp_inv_hinge(10, vap_black, vap, 0.62)
+    # add_constr_grp_hinge(20, vap_black, vap, tgts_group = 0.55)
+    # add_constr_grp_hinge(5, vap_black, vap, tgts_group = 0.55)
 
-plans <- redist_smc(map, nsims = 5e3, counties = county, constraints = constr)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 1e4, runs = 2L, counties = county, constraints = constr,
+                    pop_temper = 0.01, ncores = 8)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -22,6 +29,8 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg GA_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
+
+summary(plans)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/GA_2020/GA_cd_2020_stats.csv")

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -13,7 +13,7 @@ constr <- redist_constr(map) %>%
 
 set.seed(2020)
 plans <- redist_smc(map, nsims = 1e4, runs = 2L, counties = county, constraints = constr,
-                    pop_temper = 0.01, ncores = 8) %>%
+                    pop_temper = 0.01) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
     ungroup()

--- a/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
+++ b/analyses/GA_cd_2020/03_sim_GA_cd_2020.R
@@ -15,7 +15,7 @@ constr <- redist_constr(map) %>%
 
 set.seed(2020)
 plans <- redist_smc(map, nsims = 1e4, runs = 2L, counties = county, constraints = constr,
-                    pop_temper = 0.01, ncores = 8)
+                    pop_temper = 0.01)
 plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()

--- a/analyses/GA_cd_2020/doc_GA_cd_2020.md
+++ b/analyses/GA_cd_2020/doc_GA_cd_2020.md
@@ -1,13 +1,13 @@
 # 2020 Georgia Congressional Districts
 
 ## Redistricting requirements
-In Georgia, districts must, under the 2021-22 State House and Senate Reapportionment Committee guidelines:
+In Georgia, districts must, under the 2021-22 Guidelines for the House Legislative and Congressional Reapportionment Committee:
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. "efforts should be made to avoid the unnecessary pairing of incumbents"
+5. avoid the unnecessary pairing of incumbents
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
@@ -19,6 +19,6 @@ Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Georgia.
-To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.
-We apply a hinge Gibbs constraint of strength 20 to encourage drawing majority black districts.
+We sample 20,000 districting plans for Georgia.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Cobb, Fulton, and Gwinnett Counties must be split due to their large populations, although within each of these counties, we avoid splitting any municipality.
+We apply a hinge Gibbs constraint of strength 20 to encourage drawing the same number of majority-Black districts as the enacted plan, and a hinge Gibbs constraint of strength -20 

--- a/analyses/GA_cd_2020/doc_GA_cd_2020.md
+++ b/analyses/GA_cd_2020/doc_GA_cd_2020.md
@@ -21,4 +21,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 20,000 districting plans for Georgia.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Cobb, Fulton, and Gwinnett Counties must be split due to their large populations, although within each of these counties, we avoid splitting any municipality.
-We apply a hinge Gibbs constraint of strength 20 to encourage drawing the same number of majority-Black districts as the enacted plan, and a hinge Gibbs constraint of strength -20 
+We apply a hinge Gibbs constraint of strength 20 to encourage drawing the same number of majority-Black districts as the enacted plan, focusing on districts with relatively higher proportions of Black voters. We also apply a hinge Gibbs constraint of strength 10 to discourage packing of Black voters.

--- a/analyses/GA_cd_2020/doc_GA_cd_2020.md
+++ b/analyses/GA_cd_2020/doc_GA_cd_2020.md
@@ -19,6 +19,6 @@ Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 20,000 districting plans for Georgia.
+We sample 20,000 districting plans for Georgia across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Cobb, Fulton, and Gwinnett Counties must be split due to their large populations, although within each of these counties, we avoid splitting any municipality.
 We apply a hinge Gibbs constraint of strength 20 to encourage drawing the same number of majority-Black districts as the enacted plan, focusing on districts with relatively higher proportions of Black voters. We also apply a hinge Gibbs constraint of strength 10 to discourage packing of Black voters.


### PR DESCRIPTION
## Redistricting requirements
In Georgia, districts must, under the 2021-22 Guidelines for the House Legislative and Congressional Reapportionment Committee:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. avoid the unnecessary pairing of incumbents

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for Georgia.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Cobb, Fulton, and Gwinnett Counties must be split due to their large populations, although within each of these counties, we avoid splitting any municipality.
We apply a hinge Gibbs constraint of strength 20 to encourage drawing the same number of majority-Black districts as the enacted plan, focusing on districts with relatively higher proportions of Black voters. We also apply a hinge Gibbs constraint of strength 10 to discourage packing of Black voters.

## Validation

![validation_20220617_2318](https://user-images.githubusercontent.com/26680063/174422060-a93f440c-1a3d-421d-8492-96f4cbca01aa.png)

```
SMC: 20,000 sampled plans of 14 districts on 2,698 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5      
`est_label_mult`=1 • `pop_temper`=0.01        
ℹ Computing summary statistics for GA_cd_2020
Plan diversity 80% range: 0.62 to 0.83        
ℹ Computing summary statistics for GA_cd_2020
R-hat values for summary statistics:
    pop_overlap       total_vap        plan_dev       comp_edge     comp_polsby        pop_hisp 
       1.000799        1.003039        1.004908        1.007065        1.022116        1.009669 
      pop_white       pop_black        pop_aian       pop_asian        pop_nhpi       pop_other 
       1.006999        1.014408        1.010030        1.014722        1.001162        1.004708 
        pop_two        vap_hisp       vap_white       vap_black        vap_aian       vap_asian 
       1.009260        1.012871        1.007489        1.014679        1.012604        1.013841 
       vap_nhpi       vap_other         vap_two  pre_16_rep_tru  pre_16_dem_cli  uss_16_rep_isa 
       1.001096        1.010891        1.008015        1.005688        1.016390        1.002402 
 uss_16_dem_bar  gov_18_rep_kem  gov_18_dem_abr  atg_18_rep_car  atg_18_dem_bai  sos_18_rep_raf 
       1.006777        1.001745        1.012205        1.002346        1.004412        1.001796 
 sos_18_dem_bar sos_r18_rep_raf sos_r18_dem_bar  pre_20_rep_tru  pre_20_dem_bid  uss_20_rep_per 
       1.007770        1.011450        1.000761        1.001534        1.015859        1.002111 
 uss_20_dem_oss          arv_16          adv_16          arv_18          adv_18          arv_20 
       1.011646        1.001944        1.004733        1.001989        1.007848        1.001819 
         adv_20   county_splits     muni_splits             ndv             nrv         ndshare 
       1.017033        1.013087        1.001263        1.010022        1.001786        1.002082 
          e_dvs          pr_dem           e_dem           pbias            egap 
       1.002116        1.002921        1.000007        1.000692        1.000568 

Sampling diagnostics for SMC run 1 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,670 (86.7%)     13.9%        0.25 6,315 (100%)     13 
Split 2     8,453 (84.5%)     20.1%        0.47 5,980 ( 95%)      8 
Split 3     8,413 (84.1%)     28.5%        0.54 5,930 ( 94%)      5 
Split 4     8,307 (83.1%)     18.8%        0.57 5,882 ( 93%)      7 
Split 5     8,213 (82.1%)     19.6%        0.60 5,845 ( 92%)      6 
Split 6     8,069 (80.7%)     17.8%        0.63 5,855 ( 93%)      6 
Split 7     7,770 (77.7%)     23.1%        0.68 5,805 ( 92%)      4 
Split 8     7,571 (75.7%)     26.7%        0.71 5,764 ( 91%)      3 
Split 9     7,585 (75.8%)     23.0%        0.73 5,615 ( 89%)      3 
Split 10    7,492 (74.9%)     20.2%        0.71 5,654 ( 89%)      3 
Split 11    7,592 (75.9%)     23.1%        0.72 5,548 ( 88%)      2 
Split 12    7,647 (76.5%)     17.2%        0.68 5,405 ( 86%)      2 
Split 13    7,406 (74.1%)      6.2%        0.71 4,832 ( 76%)      2 
Resample    3,197 (32.0%)       NA%        1.19 4,661 ( 74%)     NA 

Sampling diagnostics for SMC run 2 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,668 (86.7%)     19.8%        0.25 6,336 (100%)      9 
Split 2     8,433 (84.3%)     26.5%        0.47 5,986 ( 95%)      6 
Split 3     8,417 (84.2%)     34.9%        0.53 5,969 ( 94%)      4 
Split 4     8,291 (82.9%)     26.0%        0.57 5,885 ( 93%)      5 
Split 5     8,200 (82.0%)     28.4%        0.60 5,805 ( 92%)      4 
Split 6     7,931 (79.3%)     32.5%        0.66 5,846 ( 92%)      3 
Split 7     7,876 (78.8%)     29.2%        0.69 5,793 ( 92%)      3 
Split 8     7,649 (76.5%)     34.9%        0.71 5,745 ( 91%)      2 
Split 9     7,440 (74.4%)     30.6%        0.73 5,693 ( 90%)      2 
Split 10    7,636 (76.4%)     26.8%        0.73 5,632 ( 89%)      2 
Split 11    7,638 (76.4%)     23.1%        0.71 5,602 ( 89%)      2 
Split 12    7,529 (75.3%)     12.5%        0.70 5,364 ( 85%)      3 
Split 13    7,474 (74.7%)      6.2%        0.69 4,772 ( 75%)      2 
Resample    2,879 (28.8%)       NA%        1.11 4,737 ( 75%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@kuriwaki
