### PR TITLE
Re-run 2020 Idaho Congressional Districts

### DIFF
--- a/analyses/ID_cd_2020/01_prep_ID_cd_2020.R
+++ b/analyses/ID_cd_2020/01_prep_ID_cd_2020.R
@@ -50,7 +50,7 @@ if (!file.exists(here(shp_path))) {
     id_shp$cd_2020 <- as.integer(dists$Districts)[geo_match(from = id_shp, to = dists, method = "area")]
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = id_shp,
+    redistmetrics::prep_perims(shp = id_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 
@@ -70,7 +70,7 @@ if (!file.exists(here(shp_path))) {
 
     cty_adj <- adjacency(cty) %>% lapply(\(x) x + 1)
 
-    cty_pair <- map_dfr(seq_along(cty_adj), \(x){
+    cty_pair <- purrr::map_dfr(seq_along(cty_adj), \(x){
         tibble(x = x, y = cty_adj[[x]])
     })
 
@@ -79,9 +79,9 @@ if (!file.exists(here(shp_path))) {
         geos::as_geos_geometry()
 
     ints <- geos::geos_intersects_matrix(geom = roads, tree = cty)
-    tbl <- map_dfr(ints, \(x){
+    tbl <- purrr::map_dfr(ints, \(x){
         if (length(x) > 1) {
-            expand_grid(x = x, y = x) %>% filter(
+            tidyr::expand_grid(x = x, y = x) %>% filter(
                 x != y
             )
         } else {
@@ -91,7 +91,7 @@ if (!file.exists(here(shp_path))) {
         mutate(magic = TRUE)
 
     cty_pair <- cty_pair %>%
-        left_join(tbl) %>%
+        left_join(tbl, by = c("x", "y")) %>%
         filter(is.na(magic))
 
     cty_pair <- cty_pair %>%

--- a/analyses/ID_cd_2020/03_sim_ID_cd_2020.R
+++ b/analyses/ID_cd_2020/03_sim_ID_cd_2020.R
@@ -6,7 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg ID_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 2500, runs = 2L, ncores = 8, counties = county)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/ID_cd_2020/03_sim_ID_cd_2020.R
+++ b/analyses/ID_cd_2020/03_sim_ID_cd_2020.R
@@ -8,7 +8,7 @@ cli_process_start("Running simulations for {.pkg ID_cd_2020}")
 
 set.seed(2020)
 
-plans <- redist_smc(map, nsims = 2500, runs = 2L, ncores = 8, counties = county)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
 
 plans <- match_numbers(plans, "cd_2020")
 

--- a/analyses/ID_cd_2020/doc_ID_cd_2020.md
+++ b/analyses/ID_cd_2020/doc_ID_cd_2020.md
@@ -21,6 +21,6 @@ Data for Idaho comes from the ALARM Project's [2020 Redistricting Data Files](ht
 Borders between counties which are not connected by highways were removed.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
+We sample 5,000 districting plans for Idaho across 2 independent runs of the SMC algorithm.
 We sample using the standard algorithmic county constraint.
 No special techniques were needed to produce the sample.

--- a/analyses/ID_cd_2020/doc_ID_cd_2020.md
+++ b/analyses/ID_cd_2020/doc_ID_cd_2020.md
@@ -21,6 +21,6 @@ Data for Idaho comes from the ALARM Project's [2020 Redistricting Data Files](ht
 Borders between counties which are not connected by highways were removed.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Idaho.
+We sample 5,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
 We sample using the standard algorithmic county constraint.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
[In Idaho, districts must](https://legislature.idaho.gov/statutesrules/idstat/Title72/T72CH15/SECT72-1506/):

1. be contiguous (72-1506(6)).
1. have equal populations (72-1506(3)).
1. be geographically compact (72-1506(4), 72-1506(5)).
1. preserve county and municipality boundaries as much as possible (72-1506(2)).
1. not be drawn to favor party or incumbents (72-1506(8)).
1. connect counties based on highways (72-1506(9)).


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Idaho comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Borders between counties which are not connected by highways were removed.

## Simulation Notes
We sample 5,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
We sample using the standard algorithmic county constraint.
No special techniques were needed to produce the sample.

## Validation

![validation_20220622_0012](https://user-images.githubusercontent.com/28026893/174941827-ef1396f5-66fd-4cb9-be65-e41fd73f3e21.png)

```
SMC: 5,000 sampled plans of 2 districts on 931 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.081 to 0.689

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
     1.0002363      1.0004242      0.9999541      1.0000043      0.9999779      1.0005757 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0006040      1.0003794      1.0016616      1.0010224      1.0007242      0.9998282 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0003301      1.0004728      1.0003179      1.0003911      1.0008968      1.0010054 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_cra 
     1.0010067      0.9998171      1.0007871      1.0000033      1.0012958      1.0001750 
uss_16_dem_stu gov_18_rep_lit gov_18_dem_jor atg_18_rep_was atg_18_dem_bis sos_18_rep_den 
     1.0009342      1.0002236      1.0012880      1.0000707      1.0011649      0.9999729 
sos_18_dem_hum pre_20_rep_tru pre_20_dem_bid uss_20_rep_ris uss_20_dem_jor         arv_16 
     1.0012842      0.9999582      1.0012993      1.0001819      1.0012768      0.9999313 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
     1.0010860      1.0001590      1.0012893      1.0000273      1.0012670      0.9998131 
   muni_splits            ndv            nrv        ndshare          e_dvs           egap 
     1.0002937      1.0013479      1.0000786      1.0005925      1.0007021      1.0001430 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,433 (97.3%)      3.8%        0.34 1,591 (101%)      6 
Resample    2,266 (90.7%)       NA%        0.34 1,534 ( 97%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,432 (97.3%)      4.0%        0.34 1,593 (101%)      6 
Resample    2,267 (90.7%)       NA%        0.34 1,532 ( 97%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std.
devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values
for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

![image](https://user-images.githubusercontent.com/28026893/174941848-4f5660d6-ba5b-4b60-94f4-8e1631c9192c.png)
