### PR TITLE
Re-run 2020 Hawaii Congressional Districts

### DIFF
--- a/analyses/HI_cd_2020/01_prep_HI_cd_2020.R
+++ b/analyses/HI_cd_2020/01_prep_HI_cd_2020.R
@@ -70,7 +70,7 @@ if (!file.exists(here(shp_path))) {
         )
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = hi_shp,
+    redistmetrics::prep_perims(shp = hi_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
+++ b/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
@@ -6,8 +6,14 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg HI_cd_2020}")
 
-plans_honolulu <- redist_smc(map_honolulu, nsims = 5e3, n_steps = 1,
-    counties = coalesce(muni, county))
+set.seed(2020)
+
+plans_honolulu <- redist_smc(
+    map_honolulu,
+    nsims = 2500, runs = 2L,
+    n_steps = 1,
+    counties = coalesce(muni, county)
+)
 
 plans <- matrix(data = 0, nrow = nrow(map), ncol = 5001)
 plans[map$tract %in% map_honolulu$tract, ] <- get_plans_matrix(plans_honolulu)
@@ -24,7 +30,9 @@ cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 plans <- plans %>%
-    add_reference(ref_plan = map$cd_2020, "cd_2020")
+    add_reference(ref_plan = map$cd_2020, "cd_2020") %>%
+    mutate(chain = c(NA_integer_, NA_integer_, rep(1L, 5000), rep(2L, 5000)),
+        .after = draw)
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/HI_2020/HI_cd_2020_plans.rds"), compress = "xz")

--- a/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
+++ b/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
@@ -23,16 +23,17 @@ plans <- redist_plans(
     plans = plans[, -1],
     algorithm = "smc",
     map = map,
-    wgt = get_plans_weights(plans_honolulu)[-1]
+    wgt = get_plans_weights(plans_honolulu)[-1],
+    diagnostics = attr(plans, "diagnostics")
 )
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 plans <- plans %>%
-    add_reference(ref_plan = map$cd_2020, "cd_2020") %>%
-    mutate(chain = c(NA_integer_, NA_integer_, rep(1L, 5000), rep(2L, 5000)),
-        .after = draw)
+    mutate(chain = rep(1:2, each = 5000), .after = draw) %>%
+    add_reference(ref_plan = map$cd_2020, "cd_2020")
+
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/HI_2020/HI_cd_2020_plans.rds"), compress = "xz")

--- a/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
+++ b/analyses/HI_cd_2020/03_sim_HI_cd_2020.R
@@ -24,7 +24,7 @@ plans <- redist_plans(
     algorithm = "smc",
     map = map,
     wgt = get_plans_weights(plans_honolulu)[-1],
-    diagnostics = attr(plans, "diagnostics")
+    diagnostics = attr(plans_honolulu, "diagnostics")
 )
 
 cli_process_done()
@@ -33,7 +33,6 @@ cli_process_start("Saving {.cls redist_plans} object")
 plans <- plans %>%
     mutate(chain = rep(1:2, each = 5000), .after = draw) %>%
     add_reference(ref_plan = map$cd_2020, "cd_2020")
-
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/HI_2020/HI_cd_2020_plans.rds"), compress = "xz")

--- a/analyses/HI_cd_2020/doc_HI_cd_2020.md
+++ b/analyses/HI_cd_2020/doc_HI_cd_2020.md
@@ -22,7 +22,6 @@ Data for Hawaii comes from the ALARM Project's [2020 Redistricting Data Files](h
 Islands are connecting in the adjacency graph, but this is not used for simulation purposes.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Hawaii.
+We sample 5,000 districting plans for Hawaii across 2 independent runs of the SMC algorithm.
 We use partial SMC to draw one district in the contiguous portion of Honolulu and assign the remainder to district 2.
 We use municipalities (or the county name if a tract is not assigned to a municipality) for the algorithmic constraint.
-


### PR DESCRIPTION
## Redistricting requirements
In Hawaii, under [HRS Title 1 S25](https://www.capitol.hawaii.gov/hrscurrent/Vol01_Ch0001-0042F/HRS0025/HRS_0025-0002.htm), districts must:

1. be contiguous unless crossing islands (25-2 (b) (2))
1. be geographically compact (25-2(b)(3))
1. preserve tract boundaries as much as possible (25-2(b)(4))
1. not unduly favor any people or party (25-2(b)(6))
1. avoid mixing substantially different socioeconomic regions (25-2(b)(6))


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use Census tracts are in accordance with (25-2(b)(4)).
We use municipalities to attempt to follow (25-2(b)(6)) in absence of regional knowledge.

## Data Sources
Data for Hawaii comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Islands are connecting in the adjacency graph, but this is not used for simulation purposes.

## Simulation Notes
We sample 5,000 districting plans for Hawaii across 2 independent runs of the SMC algorithm.
We use partial SMC to draw one district in the contiguous portion of Honolulu and assign the remainder to district 2.
We use municipalities (or the county name if a tract is not assigned to a municipality) for the algorithmic constraint.


## Validation

![validation_20220622_0148](https://user-images.githubusercontent.com/28026893/174953028-b6fa62fd-0f12-4e20-9e43-8a322f91590f.png)

```
SMC: 5,000 sampled plans of 2 districts on 461 units
`adapt_k_thresh`=NULL • `seq_alpha`=NULL
`est_label_mult`=NULL • `pop_temper`=NULL

Plan diversity 80% range: 0.22 to 0.67

R-hat values for summary statistics:
     total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
     1.0008174      1.0004894      0.9999982      1.0000380      1.0004853      1.0001852 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two 
     0.9999709      1.0001105      1.0000817      0.9998751      0.9998873      0.9999483 
      vap_hisp      vap_white      vap_black       vap_aian      vap_asian       vap_nhpi 
     1.0003370      1.0001420      0.9999537      1.0007178      1.0000410      0.9998735 
     vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_sch uss_16_rep_car 
     0.9999685      0.9999112      0.9998145      0.9998550      0.9998144      0.9998300 
uss_18_dem_hir uss_18_rep_cur gov_18_dem_ige gov_18_rep_tup pre_20_dem_bid pre_20_rep_tru 
     0.9998430      0.9999376      0.9998176      0.9999903      0.9998383      0.9998275 
        arv_16         adv_16         arv_18         adv_18         arv_20         adv_20 
     0.9998025      0.9998176      0.9999064      0.9998311      0.9998275      0.9998383 
   muni_splits            ndv            nrv        ndshare          e_dvs           egap 
     1.0000324      0.9998241      0.9998728      0.9998870      0.9998660      1.0000560 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large
std. devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat
values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

Note: Chain has to be assigned manually in `03_*.R` to use `summary(plans)`.