### PR TITLE
Re-run 2020 Connecticut Congressional Districts

### DIFF
--- a/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
+++ b/analyses/CT_cd_2020/03_sim_CT_cd_2020.R
@@ -6,8 +6,10 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CT_cd_2020}")
 
+set.seed(2020)
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -25,5 +27,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/CT_2020/CT_cd_2020_stats.csv")
 
 cli_process_done()
-
-validate_analysis(plans, map)

--- a/analyses/CT_cd_2020/doc_CT_cd_2020.md
+++ b/analyses/CT_cd_2020/doc_CT_cd_2020.md
@@ -15,7 +15,7 @@ Data for Connecticut's 2020 congressional district map comes from [Redistricting
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Connecticut.
+We sample 5,000 districting plans for Connecticut across two independent runs of the SMC algorithm.
 We use a pseudo-county constraint to limit the county and municipality splits.
-Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all countied with populations larger than 40% the target population for a district.
+Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all counties with populations larger than 40% the target population for a district.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2020 Connecticut Congressional Districts

## Redistricting requirements
In Connecticut, there are no state law requirements for congressional districts

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 and 2010 congressional district plans.
We use a pseudo-county constraint described below which attempts to mimic the norms in Connecticut of generally preserving county and municipal boundaries.

## Data Sources
Data for Connecticut comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for Connecticut's 2020 congressional district map comes from [Redistricting Data Hub](https://redistrictingdatahub.org/dataset/2022-connecticut-congressional-districts-approved-plan/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Connecticut across two independent runs of the SMC algorithm.
We use a pseudo-county constraint to limit the county and municipality splits.
Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all counties with populations larger than 40% the target population for a district.
No special techniques were needed to produce the sample.


## Validation

![validation_20220622_0911](https://user-images.githubusercontent.com/90931177/175081005-e31385c9-05f7-4ffd-9a3d-493108f3b516.png)

```
SMC: 5,000 sampled plans of 5 districts on 766 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.44 to 0.82

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0061487      1.0048045      1.0007067      1.0001417      1.0030249      1.0015151      1.0010612      1.0008506      1.0114048 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0045106      1.0046684      1.0011763      1.0033283      1.0016379      1.0012211      1.0003401      1.0114542      1.0022266 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_blu uss_16_rep_car uss_18_dem_mur uss_18_rep_cor 
     1.0134059      1.0004239      1.0049946      1.0059462      1.0042151      1.0050802      1.0010887      1.0033527      1.0007614 
gov_18_dem_lam gov_18_rep_ste atg_18_dem_ton atg_18_rep_hat sos_18_dem_mer sos_18_rep_cha pre_20_dem_bid pre_20_rep_tru         arv_16 
     1.0066333      1.0007305      1.0030134      1.0025954      1.0036209      1.0006548      1.0051727      1.0019582      1.0030719 
        adv_16         arv_18         adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv 
     1.0058016      1.0008761      1.0048274      1.0019582      1.0051727      1.0053965      1.0037848      1.0040302      1.0014139 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
     1.0014410      1.0015035      1.0000321      1.0000468      1.0018780      0.9998474 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,436 (97.4%)      8.5%        0.33 1,583 (100%)      5 
Split 2     2,391 (95.7%)      8.5%        0.40 1,538 ( 97%)      4 
Split 3     2,345 (93.8%)      9.2%        0.48 1,491 ( 94%)      3 
Split 4     2,319 (92.7%)      4.1%        0.52 1,281 ( 81%)      2 
Resample    1,783 (71.3%)       NA%        0.52 1,462 ( 93%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,433 (97.3%)      7.1%        0.34 1,589 (101%)      6 
Split 2     2,392 (95.7%)      9.0%        0.40 1,561 ( 99%)      4 
Split 3     2,341 (93.6%)      9.3%        0.48 1,512 ( 96%)      3 
Split 4     2,315 (92.6%)      4.0%        0.52 1,311 ( 83%)      2 
Resample    1,720 (68.8%)       NA%        0.51 1,429 ( 90%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@christopherkenny
