### PR TITLE
Re-run 2020 Massachusetts Congressional Districts

### DIFF
--- a/analyses/MA_cd_2020/01_prep_MA_cd_2020.R
+++ b/analyses/MA_cd_2020/01_prep_MA_cd_2020.R
@@ -47,10 +47,10 @@ if (!file.exists(here(shp_path))) {
 
     dists <- read_sf("https://redistricting.lls.edu/wp-content/uploads/ma_2020_congress_2021-11-05_2031-06-30.json")
 
-    ma_shp$cd_2020 <- as.numeric(dists$Districts)[geo_match(from = ma_shp, to = dists, method = "area")]
+    ma_shp$cd_2020 <- as.integer(dists$Districts)[geo_match(from = ma_shp, to = dists, method = "area")]
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = ma_shp,
+    redistmetrics::prep_perims(shp = ma_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/MA_cd_2020/03_sim_MA_cd_2020.R
+++ b/analyses/MA_cd_2020/03_sim_MA_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MA_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 5e3, runs = 2L, ncores = 8,
+    counties = pseudo_county
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/MA_cd_2020/doc_MA_cd_2020.md
+++ b/analyses/MA_cd_2020/doc_MA_cd_2020.md
@@ -17,5 +17,5 @@ Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data F
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Massachusetts.
+We sample 5,000 districting plans for Massachusetts across 2 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Massachusetts, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use the basic algorithmic county constraint applied to pseudo counties, as Congressional plans in MA do seem to follow county and municipal boundaries, despite no legal constraint. Pseudo counties are constructed by following municipal boundaries in counties larger than a district and county lines.

## Data Sources
Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Massachusetts across 2 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.


## Validation

![validation_20220622_0952](https://user-images.githubusercontent.com/28026893/175046288-ad21f818-40e9-4408-8585-611ab2cad976.png)

```
SMC: 10,000 sampled plans of 9 districts on 2,157 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.49 to 0.75

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
     1.0006960      1.0056515      1.0004752      1.0039616      1.0057621      1.0034926 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0010145      1.0017278      1.0010656      1.0024345      1.0000224      1.0018703 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0006901      1.0019529      0.9999446      1.0020708      1.0056750      1.0048278 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_18_dem_war 
     0.9999428      1.0026649      1.0008895      1.0035719      1.0058227      1.0034154 
uss_18_rep_die gov_18_rep_bak gov_18_dem_gon atg_18_dem_hea atg_18_rep_mcm pre_20_dem_bid 
     1.0060147      1.0050047      1.0032193      1.0031547      1.0059372      1.0041882 
pre_20_rep_tru uss_20_dem_mar uss_20_rep_oco         arv_16         adv_16         arv_18 
     1.0052188      1.0038477      1.0049033      1.0058227      1.0035719      1.0056643 
        adv_18         arv_20         adv_20  county_splits    muni_splits            ndv 
     1.0033901      1.0049730      1.0041586      1.0117042      1.0027346      1.0035318 
           nrv        ndshare          e_dvs          e_dem          pbias           egap 
     1.0057597      1.0043470      1.0043417      1.0032253      1.0020318      1.0008614 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,766 (95.3%)     13.7%        0.46 3,208 (101%)      9 
Split 2     4,697 (93.9%)     17.5%        0.46 3,098 ( 98%)      6 
Split 3     4,677 (93.5%)     22.1%        0.46 3,101 ( 98%)      4 
Split 4     4,624 (92.5%)     24.8%        0.50 3,083 ( 98%)      3 
Split 5     4,629 (92.6%)     16.8%        0.52 3,082 ( 98%)      4 
Split 6     4,588 (91.8%)     17.6%        0.54 2,972 ( 94%)      3 
Split 7     4,656 (93.1%)      9.7%        0.50 2,899 ( 92%)      4 
Split 8     4,620 (92.4%)      4.1%        0.53 2,496 ( 79%)      3 
Resample    3,545 (70.9%)       NA%        0.54 2,859 ( 90%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,770 (95.4%)     15.3%        0.46 3,158 (100%)      8 
Split 2     4,708 (94.2%)     21.2%        0.45 3,107 ( 98%)      5 
Split 3     4,685 (93.7%)     14.6%        0.47 3,123 ( 99%)      6 
Split 4     4,670 (93.4%)     15.5%        0.49 3,095 ( 98%)      5 
Split 5     4,616 (92.3%)     16.9%        0.54 3,045 ( 96%)      4 
Split 6     4,595 (91.9%)     17.6%        0.54 2,986 ( 94%)      3 
Split 7     4,647 (92.9%)      9.6%        0.51 2,923 ( 92%)      4 
Split 8     4,674 (93.5%)      4.1%        0.50 2,517 ( 80%)      3 
Resample    3,762 (75.2%)       NA%        0.51 2,917 ( 92%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
