### PR TITLE
Re-run 2020 Pennsylvania Congressional Districts

### DIFF
--- a/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
+++ b/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
@@ -12,7 +12,7 @@ constr <- redist_constr(map) %>%
 set.seed(2020)
 
 plans <- redist_smc(map, nsims = 5000, runs = 2L, counties = pseudo_county,
-    constraints = constr, pop_temper = 0.02, verbose = TRUE) %>%
+    constraints = constr, pop_temper = 0.02) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()

--- a/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
+++ b/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
@@ -48,5 +48,5 @@ if (interactive()) {
         size = 0.1) +
         scale_y_continuous("Percent Minority by VAP") +
         labs(title = "Approximate Performance") +
-        scale_color_manual(values = c(cd_2020_prop = "black"))
+        scale_color_manual(values = c(cd_2020 = "black"))
 }

--- a/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
+++ b/analyses/PA_cd_2020/03_sim_PA_cd_2020.R
@@ -7,10 +7,18 @@
 cli_process_start("Running simulations for {.pkg PA_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_splits(0.2, coalesce(map$county_muni, "<bg>"))
+    add_constr_splits(0.25, coalesce(map$county_muni, "<bg>"))
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county,
-    constraints = constr)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 5000, runs = 2L, counties = pseudo_county,
+    constraints = constr, pop_temper = 0.02, verbose = TRUE) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, map$cd_2020)
+
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -32,13 +40,13 @@ cli_process_done()
 # Extra validation plots for custom constraints -----
 if (interactive()) {
     library(ggplot2)
-    library(patchwork)
 
     # check performance
-    mutate(plans, mvap = 1 - vap_white/total_vap) %>%
-        number_by(mvap) %>%
-        plot(e_dvs, size = 0.01, sort = FALSE, color_thresh=0.5) +
-        scale_color_manual(values=c("red", "blue")) +
-        labs(x="Districts, ordered by minority VAP share",
-             y="ExpectedDemocratic vote share")
+    redist.plot.distr_qtys(plans, 1 - vap_white/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.1) +
+        scale_y_continuous("Percent Minority by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020_prop = "black"))
 }

--- a/analyses/PA_cd_2020/doc_PA_cd_2020.md
+++ b/analyses/PA_cd_2020/doc_PA_cd_2020.md
@@ -20,7 +20,7 @@ Data for Pennsylvania comes from the ALARM Project's [2020 Redistricting Data Fi
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Pennsylvania.
+We sample 10,000 districting plans for Pennsylvania across two runs of the SMC algorithm, then filter down to 5,000 total plans.
 To balance county and municipality splits, we create pseudocounties for use in
 the county constraint. These are counties, outside of Allegheny County,
 Montgomery County, and Philadelphia County. Within Allegheny County, Montgomery


### PR DESCRIPTION
## Redistricting requirements
In Pennsylvania, there are few formal districting requirements, but districts must generally:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.

## Data Sources
Data for Pennsylvania comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Pennsylvania across two runs of the SMC algorithm, then filter down to 5,000 total plans.
To balance county and municipality splits, we create pseudocounties for use in
the county constraint. These are counties, outside of Allegheny County,
Montgomery County, and Philadelphia County. Within Allegheny County, Montgomery
County, and Philadelphia County, each municipality is its own pseudocounty as
well. These counties were chosen since they are necessarily split by
congressional districts.
We also apply an additional Gibbs constraint to further avoid splitting municipalities.

## Validation

![image](https://user-images.githubusercontent.com/2958471/174502714-271392d1-518c-4295-a6fb-64293adef49f.png)

Performance:
![image](https://user-images.githubusercontent.com/2958471/174502739-64a95f3f-4101-4a05-bac0-feb19b6c0ea9.png)

```
SMC: 5,000 sampled plans of 17 districts on 9,178 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0.02

Plan diversity 80% range: 0.64 to 0.83

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
       1.00228        1.00001        1.00120        1.01284        1.04059        1.00331        1.00470 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
       1.00920        1.00530        1.02454        1.05424        1.01004        1.00273        1.00714 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
       1.00486        1.01070        1.00614        1.02389        1.01650        1.00496        1.01967 
pre_16_dem_cli pre_16_rep_tru uss_16_dem_mcg uss_16_rep_too atg_16_dem_sha atg_16_rep_raf uss_18_dem_cas 
       1.00445        0.99985        1.00583        1.00018        1.00512        1.00256        1.00883 
uss_18_rep_bar gov_18_dem_wol gov_18_rep_wag         arv_16         adv_16         arv_18         adv_18 
       1.00969        1.00777        1.00270        1.00063        1.00432        1.00606        1.00846 
 county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
       1.00077        1.04568        1.00365        1.00080        1.00173        1.00163        1.00156 
         e_dem          pbias           egap 
       1.01976        1.00438        1.01516 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,830 (96.6%)     17.1%        0.37 3,175 (100%)     13 
Split 2     4,753 (95.1%)     25.5%        0.42 3,098 ( 98%)      8 
Split 3     4,727 (94.5%)     36.4%        0.47 3,117 ( 99%)      5 
Split 4     4,675 (93.5%)     40.2%        0.52 3,097 ( 98%)      4 
Split 5     4,580 (91.6%)     45.7%        0.58 3,126 ( 99%)      3 
Split 6     4,502 (90.0%)     36.6%        0.62 3,121 ( 99%)      4 
Split 7     4,435 (88.7%)     34.2%        0.66 3,042 ( 96%)      4 
Split 8     4,433 (88.7%)     38.7%        0.69 3,073 ( 97%)      3 
Split 9     4,428 (88.6%)     43.7%        0.69 3,053 ( 97%)      2 
Split 10    4,435 (88.7%)     40.8%        0.67 3,046 ( 96%)      2 
Split 11    4,438 (88.8%)     38.5%        0.67 3,014 ( 95%)      2 
Split 12    4,435 (88.7%)     19.1%        0.63 2,989 ( 95%)      5 
Split 13    4,371 (87.4%)     14.2%        0.65 2,920 ( 92%)      6 
Split 14    4,311 (86.2%)     17.6%        0.65 2,883 ( 91%)      4 
Split 15    4,265 (85.3%)     16.9%        0.68 2,788 ( 88%)      3 
Split 16    4,259 (85.2%)      6.0%        0.70 2,545 ( 81%)      3 
Resample    2,416 (48.3%)       NA%        0.88 2,545 ( 81%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,824 (96.5%)     20.0%        0.38 3,160 (100%)     11 
Split 2     4,760 (95.2%)     28.6%        0.43 3,124 ( 99%)      7 
Split 3     4,742 (94.8%)     31.8%        0.46 3,115 ( 99%)      6 
Split 4     4,705 (94.1%)     40.5%        0.50 3,082 ( 98%)      4 
Split 5     4,650 (93.0%)     38.7%        0.54 3,063 ( 97%)      4 
Split 6     4,556 (91.1%)     23.0%        0.59 3,079 ( 97%)      7 
Split 7     4,414 (88.3%)     34.8%        0.64 3,054 ( 97%)      4 
Split 8     4,414 (88.3%)     17.8%        0.67 3,056 ( 97%)      8 
Split 9     4,437 (88.7%)     25.0%        0.66 3,001 ( 95%)      5 
Split 10    4,438 (88.8%)     33.2%        0.64 3,030 ( 96%)      3 
Split 11    4,389 (87.8%)     25.1%        0.65 3,050 ( 97%)      4 
Split 12    4,321 (86.4%)     28.4%        0.65 2,957 ( 94%)      3 
Split 13    4,406 (88.1%)     25.1%        0.60 2,997 ( 95%)      3 
Split 14    4,318 (86.4%)     21.2%        0.59 2,890 ( 91%)      3 
Split 15    4,205 (84.1%)     16.7%        0.65 2,837 ( 90%)      3 
Split 16    4,220 (84.4%)      7.7%        0.65 2,509 ( 79%)      2 
Resample    2,274 (45.5%)       NA%        0.84 2,583 ( 82%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny