### PR TITLE
Re-run 2020 Colorado Congressional Districts

### DIFF
--- a/analyses/CO_cd_2020/01_prep_CO_cd_2020.R
+++ b/analyses/CO_cd_2020/01_prep_CO_cd_2020.R
@@ -73,7 +73,7 @@ if (!file.exists(here(shp_path))) {
     co_shp <- co_shp %>% left_join(baf, by = "GEOID")
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = co_shp,
+    redistmetrics::prep_perims(shp = co_shp,
         perim_path = here(perim_path),
         ncores = 8)
 

--- a/analyses/CO_cd_2020/03_sim_CO_cd_2020.R
+++ b/analyses/CO_cd_2020/03_sim_CO_cd_2020.R
@@ -14,7 +14,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2500, runs = 2L, ncores = 8,
+    nsims = 2500, runs = 2L,
     counties = pseudo_county,
     constraints = cons
 )
@@ -47,16 +47,16 @@ if (interactive()) {
     set.seed(2022)
     plans2 <- redist_smc(
         map,
-        nsims = 2500, runs = 2L, ncores = 8,
+        nsims = 2500, runs = 2L,
         counties = pseudo_county
     )
     plans2 <- plans2 %>% mutate(dvs_20 = group_frac(map, adv_20, adv_20 + arv_20))
 
     redist.plot.distr_qtys(plans2, qty = dvs_20, geom = "boxplot") + theme_bw() +
-        lims(y = c(0.25, 0.8)) +
+        lims(y = c(0.25, 0.9)) +
         labs(title = "No Competitive Constraint") +
         redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") +
         theme_bw() +
-        lims(y = c(0.25, 0.8)) +
+        lims(y = c(0.25, 0.9)) +
         labs(title = "With Competitive Constraint")
 }

--- a/analyses/CO_cd_2020/03_sim_CO_cd_2020.R
+++ b/analyses/CO_cd_2020/03_sim_CO_cd_2020.R
@@ -8,13 +8,18 @@ cli_process_start("Running simulations for {.pkg CO_cd_2020}")
 
 # Set up competitiveness targets ----
 cons <- redist_constr(map) %>%
-    add_constr_compet(300, ndv, nrv, pow = 1)
+    add_constr_compet(30, ndv, nrv, pow = 1)
 
-plans <- redist_smc(map, nsims = 5e3,
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L, ncores = 8,
     counties = pseudo_county,
-    constraints = cons)
-plans2 <- redist_smc(map, nsims = 5e3,
-    counties = pseudo_county)
+    constraints = cons
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -38,16 +43,20 @@ if (interactive()) {
     library(patchwork)
 
     plans <- plans %>% mutate(dvs_20 = group_frac(map, adv_20, adv_20 + arv_20))
-    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") +
-        theme_bw() +
-        lims(y = c(0, 1)) +
-        labs(title = "With Competitive Constraint")
-    ggsave("data-raw/CO/competitiveness_plans.png", width = 6.5, height = 3)
+
+    set.seed(2022)
+    plans2 <- redist_smc(
+        map,
+        nsims = 2500, runs = 2L, ncores = 8,
+        counties = pseudo_county
+    )
     plans2 <- plans2 %>% mutate(dvs_20 = group_frac(map, adv_20, adv_20 + arv_20))
+
     redist.plot.distr_qtys(plans2, qty = dvs_20, geom = "boxplot") + theme_bw() +
-        lims(y = c(0, 1)) +
-        labs(title = "No Competitive Constraint")
-    ggsave("data-raw/CO/competitiveness_plans_no_const.png", width = 6.5, height = 3)
-
-
+        lims(y = c(0.25, 0.8)) +
+        labs(title = "No Competitive Constraint") +
+        redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") +
+        theme_bw() +
+        lims(y = c(0.25, 0.8)) +
+        labs(title = "With Competitive Constraint")
 }

--- a/analyses/CO_cd_2020/doc_CO_cd_2020.md
+++ b/analyses/CO_cd_2020/doc_CO_cd_2020.md
@@ -22,5 +22,5 @@ Data for Colorado comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Colorado.
+We sample 5,000 districting plans for Colorado across 2 independent runs of the SMC algorithm.
 A partisan competitiveness constraint was used.


### PR DESCRIPTION
## Redistricting requirements
In Colorado, districts must:

1. be contiguous
1. have equal populations -- Section 44.3 1(a)
1. be geographically compact  -- Section 44.3 2(b)
1. preserve county and municipality boundaries as much as possible -- Section 44.3 2(a)
1. preserve whole communities of interest -- Section 44.3 2(a)
1. maximize the number of politically competitive districts -- Section 44.3 3(a)
1. not be drawn protect incumbents


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Colorado comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Colorado across 2 independent runs of the SMC algorithm.
A partisan competitiveness constraint was used.


## Validation

![validation_20220622_0133](https://user-images.githubusercontent.com/28026893/174951618-95bd5111-832c-4e44-8856-adbdc5c88420.png)

```
SMC: 5,000 sampled plans of 8 districts on 3,108 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.46 to 0.76

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
      1.033023       1.012775       1.003907       1.006380       1.013037       1.009250 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
      1.016050       1.015970       1.014766       1.013059       1.024864       1.006674 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
      1.007744       1.011416       1.016515       1.015863       1.016873       1.010805 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_ben 
      1.027309       1.005074       1.007367       1.006796       1.013571       1.006939 
uss_16_rep_gle gov_18_dem_pol gov_18_rep_sta atg_18_dem_wei atg_18_rep_bra sos_18_dem_gri 
      1.014184       1.007110       1.013171       1.006367       1.013952       1.006508 
sos_18_rep_wil pre_20_dem_bid pre_20_rep_tru uss_20_dem_hic uss_20_rep_gar         arv_16 
      1.014136       1.006460       1.013171       1.005776       1.013983       1.013733 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
      1.007289       1.014109       1.006836       1.013468       1.005985       1.003699 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
      1.000444       1.006130       1.013439       1.010806       1.010808       0.999802 
         e_dem          pbias           egap 
      1.005082       1.004414       1.005532 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,790 (71.6%)     19.2%        0.51 1,582 (100%)      9 
Split 2     1,790 (71.6%)     25.5%        0.63 1,330 ( 84%)      6 
Split 3     1,783 (71.3%)     30.5%        0.67 1,327 ( 84%)      4 
Split 4     1,821 (72.8%)     33.2%        0.68 1,288 ( 82%)      3 
Split 5     1,837 (73.5%)     37.4%        0.69 1,321 ( 84%)      2 
Split 6     1,891 (75.7%)     27.3%        0.68 1,279 ( 81%)      2 
Split 7     1,780 (71.2%)      5.6%        0.68 1,200 ( 76%)      4 
Resample      906 (36.2%)       NA%        1.20 1,107 ( 70%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,821 (72.9%)     12.4%        0.51 1,634 (103%)     14 
Split 2     1,776 (71.0%)     19.6%        0.64 1,346 ( 85%)      8 
Split 3     1,753 (70.1%)     25.4%        0.68 1,322 ( 84%)      5 
Split 4     1,818 (72.7%)     25.7%        0.72 1,318 ( 83%)      4 
Split 5     1,850 (74.0%)     22.7%        0.67 1,322 ( 84%)      4 
Split 6     1,675 (67.0%)     17.7%        0.72 1,268 ( 80%)      4 
Split 7     1,790 (71.6%)      5.7%        0.74 1,162 ( 74%)      4 
Resample      961 (38.5%)       NA%        1.21 1,149 ( 73%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large
std. devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat
values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan

## Notes
Competitiveness constraint comparison
![image](https://user-images.githubusercontent.com/28026893/174951723-f0e5b156-7b56-4ed7-a5a6-ec5578d9fc9b.png)

