### PR TITLE
Re-run 2020 Louisiana Congressional Districts

### DIFF
--- a/analyses/LA_cd_2020/03_sim_LA_cd_2020.R
+++ b/analyses/LA_cd_2020/03_sim_LA_cd_2020.R
@@ -7,10 +7,12 @@
 cli_process_start("Running simulations for {.pkg LA_cd_2020}")
 
 constr <- redist_constr(map_m) %>%
-    add_constr_grp_hinge(35, vap_black, vap, tgts_group = 0.55)
+    add_constr_grp_hinge(25, vap - vap_white, vap, 0.55) %>%
+    add_constr_grp_hinge(-25, vap - vap_white, vap, 0.46) %>%
+    add_constr_grp_inv_hinge(10, vap - vap_white, vap, 0.6)
 
 set.seed(2020)
-plans <- redist_smc(map_m, nsims = 6e3,
+plans <- redist_smc(map_m, nsims = 8e3,
     runs = 2L,
     counties = pseudo_county,
     constraints = constr) %>%

--- a/analyses/LA_cd_2020/doc_LA_cd_2020.md
+++ b/analyses/LA_cd_2020/doc_LA_cd_2020.md
@@ -11,7 +11,7 @@ In Louisiana, according to [Louisiana Joint Rule No. 21](https://www.legis.la.go
 
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.5%. We add a VRA constraint targeting one majority-minority district.
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
 
 ## Data Sources
 Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/LA_cd_2020/doc_LA_cd_2020.md
+++ b/analyses/LA_cd_2020/doc_LA_cd_2020.md
@@ -20,4 +20,4 @@ Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files
 To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
 
 ## Simulation Notes
-We sample 6,000 districting plans for Louisiana and subset to 5,000 which contain at least one majority-minority district. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.
+We sample 12,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

--- a/analyses/LA_cd_2020/doc_LA_cd_2020.md
+++ b/analyses/LA_cd_2020/doc_LA_cd_2020.md
@@ -20,4 +20,4 @@ Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files
 To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
 
 ## Simulation Notes
-We sample 12,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.
+We sample 16,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Louisiana, according to [Louisiana Joint Rule No. 21](https://www.legis.la.gov/Legis/Law.aspx?d=1238755) districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve parish and municipality boundaries as much as possible
5. preserve the cores of traditional district alignments


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.

## Data Sources
Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.

## Simulation Notes
We sample 16,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

## Validation

![image](https://user-images.githubusercontent.com/55368740/175096125-996ad4d7-e96e-4d9a-b742-eaf6bd396c32.png)

```
SMC: 5,000 sampled plans of 6 districts on 3,540 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.38 to 0.66

R-hat values for summary statistics:
    pop_overlap       total_vap        plan_dev       comp_edge     comp_polsby        pop_hisp       pop_white       pop_black 
      1.0004014       1.0164981       1.0013232       1.0026631       1.0016399       1.0046681       1.0028184       1.0003868 
       pop_aian       pop_asian        pop_nhpi       pop_other         pop_two        vap_hisp       vap_white       vap_black 
      1.0005026       1.0171877       0.9998143       1.0045008       1.0007654       1.0045184       1.0013670       1.0003587 
       vap_aian       vap_asian        vap_nhpi       vap_other         vap_two  pre_16_rep_tru  pre_16_dem_cli  uss_16_rep_ken 
      1.0006045       1.0168429       0.9998946       1.0038379       1.0013667       1.0032925       1.0022517       1.0026609 
 uss_16_rep_bou  uss_16_rep_fle  uss_16_rep_man  uss_16_rep_duk  uss_16_rep_cra  uss_16_rep_cao  uss_16_rep_mar  uss_16_rep_pat 
      1.0000303       1.0067825       1.0025569       1.0011092       1.0034751       1.0182771       1.0039785       1.0050235 
 uss_16_dem_cam  uss_16_dem_fay  uss_16_dem_edw  uss_16_dem_lan  uss_16_dem_pel  uss_16_dem_wil  uss_16_dem_men uss_r16_rep_ken 
      1.0016517       1.0038730       1.0017448       1.0005400       1.0005882       0.9998624       1.0023361       1.0015958 
uss_r16_dem_cam  sos_18_rep_ard  sos_18_rep_edm  sos_18_rep_sto  sos_18_rep_ken  sos_18_rep_cro  sos_18_rep_clo  sos_18_dem_col 
      1.0020024       1.0018361       1.0003223       1.0053529       1.0009820       1.0030841       1.0013332       1.0006912 
 sos_18_dem_fre sos_r18_rep_ard sos_r18_dem_col  pre_20_rep_tru  pre_20_dem_bid  uss_20_rep_cas  uss_20_rep_mur  uss_20_dem_per 
      1.0064540       1.0005556       1.0006287       1.0031927       1.0037881       1.0021774       1.0021379       1.0063591 
 uss_20_dem_edw  uss_20_dem_pie  uss_20_dem_kni  uss_20_dem_wen          arv_16          adv_16          arv_18          adv_18 
      1.0010313       1.0009700       1.0132999       1.0014646       1.0020267       1.0018806       0.9999942       1.0021988 
         arv_20          adv_20   county_splits     muni_splits             ndv             nrv         ndshare           e_dvs 
      1.0026804       1.0039076       1.0013704       1.0006378       1.0027070       1.0019585       1.0032535       1.0040750 
         pr_dem           e_dem           pbias            egap 
      1.0003566       1.0002012       0.9999922       1.0048379 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    3,501 (140.0%)      8.1%        0.27 5,055 (320%)      9 
Split 2    4,969 (198.8%)      9.9%        0.93 3,866 (245%)      6 
Split 3    5,505 (220.2%)     12.6%        0.70 4,233 (268%)      4 
Split 4    5,429 (217.2%)     13.2%        0.69 4,287 (271%)      3 
Split 5    5,738 (229.5%)      6.0%        0.66 3,559 (225%)      2 
Resample    1,835 (73.4%)       NA%        1.31 3,717 (235%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    3,495 (139.8%)      5.2%        0.27 5,076 (321%)     14 
Split 2    4,900 (196.0%)      7.4%        0.93 3,870 (245%)      8 
Split 3    5,473 (218.9%)     10.4%        0.73 4,243 (268%)      5 
Split 4    5,500 (220.0%)     11.1%        0.69 4,245 (269%)      4 
Split 5    5,720 (228.8%)      4.8%        0.66 3,662 (232%)      3 
Resample    2,039 (81.6%)       NA%        1.30 3,680 (233%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Performance plot for minority VAP.
![image](https://user-images.githubusercontent.com/55368740/175096344-07899bf5-f894-4009-aca6-be0c1b28af74.png)


@tylersimko
