### PR TITLE
Re-run 2020 New Mexico Congressional Districts

### DIFF
--- a/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
+++ b/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
@@ -10,8 +10,11 @@ map <- redist_map(nm_shp, pop_tol = 0.005,
 
 # Set up cores objects
 map <- map %>%
-    mutate(cores = make_cores(boundary = 2))
-# Merge by both cores and county to preserve county contiguity
+    mutate(cores = make_cores(boundary = 2)) %>%
+    # merge by both cores and county to preserve county contiguity
+    merge_by(cores, county, drop_geom = FALSE)
+
+
 map_cores <- merge_by(map, cores, county)
 
 # Add an analysis name attribute

--- a/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
+++ b/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
@@ -14,9 +14,6 @@ map <- map %>%
     # merge by both cores and county to preserve county contiguity
     merge_by(cores, county, drop_geom = FALSE)
 
-
-map_cores <- merge_by(map, cores, county)
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NM_2020"
 

--- a/analyses/NM_cd_2020/03_sim_NM_cd_2020.R
+++ b/analyses/NM_cd_2020/03_sim_NM_cd_2020.R
@@ -6,8 +6,11 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NM_cd_2020}")
 
-plans <- redist_smc(map_cores, nsims = 5e3, counties = county) %>%
+set.seed(2020)
+
+plans <- redist_smc(map_cores, nsims = 2500, runs = 2L, counties = county) %>%
     pullback(map)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/NM_cd_2020/doc_NM_cd_2020.md
+++ b/analyses/NM_cd_2020/doc_NM_cd_2020.md
@@ -8,11 +8,10 @@ In New Mexico, districts must, under [legislation code SB 304](https://www.nmleg
 3. be as equal in population as practicable
 4. to the extent feasible, preserve communities of interest and take into consideration political and geographic boundaries
 5. to the extent feasible, preserve the core of existing districts
-
 Additionally, race-neutral districting principles shall not be subordinated to racial considerations
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.5%, which is only slightly greater than the strict population deviation standards observed in both the 2000 and 2010 Congressional District maps. 
+We enforce a maximum population deviation of 0.5%.
 We constrain the number of county divisions to 1 less than the number of Congressional Districts.
 We perform cores-based simulations, thereby preserving cores of prior districts.
 
@@ -25,5 +24,6 @@ Data for New Mexico' 2020 congressional district map comes from New Mexico Legis
 To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
 
 ## Simulation Notes
-We sample 5,000 districting plans for New Mexico. No special techniques were needed to produce the sample.
+We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.
 

--- a/analyses/NM_cd_2020/doc_NM_cd_2020.md
+++ b/analyses/NM_cd_2020/doc_NM_cd_2020.md
@@ -8,6 +8,7 @@ In New Mexico, districts must, under [legislation code SB 304](https://www.nmleg
 3. be as equal in population as practicable
 4. to the extent feasible, preserve communities of interest and take into consideration political and geographic boundaries
 5. to the extent feasible, preserve the core of existing districts
+
 Additionally, race-neutral districting principles shall not be subordinated to racial considerations
 
 ### Interpretation of requirements
@@ -21,9 +22,8 @@ Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data File
 Data for New Mexico' 2020 congressional district map comes from New Mexico Legislature's [Maps and Data](https://www.nmlegis.gov/Redistricting2021/Maps_And_Data?ID202=221711.1).
 
 ## Pre-processing Notes
-To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan.
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2010 plan.
 
 ## Simulation Notes
 We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.
-


### PR DESCRIPTION
## Redistricting requirements
In New Mexico, districts must, under [legislation code SB 304](https://www.nmlegis.gov/Legislation/Legislation?Chamber=S&LegType=B&LegNo=304&year=21):

1. be contiguous
2. be reasonably compact
3. be as equal in population as practicable
4. to the extent feasible, preserve communities of interest and take into consideration political and geographic boundaries
5. to the extent feasible, preserve the core of existing districts

Additionally, race-neutral districting principles shall not be subordinated to racial considerations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We constrain the number of county divisions to 1 less than the number of Congressional Districts.
We perform cores-based simulations, thereby preserving cores of prior districts.


## Data Sources
Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for New Mexico' 2020 congressional district map comes from New Mexico Legislature's [Maps and Data](https://www.nmlegis.gov/Redistricting2021/Maps_And_Data?ID202=221711.1).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2010 plan.

## Simulation Notes
We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
![validation_20220622_1008](https://user-images.githubusercontent.com/90931177/175097016-ec998b00-d411-45d9-98fa-36d327547fd8.png)
```
SMC: 5,000 sampled plans of 3 districts on 597 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.16 to 0.60

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
     1.0009521      0.9998271      1.0006511      0.9999925      1.0004038      1.0014393      1.0027362      0.9998025      1.0011978 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0011138      1.0016067      1.0027170      1.0059275      1.0018850      1.0021361      0.9998096      1.0013805      1.0012544 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli sos_16_rep_esp sos_16_dem_oli uss_18_dem_hei uss_18_rep_ric 
     1.0010377      1.0021504      1.0045363      1.0007133      1.0025530      1.0007878      1.0027285      1.0018617      1.0006518 
gov_18_dem_luj gov_18_rep_pea atg_18_dem_bal atg_18_rep_hen sos_18_dem_tou sos_18_rep_cla         arv_16         adv_16         arv_18 
     1.0019412      1.0004650      1.0019797      1.0010654      1.0015782      1.0009750      1.0005776      1.0026725      1.0007003 
        adv_18  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs          e_dem          pbias 
     1.0019060      1.0002229      1.0011125      1.0022047      1.0005951      1.0000985      1.0000956      1.0005568      1.0002955 
          egap 
     1.0002149 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,449 (98.0%)      4.2%        0.30 1,594 (101%)     11 
Split 2     2,390 (95.6%)      2.3%        0.40 1,410 ( 89%)      7 
Resample    2,031 (81.2%)       NA%        0.41 1,508 ( 95%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,449 (98.0%)      5.6%        0.30 1,562 ( 99%)      8 
Split 2     2,423 (96.9%)      3.1%        0.35 1,405 ( 89%)      5 
Resample    2,213 (88.5%)       NA%        0.36 1,544 ( 98%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
