### PR TITLE
Re-run 2020 Mississippi Congressional Districts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,4 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
@@ -47,7 +47,7 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("MS", "CD", "VTD")  %>%
         transmute(GEOID = paste0(censable::match_fips("MS"), vtd),
-                  cd_2010 = as.integer(cd))
+            cd_2010 = as.integer(cd))
     ms_shp <- left_join(ms_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
@@ -58,10 +58,10 @@ if (!file.exists(here(shp_path))) {
     ms_shp <- ms_shp %>%
         mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
             geo_match(ms_shp, cd_shp, method = "area")],
-            .after = cd_2010)
+        .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = ms_shp,
+    redistmetrics::prep_perims(shp = ms_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/01_prep_MS_cd_2020.R
@@ -57,7 +57,7 @@ if (!file.exists(here(shp_path))) {
     cd_shp <- st_read(here(path_shp))
     ms_shp <- ms_shp %>%
         mutate(cd_2020 = as.integer(cd_shp$DISTRICT)[
-            geo_match(ms_shp, cd_shp, method = "area")],
+            geo_match(ms_shp, cd_shp, method = "area")] - 2800L,
         .after = cd_2010)
 
     # Create perimeters in case shapes are simplified

--- a/analyses/MS_cd_2020/03_sim_MS_cd_2020.R
+++ b/analyses/MS_cd_2020/03_sim_MS_cd_2020.R
@@ -7,9 +7,18 @@
 cli_process_start("Running simulations for {.pkg MS_cd_2020}")
 
 cons <- redist_constr(map) %>%
-    add_constr_grp_hinge(30, vap_black, vap, tgts_group = c(0.55, 0.1))
+    add_constr_grp_hinge(20, vap_black, vap, tgts_group = c(0.55)) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, tgts_group = 0.4) %>%
+    add_constr_grp_hinge(-5, vap_black, vap, tgts_group = 0.2)
 
-plans <- redist_smc(map, nsims = 5e3, counties = county, constraints = cons)
+set.seed(2020)
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L,
+    counties = county,
+    constraints = cons
+)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -33,13 +42,13 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    redist.plot.distr_qtys(plans, vap_black / total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, '#3D77BB', '#B25D4C'),
-                           size = 0.5, alpha = 0.5) +
-        scale_y_continuous('Percent Black by VAP') +
-        labs(title = 'Mississippi Proposed Plan versus Simulations') +
-        scale_color_manual(values = c(cd_2020 = 'black')) +
-        ggredist::theme_r21()
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Mississippi Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        theme_bw()
 
 }

--- a/analyses/MS_cd_2020/doc_MS_cd_2020.md
+++ b/analyses/MS_cd_2020/doc_MS_cd_2020.md
@@ -21,5 +21,5 @@ Data for Mississippi comes from the ALARM Project's [2020 Redistricting Data Fil
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Mississippi.
+We sample 5,000 districting plans for Mississippi, across two independent runs of the SMC algorithm.
 We apply a hinge Gibbs constraint of strength 25 to encourage drawing a majority black district.

--- a/fifty-states.Rproj
+++ b/fifty-states.Rproj
@@ -18,6 +18,5 @@ LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
## Redistricting requirements
In Mississippi, [under Mississippi Code 5-3-123](https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=d062935b-fafc-45ea-a1f4-dc1ba2a3377c&nodeid=AAEAACAAFAAC&nodepath=%2FROOT%2FAAE%2FAAEAAC%2FAAEAACAAF%2FAAEAACAAFAAC&level=4&haschildren=&populated=false&title=%C2%A7+5-3-123.+Preparation+of+plan+to+redistrict+congressional+districts.&config=00JABhZDIzMTViZS04NjcxLTQ1MDItOTllOS03MDg0ZTQxYzU4ZTQKAFBvZENhdGFsb2f8inKxYiqNVSihJeNKRlUp&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A8P6B-7XD2-8T6X-701X-00008-00&ecomp=_g1_kkk&prid=4f3abbc9-f98b-4883-a5ce-fcb4020b7438) and [Committee agreement](https://www.dropbox.com/s/z36sc17c3m1cewv/MississippiLegislativeAndCongressionalRedistrictingCommitteeMinutes2012-04-05.pdf), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. comply with the Voting Rights Act of 1965


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We ensure that there is a majority minority district with at least 55% VAP.

## Data Sources
Data for Mississippi comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Mississippi, across two independent runs of the SMC algorithm.
We apply a hinge Gibbs constraint of strength 25 to encourage drawing a majority black district.


## Validation

![validation_20220621_1732](https://user-images.githubusercontent.com/28026893/174900867-0f901f29-198e-4062-8752-a510ba861896.png)

```
MC: 5,000 sampled plans of 4 districts on 1,834 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.33 to 0.65

R-hat values for summary statistics:
    pop_overlap       total_vap        plan_dev       comp_edge     comp_polsby        pop_hisp 
      1.0161978       1.0135821       1.0017838       1.0059392       1.0131546       1.0231597 
      pop_white       pop_black        pop_aian       pop_asian        pop_nhpi       pop_other 
      1.0046979       1.0001948       1.0195683       1.0105299       1.0098101       1.0225349 
        pop_two        vap_hisp       vap_white       vap_black        vap_aian       vap_asian 
      1.0308993       1.0091235       1.0040708       1.0006973       1.0219826       1.0121113 
       vap_nhpi       vap_other         vap_two  pre_16_rep_tru  pre_16_dem_cli  uss_18_rep_wic 
      1.0173080       1.0161155       1.0123284       1.0010476       1.0022840       1.0029217 
 uss_18_dem_bar uss_r18_rep_hyd uss_r18_dem_esp  pre_20_rep_tru  pre_20_dem_bid  uss_20_rep_hyd 
      1.0036974       1.0024034       1.0032830       1.0021244       1.0028947       1.0014444 
 uss_20_dem_esp          arv_16          adv_16          arv_18          adv_18          arv_20 
      1.0043998       1.0010476       1.0022840       1.0029217       1.0036974       1.0016682 
         adv_20   county_splits     muni_splits             ndv             nrv         ndshare 
      1.0030305       1.0025706       1.0197658       1.0060115       1.0013998       1.0071866 
          e_dvs           e_dem           pbias            egap 
      1.0071928       0.9999397       1.0004984       1.0205619 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,893 (75.7%)     11.8%        0.33 1,560 ( 99%)      9 
Split 2     1,362 (54.5%)     17.1%        0.75 1,458 ( 92%)      5 
Split 3     1,270 (50.8%)      9.2%        1.12 1,186 ( 75%)      3 
Resample      490 (19.6%)       NA%        3.08   967 ( 61%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,884 (75.3%)      9.0%        0.32 1,587 (100%)     12 
Split 2     1,413 (56.5%)     12.8%        0.68 1,440 ( 91%)      7 
Split 3     1,105 (44.2%)      6.9%        1.02 1,246 ( 79%)      4 
Resample      300 (12.0%)       NA%        3.09   855 ( 54%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the
log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics
should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
