### PR TITLE
Re-run 2020 Arkansas Congressional Districts

### DIFF
--- a/analyses/AR_cd_2020/03_sim_AR_cd_2020.R
+++ b/analyses/AR_cd_2020/03_sim_AR_cd_2020.R
@@ -6,7 +6,10 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg AR_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+set.seed(2020)
+
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/AR_cd_2020/doc_AR_cd_2020.md
+++ b/analyses/AR_cd_2020/doc_AR_cd_2020.md
@@ -15,5 +15,5 @@ Data for Arkansas' 2020 congressional district map comes from All About Redistri
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Arkansas.
+We sample 5,000 districting plans for Arkansas across two independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Arkansas, there are no state law requirements for congressional districts.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.

## Data Sources
Data for Arkansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for Arkansas' 2020 congressional district map comes from All About Redistricting's [Maps for Download](https://redistricting.lls.edu/mapdownload/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Arkansas across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.


## Validation

![validation_20220622_0855](https://user-images.githubusercontent.com/90931177/175077955-085237a8-53ed-45a1-9d1e-ca6d9c9915bd.png)


```
SMC: 5,000 sampled plans of 4 districts on 2,747 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.47 to 0.82

R-hat values for summary statistics:
     total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian      pop_asian 
     1.0006595      1.0006705      1.0033898      1.0017817      1.0026789      1.0020468      1.0017951      1.0035190      1.0008060 
      pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian       vap_nhpi 
     0.9999961      1.0014038      0.9998751      1.0027249      1.0018856      1.0011615      1.0040176      1.0008058      0.9998848 
     vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_boo uss_16_dem_eld gov_18_rep_hut gov_18_dem_hen atg_18_rep_rut 
     1.0006162      1.0000847      1.0006022      1.0029601      1.0014641      1.0040816      1.0018785      1.0009145      1.0013890 
atg_18_dem_lee sos_18_rep_thu sos_18_dem_inm pre_20_rep_tru pre_20_dem_bid uss_20_rep_cot uss_20_dem_har         arv_16         adv_16 
     1.0015779      1.0013111      1.0016825      1.0021395      1.0025742      1.0015275      1.0021087      1.0011969      1.0032071 
        arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv        ndshare 
     1.0013291      1.0014035      1.0016574      1.0026355      1.0003920      1.0006083      1.0009212      1.0013638      1.0026440 
         e_dvs         pr_dem          e_dem          pbias           egap 
     1.0026577      1.0015256      1.0011547      1.0061662      1.0026662 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,408 (96.3%)     10.4%        0.39 1,580 (100%)     12 
Split 2     2,405 (96.2%)     13.9%        0.37 1,559 ( 99%)      7 
Split 3     2,373 (94.9%)      7.8%        0.46 1,439 ( 91%)      4 
Resample    1,949 (78.0%)       NA%        0.43 1,496 ( 95%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,413 (96.5%)     11.9%        0.38 1,591 (101%)     10 
Split 2     2,405 (96.2%)     15.9%        0.36 1,553 ( 98%)      6 
Split 3     2,377 (95.1%)      7.9%        0.46 1,430 ( 90%)      4 
Resample    1,965 (78.6%)       NA%        0.42 1,494 ( 95%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
@christopherkenny
