### PR TITLE
Re-run 2020 Wisconsin Congressional Districts

### DIFF
--- a/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/02_setup_WI_cd_2020.R
@@ -12,19 +12,6 @@ map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
         pop_muni = get_target(map)))
 
-# make cores
-map <- map %>%
-    mutate(core_id = redist.identify.cores(adj, cd_2010, boundary = 2),
-        core_id_lump = forcats::fct_lump_n(as.character(core_id), max(cd_2010)),
-        core_id = if_else(is_county_split(core_id_lump, pseudo_county),
-            str_c(pseudo_county, "_", core_id),
-            as.character(core_id))) %>%
-    select(-core_id_lump)
-
-map_merge <- map %>%
-    `attr<-`("existing_col", NULL) %>%
-    merge_by(core_id, cd_2010, by_existing = FALSE)
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "WI_2020"
 

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -10,9 +10,8 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2500, runs = 2L, ncores = 8,
-    counties = pseudo_county # ,
-    # constraints = cons
+    nsims = 2500, runs = 2L,
+    counties = pseudo_county
 )
 
 plans <- match_numbers(plans, "cd_2020")

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -6,20 +6,23 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WI_cd_2020}")
 
-cons <- redist_constr(map_merge) %>%
-    add_constr_status_quo(
-        strength = 20,
-        current = map_merge$cd_2010
-    ) %>%
+cons <- redist_constr(map) %>%
     add_constr_splits(
         strength = 0.5,
-        admin = county_muni
+        admin = pseudo_county
     )
-plans <- redist_smc(map_merge, nsims = 5e3, counties = county_muni,
-    constraints = cons) %>%
-    pullback() %>%
-    add_reference(ref_plan = map$cd_2020)
-attr(plans, "prec_pop") <- map$pop
+
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 2500, runs = 2L, ncores = 8,
+    counties = pseudo_county,
+    constraints = cons
+)
+
+plans <- match_numbers(plans, "cd_2020")
+
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
@@ -44,9 +47,9 @@ if (interactive()) {
     library(patchwork)
 
     redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Minority by VAP") +
         labs(title = "Wisconsin Plan versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +

--- a/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
+++ b/analyses/WI_cd_2020/03_sim_WI_cd_2020.R
@@ -6,19 +6,13 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WI_cd_2020}")
 
-cons <- redist_constr(map) %>%
-    add_constr_splits(
-        strength = 0.5,
-        admin = pseudo_county
-    )
-
 set.seed(2020)
 
 plans <- redist_smc(
     map,
     nsims = 2500, runs = 2L, ncores = 8,
-    counties = pseudo_county,
-    constraints = cons
+    counties = pseudo_county # ,
+    # constraints = cons
 )
 
 plans <- match_numbers(plans, "cd_2020")
@@ -40,24 +34,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/WI_2020/WI_cd_2020_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
-        scale_y_continuous("Percent Minority by VAP") +
-        labs(title = "Wisconsin Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020 = "black")) +
-        ggredist::theme_r21()
-
-    pl_renum <- plans %>%
-        match_numbers(plan = map$cd_2010)
-
-    hist(pl_renum, pop_overlap, bins = 30) +
-        ggredist::theme_r21()
-}

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -18,7 +18,7 @@ Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files
 We use a hybrid boundary-2 cores constraint, based on the 2010 map. Any VTDs more than 2 VTD from the boundary are frozen as a core. Pseudocounties which contain any of the non-frozen VTDs are frozen into remainder portions, separate from their district core. This avoids adding additional county splits. For the pseudocounties used in freezing cores, municipality lines are used within Milwaukee County, which is larger than a congressional district in population.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Wisconsin.
+We sample 5,000 districting plans for Wisconsin across 2 independent runs of the SMC algorithm.
 We use municipalities for use in the county constraint (or counties if a VTD is not assigned to a municipality) to match norms in the state of having low county and municipality splits, despite no rules regarding this. 
 We use a status quo constraint to encourage simulated plans to be similar to the 2010 map.
 We use a weak county split Gibbs constraint to keep county splits comparable to the enacted map.

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -4,21 +4,19 @@
 In Wisconsin, districts must:
 
 1. have equal populations
-2. retain cores of existing districts
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
-We add a county/municipality constraint as described below.
-Due to the WI Supreme Court ruling in [Johnson v. Wisconsin Elections Commission](https://www.wicourts.gov/sc/opinion/DisplayDocument.pdf?content=pdf&seqNo=459269), we retain the cores of existing districts and apply a status quo constraint, as described below.
+We add a pseudo-county constraint as described below.
 
 ## Data Sources
 Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-We use a hybrid boundary-2 cores constraint, based on the 2010 map. Any VTDs more than 2 VTD from the boundary are frozen as a core. Pseudocounties which contain any of the non-frozen VTDs are frozen into remainder portions, separate from their district core. This avoids adding additional county splits. For the pseudocounties used in freezing cores, municipality lines are used within Milwaukee County, which is larger than a congressional district in population.
+No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Wisconsin across 2 independent runs of the SMC algorithm.
-We use municipalities for use in the county constraint (or counties if a VTD is not assigned to a municipality) to match norms in the state of having low county and municipality splits, despite no rules regarding this. 
-We use a status quo constraint to encourage simulated plans to be similar to the 2010 map.
-We use a weak county split Gibbs constraint to keep county splits comparable to the enacted map.
+We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines are used in Milwaukee County. 
+These are larger than the target population for a district. 
+No special techniques were needed to produce the sample.

--- a/analyses/WI_cd_2020/doc_WI_cd_2020.md
+++ b/analyses/WI_cd_2020/doc_WI_cd_2020.md
@@ -7,7 +7,7 @@ In Wisconsin, districts must:
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
-We add a pseudo-county constraint as described below.
+We add a county/municipality constraint as described below.
 
 ## Data Sources
 Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -17,6 +17,6 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Wisconsin across 2 independent runs of the SMC algorithm.
-We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines are used in Milwaukee County. 
-These are larger than the target population for a district. 
+To balance county and municipality splits, we create pseudocounties for use in the county constraint.
+These are counties, outside of Milwaukee county. Within Milwaukee county, each municipality is its own pseudocounty as well. Milwaukee county was chosen since it is necessarily split by congressional districts
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Wisconsin, districts must:

1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We add a pseudo-county constraint as described below.

## Data Sources
Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Wisconsin across 2 independent runs of the SMC algorithm.
We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines are used in Milwaukee County. 
These are larger than the target population for a district. 
No special techniques were needed to produce the sample.

## Validation

![validation_20220622_1032](https://user-images.githubusercontent.com/28026893/175057007-02dc3e41-131a-43a8-be4d-24ceab063c7c.png)

```
SMC: 5,000 sampled plans of 8 districts on 7,059 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.59 to 0.85

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
      1.018045       1.000334       1.017433       1.012493       1.001198       1.004935       1.003655       1.003070       1.000654 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
      1.016204       1.008083       1.000661       1.023666       1.005044       1.006400       1.002300       1.001295       1.015057 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_joh uss_16_dem_fei uss_18_rep_vuk uss_18_dem_bal 
      1.003765       1.001014       1.024333       1.017555       1.008775       1.013189       1.021412       1.014944       1.016234 
gov_18_rep_wal gov_18_dem_eve atg_18_rep_sch atg_18_dem_kau sos_18_rep_sch sos_18_dem_laf pre_20_dem_bid pre_20_rep_tru         arv_16 
      1.011614       1.018596       1.014212       1.017597       1.017621       1.015334       1.008323       1.013519       1.015066 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv 
      1.016569       1.014496       1.017223       1.013519       1.008323       1.002334       1.000965       1.015644       1.014567 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
      1.014480       1.013279       1.012151       1.012959       0.999987       1.009228 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,456 (98.2%)     18.9%        0.27 1,591 (101%)     10 
Split 2     2,432 (97.3%)     25.6%        0.33 1,579 (100%)      6 
Split 3     2,389 (95.6%)     31.6%        0.45 1,550 ( 98%)      4 
Split 4     2,358 (94.3%)     32.8%        0.50 1,553 ( 98%)      3 
Split 5     2,317 (92.7%)     34.5%        0.51 1,521 ( 96%)      2 
Split 6     2,305 (92.2%)     29.6%        0.53 1,484 ( 94%)      2 
Split 7     2,311 (92.5%)     10.2%        0.50 1,316 ( 83%)      2 
Resample    1,721 (68.8%)       NA%        0.52 1,460 ( 92%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,456 (98.2%)     12.7%        0.27 1,553 ( 98%)     15 
Split 2     2,430 (97.2%)     19.2%        0.33 1,560 ( 99%)      9 
Split 3     2,405 (96.2%)     24.1%        0.43 1,568 ( 99%)      6 
Split 4     2,339 (93.6%)     28.0%        0.50 1,560 ( 99%)      4 
Split 5     2,281 (91.2%)     30.0%        0.53 1,548 ( 98%)      3 
Split 6     2,307 (92.3%)     11.2%        0.53 1,448 ( 92%)      8 
Split 7     2,302 (92.1%)      6.3%        0.54 1,326 ( 84%)      5 
Resample    1,748 (69.9%)       NA%        0.54 1,456 ( 92%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

Note: Consistent with previous discussions and other states, we remove the cores requirement, as it is not a state requirement, rather a court directive for how to approach the new lines.