### PR TITLE
2020 Kentucky Congressional Districts

### DIFF
--- a/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
@@ -20,7 +20,7 @@ cli_process_start("Downloading files for {.pkg KY_cd_2020}")
 path_data <- download_redistricting_file("KY", "data-raw/KY")
 
 # download the enacted plan.
-url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+url <- "https://legislature.ky.gov/Public%20Services/GIS%20contents/C1278B01%20%2822RS-SB3%29.zip"
 path_enacted <- "data-raw/KY/KY_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KY_enacted"))

--- a/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
@@ -19,7 +19,7 @@ cli_process_start("Downloading files for {.pkg KY_cd_2020}")
 
 path_data <- download_redistricting_file("KY", "data-raw/KY")
 
-# download the enacted plan.
+# Download the enacted plan.
 url <- "https://legislature.ky.gov/Public%20Services/GIS%20contents/C1278B01%20%2822RS-SB3%29.zip"
 path_enacted <- "data-raw/KY/KY_enacted.zip"
 download(url, here(path_enacted))
@@ -63,7 +63,7 @@ if (!file.exists(here(shp_path))) {
         .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = ky_shp,
+    redistmetrics::prep_perims(shp = ky_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/01_prep_KY_cd_2020.R
@@ -27,8 +27,6 @@ unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KY_enacted"))
 file.remove(path_enacted)
 path_enacted <- "data-raw/KY/KY_enacted/C1278B01 (22RS-SB3).shp"
 
-# If large, consider checking to see if these files exist before downloading
-
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----

--- a/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
@@ -6,7 +6,10 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg KY_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 4e3, runs = 2L, counties = pseudo_county,
+                    ncores = 8)
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -19,6 +22,8 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg KY_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
+
+summary(plans)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/KY_2020/KY_cd_2020_stats.csv")

--- a/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
@@ -7,8 +7,7 @@
 cli_process_start("Running simulations for {.pkg KY_cd_2020}")
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = 4e3, runs = 2L, counties = pseudo_county,
-                    ncores = 8) %>%
+plans <- redist_smc(map, nsims = 4e3, runs = 2L, counties = pseudo_county) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()

--- a/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
@@ -8,7 +8,10 @@ cli_process_start("Running simulations for {.pkg KY_cd_2020}")
 
 set.seed(2020)
 plans <- redist_smc(map, nsims = 4e3, runs = 2L, counties = pseudo_county,
-                    ncores = 8)
+                    ncores = 8) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
@@ -37,5 +40,5 @@ if (interactive()) {
     redist.plot.distr_qtys(plans, qty = ndshare, geom = "boxplot") +
         scale_y_continuous("Democratic Voteshare", labels = scales::percent_format(accuracy = 1)) +
         theme_bw()
-    ggsave("partisan.pdf", height = 4, width = 8)
+    ggsave("figs/partisan.pdf", height = 4, width = 8)
 }

--- a/analyses/KY_cd_2020/doc_KY_cd_2020.md
+++ b/analyses/KY_cd_2020/doc_KY_cd_2020.md
@@ -10,7 +10,7 @@ In Kentucky, under the Criteria and Standards for Congressional Redistricting ad
 5. preserve communities of interest as much as possible
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.1%. We use a pseudo-county constraint described below which attempts to mimic the norms in Kentucky of generally preserving county, city, and township boundaries.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Kentucky of generally preserving county, city, and township boundaries.
 
 ## Data Sources
 Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,5 +19,5 @@ Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Kentucky.
-We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits. Municipality lines are used in Jefferson County, which has a population larger than the target population for a congressional district.
+We sample 8,000 districting plans for Kentucky across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
+We use a pseudo-county constraint to limit the county and municipality (i.e. city and township) splits. Municipality lines are used in Jefferson County, which has a population larger than the target population for a congressional district.


### PR DESCRIPTION
## Redistricting requirements
In Kentucky, under the Criteria and Standards for Congressional Redistricting adopted by Interim Joint Committee on State Government’s Redistricting Subcommittee in 1991, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve communities of interest as much as possible

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Kentucky of generally preserving county, city, and township boundaries.

## Data Sources
Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 8,000 districting plans for Kentucky across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
We use a pseudo-county constraint to limit the county and municipality (i.e. city and township) splits. Municipality lines are used in Jefferson County, which has a population larger than the target population for a congressional district.

## Validation

![validation_20220622_1644](https://user-images.githubusercontent.com/26680063/175133820-489052f8-c43d-49a0-9cc9-d8d4fe299188.png)

```
SMC: 5,000 sampled plans of 6 districts on 3,693 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.46 to 0.78

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
     1.0026795      1.0056163      0.9998512      1.0014006      1.0089357      1.0038177      1.0001899 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
     1.0020155      1.0026037      1.0004992      1.0002646      1.0006421      1.0014589      1.0018988 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0006832      1.0024479      1.0016443      1.0004699      1.0001827      1.0000130      1.0019312 
pre_16_rep_tru pre_16_dem_cli uss_16_rep_pau uss_16_dem_gra         arv_16         adv_16         arv_18 
     1.0013822      1.0028450      1.0006595      1.0144964      1.0006365      1.0013169             NA 
        adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv 
            NA             NA             NA      1.0061338      1.0034688      1.0013169      1.0006365 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
     1.0021110      1.0022326            NaN      1.0009358      1.0010513      1.0013598 
Error in if (any(rhats >= 1.05)) { : 
  missing value where TRUE/FALSE needed
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
