### PR TITLE
Re-run 2020 Nevada Congressional Districts

### DIFF
--- a/analyses/NV_cd_2020/01_prep_NV_cd_2020.R
+++ b/analyses/NV_cd_2020/01_prep_NV_cd_2020.R
@@ -55,11 +55,10 @@ if (!file.exists(here(shp_path))) {
 
     # Add enacted ----
     dists <- read_sf(path_shp)
-    nv_shp$cd_2020 <- as.numeric(dists$DISTRICT)[geo_match(from = nv_shp, to = dists, method = "area")]
-
+    nv_shp$cd_2020 <- as.integer(dists$DISTRICT)[geo_match(from = nv_shp, to = dists, method = "area")]
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = nv_shp,
+    redistmetrics::prep_perims(shp = nv_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/NV_cd_2020/03_sim_NV_cd_2020.R
+++ b/analyses/NV_cd_2020/03_sim_NV_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NV_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L, ncores = 8,
+    counties = county
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/NV_cd_2020/03_sim_NV_cd_2020.R
+++ b/analyses/NV_cd_2020/03_sim_NV_cd_2020.R
@@ -10,7 +10,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2500, runs = 2L, ncores = 8,
+    nsims = 2500, runs = 2L,
     counties = county
 )
 

--- a/analyses/NV_cd_2020/doc_NV_cd_2020.md
+++ b/analyses/NV_cd_2020/doc_NV_cd_2020.md
@@ -20,5 +20,5 @@ Data for Nevada comes from the ALARM Project's [2020 Redistricting Data Files](h
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Nevada.
+We sample 5,000 districting plans for Nevada across 2 independent runs of the SMC algorithm.
 We use a standard algorithmic county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Nevada, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. preserve communities of interest.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use a county constraint to avoid splitting counties, municipalities, and potential COIs.

## Data Sources
Data for Nevada comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Nevada across 2 independent runs of the SMC algorithm.
We use a standard algorithmic county constraint.

## Validation

![validation_20220622_0044](https://user-images.githubusercontent.com/28026893/174945562-c9910cf8-b867-44fb-b388-73e869a7d97b.png)

```
SMC: 5,000 sampled plans of 4 districts on 2,102 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.56 to 0.75

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0033881      1.0034257      1.0007654      1.0002019      0.9998652      1.0086061      1.0051772      1.0033299      1.0018295 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0025396      0.9998896      1.0025051      1.0028161      1.0074502      1.0063387      1.0037852      1.0010966      1.0024125 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_cor uss_16_rep_hec uss_18_dem_ros uss_18_rep_hel 
     0.9998588      1.0068736      1.0031759      1.0005813      1.0028598      1.0004076      1.0039857      1.0022196      1.0024608 
gov_18_dem_sis gov_18_rep_lax atg_18_dem_for atg_18_rep_dun sos_18_dem_ara sos_18_rep_ceg pre_20_dem_bid pre_20_rep_tru         arv_16 
     1.0023836      1.0025960      1.0014728      1.0024478      1.0011395      1.0027894      1.0017449      1.0044291      1.0033986 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv 
     1.0004660      1.0025878      1.0018907      1.0044291      1.0017449      1.0017096      1.0029806      1.0018867      1.0030886 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
     1.0028311      1.0027289      1.0013073      1.0017539      0.9998246      1.0011933 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,215 (88.6%)     19.7%        0.93 1,583 (100%)     10 
Split 2     2,287 (91.5%)     12.8%        0.51 1,565 ( 99%)      6 
Split 3     2,242 (89.7%)      5.9%        0.56 1,441 ( 91%)      4 
Resample    1,352 (54.1%)       NA%        0.57 1,409 ( 89%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,228 (89.1%)     15.1%        0.91 1,584 (100%)     13 
Split 2     2,285 (91.4%)      9.7%        0.52 1,574 (100%)      8 
Split 3     2,236 (89.4%)      5.0%        0.58 1,444 ( 91%)      5 
Resample    1,471 (58.8%)       NA%        0.59 1,399 ( 89%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so),
and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
