### PR TITLE
Re-run 2020 Virginia Congressional Districts

### DIFF
--- a/analyses/VA_cd_2020/01_prep_VA_cd_2020.R
+++ b/analyses/VA_cd_2020/01_prep_VA_cd_2020.R
@@ -19,7 +19,11 @@ cli_process_start("Downloading files for {.pkg VA_cd_2020}")
 
 path_data <- download_redistricting_file("VA", "data-raw/VA")
 
-# 2020 enacted map manually downloaded from SCV Box folder
+url <- "https://redistrictingdatahub.org/download/?datasetid=33553&document=%2Fweb_ready_stage%2Flegislative%2F2021_adopted_plans%2Fva_cong_adopted_2021.zip"
+path_enacted <- "data-raw/VA/VA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "VA_enacted"))
+file.remove(path_enacted)
 path_enacted <- "data-raw/VA/VA_enacted/SCV FINAL CD.shp"
 
 cli_process_done()
@@ -56,7 +60,7 @@ if (!file.exists(here(shp_path))) {
         .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = va_shp,
+    redistmetrics::prep_perims(shp = va_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/VA_cd_2020/03_sim_VA_cd_2020.R
+++ b/analyses/VA_cd_2020/03_sim_VA_cd_2020.R
@@ -6,8 +6,12 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg VA_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county,
-    verbose = TRUE)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 5e3, runs = 2L, counties = pseudo_county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -20,6 +24,8 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg VA_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
+
+summary(plans)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/VA_2020/VA_cd_2020_stats.csv")

--- a/analyses/VA_cd_2020/doc_VA_cd_2020.md
+++ b/analyses/VA_cd_2020/doc_VA_cd_2020.md
@@ -19,5 +19,5 @@ Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Virginia.
-No special techniques were needed to produce the sample.
+We sample 10,000 districting plans for Virginia across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Fairfax County must be split due to its large population, although within the county, we avoid splitting any municipality.


### PR DESCRIPTION
## Redistricting requirements
In Virginia, districts must, under Va. Code Ann. § 24.2-304.04:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. "not, when considered on a statewide basis, unduly favor or disfavor any political party"

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Virginia across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Fairfax County must be split due to its large population, although within the county, we avoid splitting any municipality.

## Validation

![validation_20220622_1706](https://user-images.githubusercontent.com/26680063/175145812-da407899-bee1-423c-b1e7-f117647b29e0.png)

```
SMC: 5,000 sampled plans of 11 districts on 2,465 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.67 to 0.89

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
      1.008483       1.011457       1.000227       1.005380       1.009023       1.000347       1.001906 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
      1.001395       1.002677       1.048318       1.017995       1.023632       1.001615       1.002065 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.002504       1.001680       1.005151       1.045689       1.021606       1.024723       1.028580 
pre_16_dem_cli pre_16_rep_tru uss_18_dem_kai uss_18_rep_ste         arv_16         adv_16         arv_18 
      1.012611       1.006866       1.021661       1.005162       1.006866       1.012611       1.005162 
        adv_18         arv_20         adv_20  county_splits    muni_splits            ndv            nrv 
      1.021661             NA             NA       1.002662       1.006310       1.018734       1.006016 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
      1.012606       1.012579       1.003115       1.002241       1.019433       1.002121 
Error in if (any(rhats >= 1.05)) { : 
  missing value where TRUE/FALSE needed
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
