### PR TITLE
Re-run 2020 Washington Congressional Districts

### DIFF
--- a/analyses/WA_cd_2020/03_sim_WA_cd_2020.R
+++ b/analyses/WA_cd_2020/03_sim_WA_cd_2020.R
@@ -7,12 +7,12 @@
 cli_process_start("Running simulations for {.pkg WA_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(10.0, vap - vap_white, vap, c(0.37, 0.55)) %>%
-    add_constr_grp_hinge(-10.0, vap - vap_white, vap, 0.32)
+    add_constr_grp_hinge(10.0, vap - vap_white, vap, c(0.52, 0.35, 0.25)) %>%
+    add_constr_grp_hinge(-8.0, vap - vap_white, vap, c(0.35, 0.25))
 
 set.seed(2020)
 
-plans <- redist_smc(map, nsims = 6000, runs = 2L, counties = pseudo_county,
+plans <- redist_smc(map, nsims = 8e3, runs = 2L, counties = pseudo_county,
     constraints = constr, pop_temper = 0.02, seq_alpha = 0.9) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples

--- a/analyses/WA_cd_2020/03_sim_WA_cd_2020.R
+++ b/analyses/WA_cd_2020/03_sim_WA_cd_2020.R
@@ -6,11 +6,19 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WA_cd_2020}")
 
-
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(15.0, vap - vap_white, vap, c(0.5, 0.35, 0.25))
+    add_constr_grp_hinge(10.0, vap - vap_white, vap, c(0.37, 0.55)) %>%
+    add_constr_grp_hinge(-10.0, vap - vap_white, vap, 0.32)
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county, constraints = constr)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 6000, runs = 2L, counties = pseudo_county,
+    constraints = constr, pop_temper = 0.02, seq_alpha = 0.9) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, map$cd_2020)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -32,9 +40,10 @@ cli_process_done()
 # Extra validation plots for custom constraints -----
 if (interactive()) {
     library(ggplot2)
-    library(patchwork)
 
-    # checking contiguity
-    redist.plot.plans(plans, 25, map) +
-        geom_sf(data = d_water, size = 0.0, fill = "white", color = NA)
+    if (exists("d_water")) {
+        # checking contiguity
+        redist.plot.plans(plans, 25, map) +
+            geom_sf(data = d_water, size = 0.0, fill = "white", color = NA)
+    }
 }

--- a/analyses/WA_cd_2020/doc_WA_cd_2020.md
+++ b/analyses/WA_cd_2020/doc_WA_cd_2020.md
@@ -24,6 +24,6 @@ As described above, the adjacency graph was modified by hand to reflect Washingt
 The full list of these changes can be found in the `01_prep_WA_cd_2020.R` file.
 
 ## Simulation Notes
-We sample 12,000 districting plans for Washington across two runs of the SMC algorithm, then filter down to 5,000 total plans.
+We sample 16,000 districting plans for Washington across two runs of the SMC algorithm, then filter down to 5,000 total plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of King County, Pierce County, and Snohomish County. Within King County, Pierce County, and Snohomish County, each municipality is its own pseudocounty as well. King County, Pierce County, and Snohomish County were chosen since they are necessarily split by congressional districts.
 To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).

--- a/analyses/WA_cd_2020/doc_WA_cd_2020.md
+++ b/analyses/WA_cd_2020/doc_WA_cd_2020.md
@@ -24,6 +24,6 @@ As described above, the adjacency graph was modified by hand to reflect Washingt
 The full list of these changes can be found in the `01_prep_WA_cd_2020.R` file.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Washington.
+We sample 12,000 districting plans for Washington across two runs of the SMC algorithm, then filter down to 5,000 total plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of King County, Pierce County, and Snohomish County. Within King County, Pierce County, and Snohomish County, each municipality is its own pseudocounty as well. King County, Pierce County, and Snohomish County were chosen since they are necessarily split by congressional districts.
 To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).


### PR DESCRIPTION
## Redistricting requirements
In Washington, districts must, under [Article 2, Section 43 of the constitution](https://leg.wa.gov/CodeReviser/Pages/WAConstitution.aspx) and [RCW 44.05.090](https://apps.leg.wa.gov/RCW/default.aspx?cite=44.05.090):

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not be connected across geographic barriers, although ferries across water may establish contiguity 
1. "provide fair and effective representation and ... encourage electoral competition"


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.
To reflect the barriers and contiguity requirements, we remove edges across water regions and mountains in the adjacency graph, but reconnect precincts which are linked by a bridge, highway, or ferry.

## Data Sources
Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements.
The full list of these changes can be found in the `01_prep_WA_cd_2020.R` file.

## Simulation Notes
We sample 16,000 districting plans for Washington across two runs of the SMC algorithm, then filter down to 5,000 total plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of King County, Pierce County, and Snohomish County. Within King County, Pierce County, and Snohomish County, each municipality is its own pseudocounty as well. King County, Pierce County, and Snohomish County were chosen since they are necessarily split by congressional districts.
To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).


## Validation

![image](https://user-images.githubusercontent.com/2958471/174508697-0df6b746-7f8a-4192-91ce-f744460c2a34.png)

Adjacency graph:
![](https://user-images.githubusercontent.com/2958471/154144571-952b5014-deec-4bb1-b085-39f74818f7d1.png)

```
SMC: 5,000 sampled plans of 10 districts on 7,434 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.9
`est_label_mult`=1 • `pop_temper`=0.02

Plan diversity 80% range: 0.46 to 0.75

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
       1.04171        1.01528        1.00537        1.02483        1.00903        1.00308        1.01287 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
       1.00804        1.02013        1.00765        1.00579        1.00713        1.00185        1.01122 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
       1.01964        1.01291        1.01976        1.00601        1.00536        1.00442        1.00370 
pre_16_dem_cli pre_16_rep_tru uss_16_dem_mur uss_16_rep_van gov_16_dem_ins gov_16_rep_bry atg_16_dem_fer 
       1.00271        1.00187        1.00172        1.00113        1.00255        1.00100        1.00083 
atg_16_rep_tru sos_16_dem_pod sos_16_rep_wym uss_18_dem_can uss_18_rep_hut pre_20_dem_bid pre_20_rep_tru 
       1.00054        1.00145        1.00232        1.00525        1.00284        1.00079        1.00155 
gov_20_dem_ins gov_20_rep_cul atg_20_dem_fer atg_20_rep_lar sos_20_dem_tar sos_20_rep_wym         arv_16 
       1.00100        1.00136        1.00128        1.00118        1.00175        1.00270        1.00145 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits 
       1.00162        1.00284        1.00525        1.00178        1.00045        1.00095        1.00379 
           ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
       1.00040        1.00173        1.00015        1.00005        0.99999        1.01330        1.00917 
          egap 
       1.00994 

Sampling diagnostics for SMC run 1 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,999 (75.0%)     14.3%        0.67 5,065 (100%)     12 
Split 2     5,112 (63.9%)     23.9%        0.74 4,528 ( 90%)      7 
Split 3     4,739 (59.2%)     28.5%        0.77 4,401 ( 87%)      5 
Split 4     4,342 (54.3%)     26.7%        0.75 4,305 ( 85%)      5 
Split 5     4,174 (52.2%)     28.9%        0.74 4,364 ( 86%)      4 
Split 6     3,210 (40.1%)     31.2%        0.74 4,278 ( 85%)      3 
Split 7     3,737 (46.7%)     23.5%        0.72 4,136 ( 82%)      4 
Split 8     3,274 (40.9%)     16.3%        0.71 3,893 ( 77%)      5 
Split 9     2,966 (37.1%)      8.2%        0.72 3,468 ( 69%)      3 
Resample    2,465 (30.8%)       NA%        1.31 3,694 ( 73%)     NA 

Sampling diagnostics for SMC run 2 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     6,028 (75.3%)     17.4%        0.67 5,109 (101%)     10 
Split 2     5,194 (64.9%)     26.6%        0.73 4,541 ( 90%)      6 
Split 3     4,826 (60.3%)     33.8%        0.76 4,452 ( 88%)      4 
Split 4     4,268 (53.4%)     31.4%        0.76 4,378 ( 87%)      4 
Split 5     3,879 (48.5%)     34.1%        0.74 4,325 ( 86%)      3 
Split 6     4,028 (50.4%)     37.3%        0.74 4,312 ( 85%)      2 
Split 7     3,804 (47.5%)     27.9%        0.70 4,180 ( 83%)      3 
Split 8     3,685 (46.1%)     25.9%        0.71 4,077 ( 81%)      2 
Split 9     3,692 (46.2%)      4.4%        0.67 3,655 ( 72%)      6 
Resample    3,209 (40.1%)       NA%        1.30 3,854 ( 76%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
