### PR TITLE
Re-run 2020 Ohio Congressional Districts

### DIFF
--- a/analyses/OH_cd_2020/01_prep_OH_cd_2020.R
+++ b/analyses/OH_cd_2020/01_prep_OH_cd_2020.R
@@ -56,7 +56,7 @@ if (!file.exists(here(shp_path))) {
 
     # add the enacted plan
     baf_20 <- readxl::read_xlsx(path_enacted) %>%
-        rename(BLOCKID=BLOCK)
+        rename(BLOCKID = BLOCK)
     d_cd <- make_from_baf("OH", baf_20, "VTD") %>%
         transmute(GEOID = paste0(censable::match_fips("OH"), vtd),
             cd_2020 = as.integer(districtid))

--- a/analyses/OH_cd_2020/03_sim_OH_cd_2020.R
+++ b/analyses/OH_cd_2020/03_sim_OH_cd_2020.R
@@ -6,8 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OH_cd_2020}")
 
-N <- 5000 # simulations
-
 ## First, simulate a VRA district in Cuyahoga county (Cleveland) -----
 
 idxs <- which(map_2020$county == "Cuyahoga County")
@@ -22,22 +20,26 @@ constr <- redist_constr(map_cleve) %>%
         spl <- tapply(pl, map_cleve$county, dplyr::n_distinct) - 1L
         any(spl >= 3)
     }) %>%
-    add_constr_grp_hinge(60.0, vap_black, vap, c(0.02, 0.07, 0.41))
+    add_constr_grp_hinge(20.0, vap_black, vap, 0.4) %>%
+    add_constr_grp_hinge(-20.0, vap_black, vap, 0.25)
 
-pl_cleve <- redist_smc(map_cleve, N, counties = split_unit, constraints = constr, n_steps = 1,
-    pop_temper = 0.05, seq_alpha = 0.5, verbose = TRUE) %>%
+set.seed(2020)
+
+pl_cleve <- redist_smc(map_cleve, N, runs = 4, counties = split_unit,
+    constraints = constr, n_steps = 1, pop_temper = 0.05, verbose = TRUE) %>%
     mutate(black = group_frac(map_cleve, vap_black, vap)) %>%
     number_by(black)
 
 # prepare for simulating remainder
+N <- 30000 # simulations
+
 m_cleve <- pl_cleve %>%
     group_by(draw) %>%
     filter(black[2] > 0.4, total_pop[2] >= attr(map, "pop_bounds")[1]) %>%
     as.matrix()
 N_valid <- ncol(m_cleve)
 m_init <- matrix(0L, nrow = nrow(map_2020), ncol = N)
-m_init[idxs, seq_len(N_valid)] <- m_cleve
-m_init[idxs, seq(N_valid + 1, N)] <- m_cleve[, sample(N_valid, N - N_valid, replace = TRUE)]
+m_init[idxs, ] <- m_cleve[, sample(N_valid, N, replace = FALSE)]
 m_init[m_init != 2] <- 0L
 m_init[m_init == 2] <- 1L
 
@@ -47,17 +49,25 @@ m_init[m_init == 2] <- 1L
 columbus_idx <- which(map_2020$class_muni == "B(4)(a)")
 
 constr <- redist_constr(map_2020) %>%
-    add_constr_custom(100.0, function(pl, i) {
-        spl <- tapply(pl, map_2020$county, dplyr::n_distinct) - 1L
-        any(spl >= 3) + 0.03*any(spl == 2)
+    add_constr_custom(10.0, function(plan, i) {
+        spl <- tapply(plan, map_2020$county, dplyr::n_distinct) - 1L
+        any(spl >= 3) + 0.1*any(spl == 2)
     }) %>%
-    add_constr_custom(0.5, function(pl, i) dplyr::n_distinct(pl[columbus_idx]) - 1L)
+    add_constr_custom(0.3, function(plan, i) {
+        n_distinct(plan[columbus_idx]) - 1L
+    })
 
-plans <- redist_smc(map_2020, N, counties = split_unit, constraints = constr,
-    init_particles = m_init[, 1:N], pop_temper = 0.01, seq_alpha = 0.7,
-    verbose = TRUE) %>%
+set.seed(2020)
+
+plans <- redist_smc(map_2020, N, runs = 2, counties = split_unit,
+    constraints = constr, init_particles = m_init, pop_temper = 0.04,
+    seq_alpha = 0.95, verbose = TRUE) %>%
     pullback(map) %>%
-    `attr<-`("prec_pop", map$pop)
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, map$cd_2020)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/OH_cd_2020/doc_OH_cd_2020.md
+++ b/analyses/OH_cd_2020/doc_OH_cd_2020.md
@@ -26,7 +26,7 @@ We merge the precincts in all counties which are not split by the enacted plan.
 We merge the cities of Cincinnati and Cleveland.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Ohio.
+We sample 40,000 districting plans for Ohio across two runs of the SMC algorithm, then filter down to 5,000 total plans.
 We begin by sampling plans in Cuyahoga county to generate a VRA district with BVAP at least 40%. Then we sample the remaining districts.
 We apply a Gibbs constraint to discourage multiple splits (a penalty of 100.0 for 3 splits, and 3.0 for 2 splits)
 We apply a Gibbs constraint to discourage splitting Columbus (a penalty of 0.5 per splitting district)


### PR DESCRIPTION
## Redistricting requirements
In Ohio, districts must, under [Article XIX of the Ohio Constitution](https://www.legislature.ohio.gov/laws/ohio-constitution/article?id=19):

1. be contiguous
1. have equal populations
1. be geographically compact
1. not split Cincinnati or Cleveland
1. minimize splitting of Columbus
1. split no more than 18 counties once, and no more than 5 counties twice, and no counties three times
1. additionally preserve county and municipality boundaries where possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We employ a variety of anti-split constraints, both in pre-processing and in simulation, as detailed below.
Ohio also has one VRA district in Cuyahoga county.

## Data Sources
Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Ohio has many precincts which are not geographically contiguous, especially in and around Franklin County (Columbus). We do not attempt to split or otherwise correct these precincts, which may lead some simulated districts to be geographically noncontiguous, despite being contiguous according to the precinct adjacency graph.

## Pre-processing Notes
We merge the precincts in all counties which are not split by the enacted plan.
We merge the cities of Cincinnati and Cleveland.

## Simulation Notes
We sample 40,000 districting plans for Ohio across two runs of the SMC algorithm, then filter down to 5,000 total plans.
We begin by sampling plans in Cuyahoga county to generate a VRA district with BVAP at least 40%. Then we sample the remaining districts.
We apply a Gibbs constraint to discourage multiple splits (a penalty of 100.0 for 3 splits, and 3.0 for 2 splits)
We apply a Gibbs constraint to discourage splitting Columbus (a penalty of 0.5 per splitting district)
We use population tempering of 0.01 to encourage efficiency.


## Validation

![image](https://user-images.githubusercontent.com/2958471/174467334-a638e9a5-7817-4854-895f-0e3f63f5b552.png)

Extra validation:
![image](https://user-images.githubusercontent.com/2958471/174467346-2b2bac87-b61a-45fd-95af-d1e7531169fa.png)


```
SMC: 5,000 sampled plans of 15 districts on 8,937 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.04

Plan diversity 80% range: 0.50 to 0.69

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black 
       1.01386        1.04624        1.10217        1.02453        1.01502        1.02831        1.05033        1.03351 
      pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black 
       1.08934        1.00760        1.00196        1.05412        1.01050        1.03566        1.07376        1.03281 
      vap_aian      vap_asian       vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_por 
       1.08288        1.00059        1.00261        1.01985        1.02981        1.04805        1.08137        1.05697 
uss_16_dem_str uss_18_rep_ren uss_18_dem_bro gov_18_rep_dew gov_18_dem_cor atg_18_rep_yos atg_18_dem_det sos_18_rep_lar 
       1.08008        1.05659        1.06499        1.05495        1.09719        1.05576        1.09826        1.05207 
sos_18_dem_cly pre_20_rep_tru pre_20_dem_bid         arv_16         adv_16         arv_18         adv_18         arv_20 
       1.09493        1.05571        1.02517        1.05657        1.09918        1.05377        1.09352        1.05571 
        adv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
       1.02517        1.03256        1.00399        1.09501        1.05440        1.03986        1.03665        1.01368 
         e_dem          pbias           egap       splits_1       splits_2 
       0.99989        1.01206        1.00020        1.00347        1.00802 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (30,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k    
Split 1    22,039 (73.5%)     18.9%        0.76 18,868 ( 99%)     10    
Split 2    19,496 (65.0%)     20.5%        0.84 16,604 ( 88%)      7    
Split 3    17,009 (56.7%)     16.5%        0.90 16,242 ( 86%)      7    
Split 4    13,845 (46.1%)     13.9%        0.95 15,744 ( 83%)      7    
Split 5     9,806 (32.7%)     12.1%        0.99 15,299 ( 81%)      7    
Split 6     8,156 (27.2%)     17.5%        1.05 14,709 ( 78%)      4    
Split 7     6,705 (22.3%)     19.2%        1.10 14,144 ( 75%)      3    
Split 8     7,126 (23.8%)     17.2%        1.10 13,494 ( 71%)      3    
Split 9     6,051 (20.2%)     20.3%        1.13 13,128 ( 69%)      2    
Split 10    4,940 (16.5%)     19.1%        1.10 12,263 ( 65%)      2    
Split 11    6,043 (20.1%)     17.7%        1.12 11,082 ( 58%)      2    
Split 12    5,300 (17.7%)     17.8%        1.00  9,761 ( 51%)      2    
Split 13     1,782 (5.9%)      5.3%        0.85 10,534 ( 56%)      2    
Resample     1,429 (4.8%)       NA%        6.10  9,429 ( 50%)     NA  * 

Sampling diagnostics for SMC run 2 of 2 (30,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    22,038 (73.5%)     23.2%        0.75 18,875 (100%)      8 
Split 2    19,563 (65.2%)     27.3%        0.84 16,596 ( 88%)      5 
Split 3    15,832 (52.8%)     22.4%        0.90 16,240 ( 86%)      5 
Split 4    12,884 (42.9%)     27.9%        0.96 15,589 ( 82%)      3 
Split 5    12,038 (40.1%)     29.8%        1.01 15,195 ( 80%)      2 
Split 6    10,495 (35.0%)     17.0%        1.05 14,760 ( 78%)      4 
Split 7     9,023 (30.1%)     18.7%        1.08 14,336 ( 76%)      3 
Split 8     7,889 (26.3%)     21.5%        1.11 13,819 ( 73%)      2 
Split 9     3,538 (11.8%)     16.0%        1.13 13,169 ( 69%)      3 
Split 10    4,355 (14.5%)     18.3%        1.08 11,888 ( 63%)      2 
Split 11    4,089 (13.6%)     16.7%        1.09 11,044 ( 58%)      2 
Split 12    4,152 (13.8%)     13.9%        0.97 10,081 ( 53%)      2 
Split 13     1,879 (6.3%)      4.4%        0.94  9,883 ( 52%)      2 
Resample     2,010 (6.7%)       NA%        6.91  8,700 ( 46%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low plan diversity or bottlenecks as well,
address those issues first.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population tolerance. If the
accpetance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01. To visualize what geographic
areas may be causing problems, try running the following code. Highlighted areas are those that may be causing the
bottleneck.
```

**NOTE:** high partisan R-hats are unique to District 1, which is wedged inside Hamilton county.  R-hats are well below 1.05 for other spot-checked districts.  And given ≤ 1.05 for population totals, not concerned about a value of ~ 1.1 for `pop_dev`

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited



@christopherkenny
@kosukeimai — check re: case. 
