### PR TITLE
Re-run 2020 Oklahoma Congressional Districts

### DIFF
--- a/analyses/OK_cd_2020/01_prep_OK_cd_2020.R
+++ b/analyses/OK_cd_2020/01_prep_OK_cd_2020.R
@@ -20,11 +20,10 @@ cli_process_start("Downloading files for {.pkg OK_cd_2020}")
 path_data <- download_redistricting_file("OK", "data-raw/OK")
 
 # https://oksenate.gov/redistricting
-path_enacted <- here("data-raw", "OK", "Congress Final 102621.shp")
+path_enacted <- here("data-raw", "OK", "ok.geojson")
 if (!file.exists(path_enacted)) {
-    url <- "https://oksenategov-my.sharepoint.com/personal/website_oksenate_gov/_layouts/15/download.aspx?UniqueId=1860110b%2D0561%2D4a92%2D8a9b%2Db2bebf6767f6"
-    download(url, paste0(dirname(path_enacted), "/ok.zip"))
-    unzip(paste0(dirname(path_enacted), "/ok.zip"), exdir = dirname(path_enacted))
+    url <- "https://redistricting.lls.edu/wp-content/uploads/ok_2020_congress_2021-11-22_2031-06-30.json"
+    download(url, path_enacted)
 }
 
 cli_process_done()
@@ -54,14 +53,13 @@ if (!file.exists(here(shp_path))) {
         relocate(muni, county_muni, cd_2010, .after = county)
 
     dists <- read_sf(path_enacted)
-    ok_shp$cd_2020 <- as.integer(dists$DISTRICT)[geo_match(from = ok_shp, to = dists, method = "area")]
-
+    ok_shp$cd_2020 <- as.integer(dists$District)[geo_match(from = ok_shp, to = dists, method = "area")]
 
     ok_shp <- ok_shp %>%
         mutate(across(contains(c("_16", "_18", "_20", "nrv", "ndv")), tidyr::replace_na, 0))
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = ok_shp,
+    redistmetrics::prep_perims(shp = ok_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/OK_cd_2020/03_sim_OK_cd_2020.R
+++ b/analyses/OK_cd_2020/03_sim_OK_cd_2020.R
@@ -10,7 +10,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2500, runs = 2L, ncores = 8,
+    nsims = 2500, runs = 2L,
     counties = pseudo_county
 )
 

--- a/analyses/OK_cd_2020/03_sim_OK_cd_2020.R
+++ b/analyses/OK_cd_2020/03_sim_OK_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OK_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L, ncores = 8,
+    counties = pseudo_county
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/OK_cd_2020/doc_OK_cd_2020.md
+++ b/analyses/OK_cd_2020/doc_OK_cd_2020.md
@@ -19,6 +19,6 @@ Data for Oklahoma comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Oklahoma.
+We sample 5,000 districting plans for Oklahoma across 2 independent runs of the SMC algorithm.
 We use a pseudo county constraint which uses counties, except for Oklahoma County which uses municipalities.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
[In Oklahoma, districts must](https://oksenate.gov/sites/default/files/inline-files/Senate%20Redistricting%20Guidelines.pdf):

1. be contiguous (C)
1. have equal populations (A.2)
1. be geographically compact (C)
1. preserve county and municipality boundaries as much as possible (C)

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.

## Data Sources
Data for Oklahoma comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Oklahoma across 2 independent runs of the SMC algorithm.
We use a pseudo county constraint which uses counties, except for Oklahoma County which uses municipalities.
No special techniques were needed to produce the sample.

## Validation

![validation_20220622_0105](https://user-images.githubusercontent.com/28026893/174947863-029d8a6d-6300-4685-a846-e83abda538ea.png)

```
SMC: 5,000 sampled plans of 5 districts on 1,947 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.59 to 0.91

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0026971      1.0016413      0.9999266      1.0000279      1.0025800      1.0012320      1.0037122      1.0072595      1.0007859 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0035005      1.0008942      1.0004423      1.0002995      1.0010506      1.0035990      1.0075433      1.0005558      1.0023831 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_lan uss_16_dem_wor gov_18_rep_sti gov_18_dem_edm 
     1.0010786      1.0000068      1.0000888      1.0005939      1.0011868      1.0010260      1.0034591      1.0007339      1.0004562 
atg_18_rep_hun atg_18_dem_myl pre_20_rep_tru pre_20_dem_bid uss_20_rep_inh uss_20_dem_bro         arv_16         adv_16         arv_18 
     1.0011417      1.0017219      1.0005910      1.0010144      1.0006824      1.0019222      1.0009923      1.0021257      1.0009233 
        adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0009864      1.0006110      1.0012889      1.0013199      1.0016048      1.0011041      1.0008314      1.0022144      1.0021898 
         e_dem          pbias           egap 
     0.9999422      1.0005190      1.0017663 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,454 (98.2%)     11.8%        0.27 1,588 (100%)      7 
Split 2     2,416 (96.6%)     15.6%        0.38 1,559 ( 99%)      5 
Split 3     2,386 (95.4%)     22.4%        0.42 1,524 ( 96%)      3 
Split 4     2,352 (94.1%)     10.0%        0.47 1,368 ( 87%)      2 
Resample    1,871 (74.8%)       NA%        0.46 1,470 ( 93%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,454 (98.2%)      8.4%        0.27 1,567 ( 99%)     10 
Split 2     2,413 (96.5%)     13.4%        0.38 1,566 ( 99%)      6 
Split 3     2,335 (93.4%)     14.5%        0.49 1,517 ( 96%)      5 
Split 4     2,304 (92.2%)      7.6%        0.51 1,400 ( 89%)      3 
Resample    1,637 (65.5%)       NA%        0.50 1,444 ( 91%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
