### PR TITLE
Re-run 2020 Maryland Congressional Districts

### DIFF
--- a/analyses/MD_cd_2020/01_prep_MD_cd_2020.R
+++ b/analyses/MD_cd_2020/01_prep_MD_cd_2020.R
@@ -70,7 +70,7 @@ if (!file.exists(here(shp_path))) {
     md_shp <- md_shp %>% left_join(baf, by = "GEOID")
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = md_shp,
+    redistmetrics::prep_perims(shp = md_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/MD_cd_2020/03_sim_MD_cd_2020.R
+++ b/analyses/MD_cd_2020/03_sim_MD_cd_2020.R
@@ -10,7 +10,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 5e3, runs = 2L, ncores = 8,
+    nsims = 2500, runs = 2L,
     counties = county
 )
 

--- a/analyses/MD_cd_2020/03_sim_MD_cd_2020.R
+++ b/analyses/MD_cd_2020/03_sim_MD_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MD_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 5e3, runs = 2L, ncores = 8,
+    counties = county
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/MD_cd_2020/doc_MD_cd_2020.md
+++ b/analyses/MD_cd_2020/doc_MD_cd_2020.md
@@ -20,5 +20,5 @@ Data for Maryland comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Maryland across 2 indpendent runs of the SMC algorithm.
+We sample 5,000 districting plans for Maryland across 2 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.

--- a/analyses/MD_cd_2020/doc_MD_cd_2020.md
+++ b/analyses/MD_cd_2020/doc_MD_cd_2020.md
@@ -20,5 +20,5 @@ Data for Maryland comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Maryland.
+We sample 5,000 districting plans for Maryland across 2 indpendent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
[In Maryland, districts must](https://governor.maryland.gov/wp-content/uploads/2021/01/execorder.pdf):

1. be contiguous (C.1.a.i.)
1. have equal populations (C.1.c.i.)
1. be geographically compact (C.1.a.iv.)
1. preserve county and municipality boundaries as much as possible (C.1.a.iii.)
1. not consider incumbent or partisan information (C.1.b.i., C.1.b.ii.)


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Maryland comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
    
## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Maryland across 2 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

![validation_20220622_1000](https://user-images.githubusercontent.com/28026893/175048194-9952b59d-a6bb-4642-b16c-b64193456985.png)

```
SMC: 5,000 sampled plans of 8 districts on 2,042 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.49 to 0.78

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
     1.0205068      1.0031847      1.0026922      1.0018201      1.0021193      1.0076208 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0057755      1.0173884      1.0045380      1.0055871      1.0129847      0.9998311 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0330381      1.0058124      1.0073100      1.0162325      1.0067133      1.0053799 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_sze 
     1.0201413      1.0005733      1.0271314      1.0024141      1.0125128      1.0033708 
uss_16_dem_van uss_18_rep_cam uss_18_dem_car gov_18_rep_hog gov_18_dem_jea atg_18_rep_wol 
     1.0112053      1.0035371      1.0098955      1.0051524      1.0152211      1.0011091 
atg_18_dem_fro pre_20_dem_bid pre_20_rep_tru         arv_16         adv_16         arv_18 
     1.0085301      1.0032436      1.0062913      1.0014592      1.0120006      1.0056666 
        adv_18         arv_20         adv_20  county_splits    muni_splits            ndv 
     1.0097472      1.0062913      1.0032436      1.0132886      1.0177737      1.0095900 
           nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
     1.0016500      1.0070707      1.0070875      1.0127817      1.0138223      1.0032670 
          egap 
     1.0155451 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,456 (98.3%)      9.8%        0.27 1,600 (101%)      8 
Split 2     2,427 (97.1%)     14.4%        0.34 1,561 ( 99%)      5 
Split 3     2,386 (95.4%)     17.2%        0.45 1,551 ( 98%)      4 
Split 4     2,358 (94.3%)     20.0%        0.51 1,536 ( 97%)      3 
Split 5     2,305 (92.2%)     17.7%        0.55 1,542 ( 98%)      3 
Split 6     2,256 (90.2%)     21.4%        0.61 1,480 ( 94%)      2 
Split 7     2,234 (89.4%)      7.3%        0.60 1,325 ( 84%)      2 
Resample    1,563 (62.5%)       NA%        0.63 1,390 ( 88%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,457 (98.3%)     13.2%        0.27 1,578 (100%)      6 
Split 2     2,424 (97.0%)     17.8%        0.35 1,586 (100%)      4 
Split 3     2,395 (95.8%)     17.2%        0.43 1,561 ( 99%)      4 
Split 4     2,326 (93.0%)     13.0%        0.52 1,540 ( 97%)      5 
Split 5     2,293 (91.7%)     18.5%        0.56 1,513 ( 96%)      3 
Split 6     2,293 (91.7%)     20.2%        0.57 1,436 ( 91%)      2 
Split 7     2,271 (90.8%)      7.0%        0.57 1,303 ( 82%)      2 
Resample    1,641 (65.6%)       NA%        0.58 1,438 ( 91%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
