### PR TITLE
Re-run 2020 West Virginia Congressional Districts

### DIFF
--- a/analyses/WV_cd_2020/01_prep_WV_cd_2020.R
+++ b/analyses/WV_cd_2020/01_prep_WV_cd_2020.R
@@ -49,7 +49,7 @@ if (!file.exists(here(shp_path))) {
             pre_20_dem_bid = sum(votes_dem),
             .groups = "drop")  %>%
         mutate(ndv = pre_20_dem_bid, adv_20 = pre_20_dem_bid,
-            nrv = pre_20_rep_tru, arv_20 = pre_20_rep_tru, )
+            nrv = pre_20_rep_tru, arv_20 = pre_20_rep_tru)
 
     wv_shp <- censable::build_dec("county", "WV") %>%
         censable::breakdown_geoid() %>%
@@ -80,7 +80,7 @@ if (!file.exists(here(shp_path))) {
     )
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = wv_shp,
+    redistmetrics::prep_perims(shp = wv_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 
@@ -93,6 +93,8 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     wv_shp$adj <- redist.adjacency(wv_shp)
+
+    wv_shp$state <- "WV"
 
     write_rds(wv_shp, here(shp_path), compress = "gz")
     cli_process_done()

--- a/analyses/WV_cd_2020/03_sim_WV_cd_2020.R
+++ b/analyses/WV_cd_2020/03_sim_WV_cd_2020.R
@@ -8,7 +8,7 @@ cli_process_start("Running simulations for {.pkg WV_cd_2020}")
 
 set.seed(2020)
 
-plans <- redist_smc(map, nsims = 1250, runs = 4L, ncores = 4, counties = county)
+plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = county)
 
 plans <- match_numbers(plans, "cd_2020")
 

--- a/analyses/WV_cd_2020/03_sim_WV_cd_2020.R
+++ b/analyses/WV_cd_2020/03_sim_WV_cd_2020.R
@@ -6,7 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WV_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 1250, runs = 4L, ncores = 4, counties = county)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/WV_cd_2020/doc_WV_cd_2020.md
+++ b/analyses/WV_cd_2020/doc_WV_cd_2020.md
@@ -20,5 +20,5 @@ Data for West Virginia comes from the [The Upshot Presidential Precinct Map data
 Data is aggregated to the county level.
 
 ## Simulation Notes
-We sample 5,000 districting plans for West Virginia.
+We sample 5,000 districting plans for West Virginia, across 4 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.

--- a/analyses/WV_cd_2020/doc_WV_cd_2020.md
+++ b/analyses/WV_cd_2020/doc_WV_cd_2020.md
@@ -20,5 +20,5 @@ Data for West Virginia comes from the [The Upshot Presidential Precinct Map data
 Data is aggregated to the county level.
 
 ## Simulation Notes
-We sample 5,000 districting plans for West Virginia, across 4 independent runs of the SMC algorithm.
+We sample 5,000 districting plans for West Virginia across 4 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
[In West Virginia, under the state constitution, districts must](http://www.wvlegislature.gov/WVCODE/WV_CON.cfm):

1. be contiguous (I 1-4)
1. have equal populations (I 1-4)
1. be geographically compact (I 1-4)
1. districts must be made of contiguous counties (I 1-4)


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We simulate at the county level.

## Data Sources
Data for West Virginia comes from the [The Upshot Presidential Precinct Map data](https://github.com/TheUpshot/presidential-precinct-map-2020) and are joined with county level Census data.

## Pre-processing Notes
Data is aggregated to the county level.

## Simulation Notes
We sample 5,000 districting plans for West Virginia, across 4 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

![validation_20220621_2356](https://user-images.githubusercontent.com/28026893/174940449-269bb68a-632b-4889-8703-c1d110dd33da.png)

```
SMC: 5,000 sampled plans of 2 districts on 55 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.097 to 0.434
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
     1.0020773      0.9998947      0.9999536      1.0003087      1.0007092      1.0002150      1.0005952      1.0005577      1.0014897      1.0006485 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
     1.0001644      1.0010625      1.0022005      1.0001193      1.0005887      1.0000335      1.0006007      1.0005678      1.0001469      1.0008277 
       vap_two pre_20_rep_tru pre_20_dem_bid         adv_20         arv_20            ndv            nrv        ndshare          e_dvs           egap 
     1.0016263      1.0009999      1.0011749      1.0011749      1.0009999      1.0011749      1.0009999      1.0006942      1.0006942      1.0014646 

Sampling diagnostics for SMC run 1 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,239 (99.1%)      2.8%         0.2   784 ( 99%)      4 
Resample    1,211 (96.8%)       NA%         0.2   778 ( 98%)     NA 

Sampling diagnostics for SMC run 2 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,239 (99.1%)      2.7%         0.2   783 ( 99%)      4 
Resample    1,209 (96.8%)       NA%         0.2   777 ( 98%)     NA 

Sampling diagnostics for SMC run 3 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,239 (99.1%)      2.7%         0.2   770 ( 97%)      4 
Resample    1,211 (96.9%)       NA%         0.2   783 ( 99%)     NA 

Sampling diagnostics for SMC run 4 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,239 (99.1%)      2.9%         0.2   806 (102%)      4 
Resample    1,209 (96.7%)       NA%         0.2   789 (100%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with `hist(plans_diversity(plans),
breaks=24)`. Consider weakening or removing constraints, or increasing the population tolerance. If the accpetance rate drops quickly in the final splits,
try increasing `pop_temper` by 0.01.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes:
Appears to me that the diversity is actually fine. This is a 55 county into 2 districts problem.