### PR TITLE
Re-run 2020 Montana Congressional Districts

### DIFF
--- a/analyses/MT_cd_2020/03_sim_MT_cd_2020.R
+++ b/analyses/MT_cd_2020/03_sim_MT_cd_2020.R
@@ -6,7 +6,9 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MT_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+plans <- match_numbers(plans, map$cd_2020)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/MT_cd_2020/doc_MT_cd_2020.md
+++ b/analyses/MT_cd_2020/doc_MT_cd_2020.md
@@ -20,7 +20,7 @@ Data for Montana comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Montana.
+We sample 5,000 districting plans for Montana across two runs of the SMC algorithm.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties for all counties with a population under 50,000.
 Within counties larger than 50,000, municipalities are each their own pseudocounty as well.

--- a/analyses/MT_cd_2020/doc_MT_cd_2020.md
+++ b/analyses/MT_cd_2020/doc_MT_cd_2020.md
@@ -20,7 +20,7 @@ Data for Montana comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Montana across two runs of the SMC algorithm.
+We sample 5,000 districting plans for Montana across two independent runs of the SMC algorithm.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties for all counties with a population under 50,000.
 Within counties larger than 50,000, municipalities are each their own pseudocounty as well.


### PR DESCRIPTION
## Redistricting requirements
In Montana, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.

## Data Sources
Data for Montana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Montana across two runs of the SMC algorithm.
To balance county and municipality splits, we create pseudocounties for use in the county constraint.
These are counties for all counties with a population under 50,000.
Within counties larger than 50,000, municipalities are each their own pseudocounty as well.
Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.


## Validation

![image](https://user-images.githubusercontent.com/2958471/174454770-411eaa35-1610-4144-8cb8-37d2cd1d19e9.png)

```
SMC: 5,000 sampled plans of 2 districts on 666 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.21 to 0.68

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
       1.00069        1.00333        1.00123        1.00073        0.99982        1.00328        1.00423 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
       1.00051        1.00353        1.00051        1.00050        1.00234        1.00023        1.00350 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
       1.00380        1.00020        1.00345        1.00048        1.00019        1.00253        0.99980 
pre_16_rep_tru pre_16_dem_cli gov_16_rep_gia gov_16_dem_bul atg_16_rep_fox atg_16_dem_jen sos_16_rep_sta 
       1.00060        1.00196        1.00087        1.00184        1.00152        1.00233        1.00173 
sos_16_dem_lin uss_18_rep_ros uss_18_dem_tes pre_20_rep_tru pre_20_dem_bid uss_20_rep_dai uss_20_dem_bul 
       1.00163        1.00144        1.00190        1.00142        1.00250        1.00214        1.00239 
gov_20_rep_gia gov_20_dem_coo atg_20_rep_knu atg_20_dem_gra sos_20_rep_jac sos_20_dem_ben         arv_16 
       1.00222        1.00247        1.00222        1.00221        1.00130        1.00236        1.00069 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits 
       1.00208        1.00144        1.00190        1.00249        1.00241        1.00006        1.00065 
           ndv            nrv        ndshare          e_dvs         pr_dem          e_dem           egap 
       1.00211        1.00113        1.00148        1.00148        1.00065        1.00037        0.99986 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,466 (98.7%)      3.3%        0.23 1,590 (101%)      7 
Resample    2,370 (94.8%)       NA%        0.23 1,550 ( 98%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,466 (98.6%)      3.3%        0.24 1,586 (100%)      7 
Resample    2,367 (94.7%)       NA%        0.24 1,577 (100%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@christopherkenny
