### PR TITLE
Re-run 2020 Indiana Congressional Districts

### DIFF
--- a/analyses/IN_cd_2020/01_prep_IN_cd_2020.R
+++ b/analyses/IN_cd_2020/01_prep_IN_cd_2020.R
@@ -51,7 +51,7 @@ if (!file.exists(here(shp_path))) {
     in_shp$cd_2020 <- geo_match(in_shp, dists, "area")
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = in_shp,
+    redistmetrics::prep_perims(shp = in_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/IN_cd_2020/03_sim_IN_cd_2020.R
+++ b/analyses/IN_cd_2020/03_sim_IN_cd_2020.R
@@ -10,7 +10,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2500, runs = 2L, ncores = 8,
+    nsims = 2500, runs = 2L,
     counties = county
 )
 

--- a/analyses/IN_cd_2020/03_sim_IN_cd_2020.R
+++ b/analyses/IN_cd_2020/03_sim_IN_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg IN_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L, ncores = 8,
+    counties = county
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/IN_cd_2020/doc_IN_cd_2020.md
+++ b/analyses/IN_cd_2020/doc_IN_cd_2020.md
@@ -16,6 +16,6 @@ Data for Indiana comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Indiana.
+We sample 5,000 districting plans for Indiana across 2 independent runs of the SMC algorithm.
 We use counties, despite the lack of requirements, as the enacted does generally follow county lines.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Indiana, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Indiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Indiana across 2 independent runs of the SMC algorithm.
We use counties, despite the lack of requirements, as the enacted does generally follow county lines.
No special techniques were needed to produce the sample.


## Validation

![validation_20220622_0115](https://user-images.githubusercontent.com/28026893/174949160-80ed4c60-ce09-44f8-bcff-1e88c0471c91.png)

```
SMC: 5,000 sampled plans of 9 districts on 5,159 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.64 to 0.86

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0092793      1.0323612      1.0000043      1.0003440      1.0054812      1.0012991      1.0006963      1.0050058      1.0056302 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0114776      1.0063665      1.0076053      1.0124063      1.0034417      1.0002915      1.0047207      1.0025630      1.0118422 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_you uss_16_dem_bay gov_16_rep_hol gov_16_dem_gre 
     1.0026808      1.0070690      1.0049545      1.0004291      1.0085702      1.0005199      1.0061758      0.9999680      1.0057137 
atg_16_rep_hil atg_16_dem_arr uss_18_rep_bra uss_18_dem_don sos_18_rep_law sos_18_dem_har pre_20_rep_tru pre_20_dem_bid gov_20_rep_hol 
     1.0000845      1.0089867      1.0002180      1.0041050      0.9999506      1.0066918      1.0005494      1.0111095      1.0002200 
gov_20_dem_mye atg_20_rep_rok atg_20_dem_wei         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20 
     1.0081926      0.9998263      1.0105452      0.9998311      1.0077229      0.9998739      1.0052246      0.9998315      1.0105658 
 county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
     0.9998692      1.0128082      1.0078009      0.9998162      1.0003779      1.0004112      1.0027921      1.0006306      1.0046171 
          egap 
     1.0019987 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,392 (95.7%)     15.4%        0.44 1,564 ( 99%)     11 
Split 2     2,357 (94.3%)     19.9%        0.50 1,538 ( 97%)      8 
Split 3     2,309 (92.4%)     26.7%        0.58 1,567 ( 99%)      5 
Split 4     2,266 (90.6%)     20.9%        0.60 1,522 ( 96%)      6 
Split 5     2,239 (89.6%)     25.7%        0.61 1,533 ( 97%)      4 
Split 6     2,259 (90.4%)     26.2%        0.59 1,535 ( 97%)      3 
Split 7     2,232 (89.3%)     26.2%        0.63 1,453 ( 92%)      2 
Split 8     2,251 (90.0%)      5.6%        0.63 1,320 ( 84%)      4 
Resample    1,659 (66.4%)       NA%        0.63 1,394 ( 88%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,393 (95.7%)     17.0%        0.44 1,588 (100%)     10 
Split 2     2,356 (94.2%)     21.5%        0.50 1,563 ( 99%)      7 
Split 3     2,283 (91.3%)     23.4%        0.61 1,531 ( 97%)      6 
Split 4     2,240 (89.6%)     24.2%        0.64 1,533 ( 97%)      5 
Split 5     2,236 (89.4%)     25.7%        0.60 1,522 ( 96%)      4 
Split 6     2,261 (90.5%)     18.6%        0.59 1,525 ( 97%)      5 
Split 7     2,257 (90.3%)     17.4%        0.59 1,473 ( 93%)      4 
Split 8     2,251 (90.0%)      4.6%        0.62 1,336 ( 85%)      5 
Resample    1,633 (65.3%)       NA%        0.63 1,404 ( 89%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
