### PR TITLE
Re-run 2020 New York Congressional Districts

### DIFF
--- a/analyses/NY_cd_2020/01_prep_NY_cd_2020.R
+++ b/analyses/NY_cd_2020/01_prep_NY_cd_2020.R
@@ -22,10 +22,35 @@ path_data <- download_redistricting_file("NY", "data-raw/NY")
 
 path_dem_irc <- here("data-raw/NY/NY congress Letters Plan Draft 9.14.csv")
 path_rep_irc <- here("data-raw/NY/NY CD Block Equivalency.xlsx")
-path_enacted <- here("data-raw/NY/ny_baf.dbf")
-if (!file.exists(path_enacted)) {
+path_enacted_old <- here("data-raw/NY/ny_baf.dbf")
+path_enacted <- here("data-raw/NY/ny_baf.csv")
+
+if (!file.exists(path_dem_irc)) {
+    temp_dem_irc <- fs::file_temp(ext = "zip")
+    download(
+        url = "https://nyirc.gov/storage/plans/20210915/congress_letters.zip",
+        path = temp_dem_irc
+    )
+    unzip(temp_dem_irc, exdir = "data-raw/NY")
+}
+
+if (!file.exists(path_rep_irc)) {
+    temp_rep_irc <- fs::file_temp(ext = "zip")
+    download(
+        url = "https://nyirc.gov/storage/plans/20210915/congress_names.zip",
+        path = temp_rep_irc
+    )
+    unzip(temp_rep_irc, exdir = "data-raw/NY")
+}
+
+if (!file.exists(path_enacted_old)) {
     download(url = "https://latfor.state.ny.us/maps/2022congress/Congress2022_BlockEquivalency.dbf",
-        path = path_enacted)
+        path = path_enacted_old)
+}
+
+if (!file.exists(path_enacted)) {
+    download(url = "https://latfor.state.ny.us/maps/2022congress/congress_block.csv",
+             path = path_enacted)
 }
 
 cli_process_done()
@@ -56,14 +81,7 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2010, .after = county)
 
-    if (!file.exists(path_dem_irc)) {
-        temp_dem_irc <- fs::file_temp(ext = "zip")
-        download(
-            url = "https://nyirc.gov/storage/plans/20210915/congress_letters.zip",
-            path = temp_dem_irc
-        )
-        unzip(temp_dem_irc, exdir = "data-raw/NY")
-    }
+
     dem_irc_baf <- read_csv(here(path_dem_irc),
         col_names = c("GEOID", "dem_irc"),
         col_types = "cc"
@@ -74,14 +92,7 @@ if (!file.exists(here(shp_path))) {
             dem_irc = which(dem_irc == letters)) %>%
         ungroup()
 
-    if (!file.exists(path_rep_irc)) {
-        temp_rep_irc <- fs::file_temp(ext = "zip")
-        download(
-            url = "https://nyirc.gov/storage/plans/20210915/congress_names.zip",
-            path = temp_rep_irc
-        )
-        unzip(temp_rep_irc, exdir = "data-raw/NY")
-    }
+
     rep_irc_baf <- readxl::read_xlsx(here(path_rep_irc))
     names(rep_irc_baf) <- c("GEOID", "rep_irc")
     vals <- unique(rep_irc_baf$rep_irc)
@@ -91,10 +102,15 @@ if (!file.exists(here(shp_path))) {
         ungroup()
     rm(vals)
 
-    baf_enacted <- foreign::read.dbf(path_enacted) %>%
+    baf_enacted_old <- foreign::read.dbf(path_enacted_old) %>%
         rename(
             GEOID = BLOCK,
-            cd_2020 = DISTRICTID
+            cd_2020_leg = DISTRICTID
+        )
+    baf_enacted <- read_csv(path_enacted, col_types = "ci") %>%
+        rename(
+            GEOID = GEOID20,
+            cd_2020 = District
         )
 
     baf_vtd <- PL94171::pl_get_baf("NY", geographies = "VTD")$VTD %>%
@@ -102,6 +118,7 @@ if (!file.exists(here(shp_path))) {
     baf <- baf_vtd %>%
         left_join(rep_irc_baf, by = "GEOID") %>%
         left_join(dem_irc_baf, by = "GEOID") %>%
+        left_join(baf_enacted_old, by = "GEOID") %>%
         left_join(baf_enacted, by = "GEOID")
     baf <- baf %>% select(-GEOID) %>%
         mutate(GEOID = paste0(censable::match_fips("NY"), county, vtd)) %>%
@@ -109,12 +126,14 @@ if (!file.exists(here(shp_path))) {
 
     baf <- baf %>%
         group_by(GEOID) %>%
-        summarize(rep_irc = Mode(rep_irc),
+        summarize(
+            rep_irc = Mode(rep_irc),
             dem_irc = Mode(dem_irc),
+            cd_2020_leg = Mode(cd_2020_leg),
             cd_2020 = Mode(cd_2020)
         )
 
-    baf <- baf %>% select(GEOID, rep_irc, dem_irc, cd_2020)
+    baf <- baf %>% select(GEOID, rep_irc, dem_irc, cd_2020_leg, cd_2020)
 
     ny_shp <- ny_shp %>% left_join(baf, by = "GEOID")
 

--- a/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
+++ b/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
@@ -10,9 +10,14 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 2e4, runs = 2L, ncores = 4, verbose = TRUE,
+    nsims = 2e4, runs = 2L,
     seq_alpha = 0.95, counties = pseudo_county, pop_temper = 0.001
 )
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 
 plans <- match_numbers(plans, "cd_2020")
 

--- a/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
+++ b/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
@@ -6,7 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NY_cd_2020}")
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 1e4, runs = 2L, ncores = 8,
+    seq_alpha = 0.95, counties = pseudo_county, pop_temper = 0.03
+)
+
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
+++ b/analyses/NY_cd_2020/03_sim_NY_cd_2020.R
@@ -10,8 +10,8 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 1e4, runs = 2L, ncores = 8,
-    seq_alpha = 0.95, counties = pseudo_county, pop_temper = 0.03
+    nsims = 2e4, runs = 2L, ncores = 4, verbose = TRUE,
+    seq_alpha = 0.95, counties = pseudo_county, pop_temper = 0.001
 )
 
 plans <- match_numbers(plans, "cd_2020")

--- a/analyses/NY_cd_2020/doc_NY_cd_2020.md
+++ b/analyses/NY_cd_2020/doc_NY_cd_2020.md
@@ -30,3 +30,4 @@ We apply a pseudo-county algorithmic constraint, which encourages keeping togeth
 The boundary here is set at the size of one district, so Bronx County, Erie County, Kings County, Nassau County, New York County, Queens County, Suffolk County, and Westchester County use municipalities over counties.
 The core constraint here is unclear, as the number of districts have changed, and because it is crossed with preserving other communities.
 As such, the pseudo-county constraint should weakly preserve the cores, as the prior map generally held together counties and municipalities.
+A small population tempering value was used to avoid losing diversity at the final step based on initial runs.

--- a/analyses/NY_cd_2020/doc_NY_cd_2020.md
+++ b/analyses/NY_cd_2020/doc_NY_cd_2020.md
@@ -24,8 +24,9 @@ Data for New York comes from the ALARM Project's [2020 Redistricting Data Files]
 Islands are connected to their nearest point on land.
 
 ## Simulation Notes
-We sample 5,000 districting plans for New York.
-we apply a pseudo-county algorithmic constraint, which encourages keeping together counties in less populated counties and municipalities in the largest counties.
+We sample 40,000 districting plans for New York across 2 independent runs of the SMC algorithm.
+We then thin the sample to down to 5,000 plans.
+We apply a pseudo-county algorithmic constraint, which encourages keeping together counties in less populated counties and municipalities in the largest counties.
 The boundary here is set at the size of one district, so Bronx County, Erie County, Kings County, Nassau County, New York County, Queens County, Suffolk County, and Westchester County use municipalities over counties.
 The core constraint here is unclear, as the number of districts have changed, and because it is crossed with preserving other communities.
 As such, the pseudo-county constraint should weakly preserve the cores, as the prior map generally held together counties and municipalities.


### PR DESCRIPTION
## Redistricting requirements
[In New York, districts must](https://www.nysenate.gov/sites/default/files/ckeditor/Oct-21/ny_state_constitution_2021.pdf):

1. be contiguous (III.4(c)(3))
1. have equal populations (III.4(c)(2))
1. be geographically compact (III.4(c)(4))
1. preserve cores of existing districts, political subdivisions, and communities of interest (III.4(c)(5))
1. not be drawn to discourage competition (III.4(c)(5))
1. not be drawn to favor or disfavor incumbents (III.4(c)(5))
1. not be drawn to favor or disfavor parties (III.4(c)(5))
1. not abridge minority group vote power (III.4(c)(1))


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We preserve cores of the many geographic regions by using a pseudo county constraint.

## Data Sources
Data for New York comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Islands are connected to their nearest point on land.

## Simulation Notes
We sample 40,000 districting plans for New York across 2 independent runs of the SMC algorithm.
We then thin the sample to down to 5,000 plans.
We apply a pseudo-county algorithmic constraint, which encourages keeping together counties in less populated counties and municipalities in the largest counties.
The boundary here is set at the size of one district, so Bronx County, Erie County, Kings County, Nassau County, New York County, Queens County, Suffolk County, and Westchester County use municipalities over counties.
The core constraint here is unclear, as the number of districts have changed, and because it is crossed with preserving other communities.
As such, the pseudo-county constraint should weakly preserve the cores, as the prior map generally held together counties and municipalities.
A small population tempering value was used to avoid losing diversity at the final step based on initial runs.

## Validation

![image](https://user-images.githubusercontent.com/28026893/175202481-b0cc3ef1-f63a-4f58-beac-f5880212573b.png)

Full 40,000:
```
SMC: 40,000 sampled plans of 26 districts on 14,191 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.001

Plan diversity 80% range: 0.79 to 0.93

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black 
      1.017778       1.029809       1.002210       1.022183       1.012331       1.010768       1.011560       1.002139 
      pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black 
      1.016379       1.018613       1.018199       1.009705       1.030600       1.007739       1.009024       1.003756 
      vap_aian      vap_asian       vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_sch 
      1.007639       1.018909       1.020302       1.004625       1.010178       1.016468       1.004883       1.057457 
uss_16_rep_lon uss_18_dem_gil uss_18_rep_far gov_18_dem_cuo gov_18_rep_mol atg_18_dem_jam atg_18_rep_wof pre_20_dem_bid 
      1.021692       1.027412       1.005755       1.033585       1.005074       1.032453       1.005685       1.036451 
pre_20_rep_tru         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
      1.006227       1.014265       1.033816       1.005319       1.031190       1.006227       1.036451       1.029211 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
      1.006446       1.035535       1.006265       1.013228       1.013553       1.020514       1.026993       1.014723 
          egap 
      1.023108 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    17,105 (85.5%)     18.0%        0.43 12,610 (100%)     18 
Split 2    16,299 (81.5%)     28.2%        0.46 12,143 ( 96%)     11 
Split 3     9,756 (48.8%)     36.9%        0.51 11,973 ( 95%)      8 
Split 4     9,922 (49.6%)     51.3%        0.54 11,679 ( 92%)      5 
Split 5    12,321 (61.6%)     56.3%        0.56 11,611 ( 92%)      4 
Split 6    10,201 (51.0%)     48.2%        0.57 11,498 ( 91%)      5 
Split 7     9,296 (46.5%)     60.0%        0.58 11,454 ( 91%)      3 
Split 8    11,362 (56.8%)     58.0%        0.59 11,426 ( 90%)      3 
Split 9    10,497 (52.5%)     37.0%        0.58 11,364 ( 90%)      6 
Split 10   11,079 (55.4%)     46.7%        0.59 11,374 ( 90%)      4 
Split 11   10,693 (53.5%)     51.3%        0.61 11,421 ( 90%)      3 
Split 12   10,315 (51.6%)     48.9%        0.62 11,219 ( 89%)      3 
Split 13   10,040 (50.2%)     55.0%        0.63 11,231 ( 89%)      2 
Split 14    7,323 (36.6%)     51.4%        0.62 11,020 ( 87%)      2 
Split 15    7,382 (36.9%)     49.2%        0.82 10,231 ( 81%)      2 
Split 16    8,217 (41.1%)     47.0%        0.85 10,344 ( 82%)      2 
Split 17    8,606 (43.0%)     44.7%        0.88 10,212 ( 81%)      2 
Split 18    7,999 (40.0%)     28.5%        0.89 10,212 ( 81%)      4 
Split 19    7,721 (38.6%)     16.2%        0.89 10,070 ( 80%)      7 
Split 20    7,511 (37.6%)     20.5%        0.90  9,928 ( 79%)      5 
Split 21    6,139 (30.7%)     27.0%        0.90  9,890 ( 78%)      3 
Split 22    5,795 (29.0%)     28.9%        0.89  9,685 ( 77%)      2 
Split 23    7,022 (35.1%)     12.9%        0.86  9,368 ( 74%)      5 
Split 24    3,801 (19.0%)      8.3%        0.88  9,295 ( 74%)      6 
Split 25    7,594 (38.0%)      4.3%        0.79  8,445 ( 67%)      4 
Resample    6,728 (33.6%)       NA%        0.87  9,899 ( 78%)     NA 

Sampling diagnostics for SMC run 2 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    17,130 (85.7%)     26.5%        0.43 12,692 (100%)     12 
Split 2    16,248 (81.2%)     33.9%        0.46 11,946 ( 94%)      9 
Split 3    14,307 (71.5%)     46.4%        0.53 12,030 ( 95%)      6 
Split 4    13,826 (69.1%)     51.3%        0.54 11,735 ( 93%)      5 
Split 5    12,392 (62.0%)     44.0%        0.56 11,605 ( 92%)      6 
Split 6     8,731 (43.7%)     42.8%        0.58 11,458 ( 91%)      6 
Split 7    11,778 (58.9%)     53.1%        0.59 11,255 ( 89%)      4 
Split 8     9,826 (49.1%)     39.9%        0.60 11,395 ( 90%)      6 
Split 9    10,473 (52.4%)     29.5%        0.60 11,307 ( 89%)      8 
Split 10    7,213 (36.1%)     40.8%        0.62 11,260 ( 89%)      5 
Split 11   10,142 (50.7%)     44.8%        0.62 11,168 ( 88%)      4 
Split 12   11,178 (55.9%)     48.8%        0.61 11,279 ( 89%)      3 
Split 13   11,641 (58.2%)     25.9%        0.61 11,226 ( 89%)      7 
Split 14    8,025 (40.1%)     32.4%        0.63 11,290 ( 89%)      5 
Split 15    6,956 (34.8%)     35.9%        0.82 10,211 ( 81%)      4 
Split 16    5,186 (25.9%)     40.3%        0.90 10,113 ( 80%)      3 
Split 17    6,912 (34.6%)     44.1%        0.86  9,730 ( 77%)      2 
Split 18    8,259 (41.3%)     28.9%        0.87 10,087 ( 80%)      4 
Split 19    8,480 (42.4%)     32.7%        0.86 10,122 ( 80%)      3 
Split 20    8,082 (40.4%)     30.0%        0.87 10,066 ( 80%)      3 
Split 21    7,691 (38.5%)     22.0%        0.87 10,085 ( 80%)      4 
Split 22    5,491 (27.5%)     23.5%        0.87  9,889 ( 78%)      3 
Split 23    8,147 (40.7%)     25.2%        0.85  9,632 ( 76%)      2 
Split 24    6,260 (31.3%)     19.8%        0.85  9,416 ( 74%)      2 
Split 25    6,201 (31.0%)      2.6%        0.84  8,620 ( 68%)      7 
Resample    5,270 (26.4%)       NA%        0.92  9,635 ( 76%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more
than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low plan diversity or bottlenecks as well, address
those issues first.
```

Thinned 5,000:
```
SMC: 5,000 sampled plans of 26 districts on 14,191 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.001

Plan diversity 80% range: 0.80 to 0.92

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black 
      1.016363       1.044767       1.002854       1.024087       1.009022       1.009970       1.010395       1.005168 
      pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black 
      1.013461       1.014510       1.013648       1.008038       1.025083       1.009910       1.005954       1.003035 
      vap_aian      vap_asian       vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru uss_16_dem_sch 
      1.006392       1.014438       1.017055       1.001803       1.010610       1.013271       1.005047       1.050575 
uss_16_rep_lon uss_18_dem_gil uss_18_rep_far gov_18_dem_cuo gov_18_rep_mol atg_18_dem_jam atg_18_rep_wof pre_20_dem_bid 
      1.021334       1.023798       1.006378       1.029947       1.005677       1.029048       1.006460       1.032472 
pre_20_rep_tru         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
      1.006549       1.014065       1.037519       1.006040       1.027816       1.006549       1.032472       1.027637 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
      1.010655       1.030950       1.006641       1.010450       1.010720       1.019210       1.025588       1.013875 
          egap 
      1.022681 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    17,105 (85.5%)     18.0%        0.43 12,610 (100%)     18 
Split 2    16,299 (81.5%)     28.2%        0.46 12,143 ( 96%)     11 
Split 3     9,756 (48.8%)     36.9%        0.51 11,973 ( 95%)      8 
Split 4     9,922 (49.6%)     51.3%        0.54 11,679 ( 92%)      5 
Split 5    12,321 (61.6%)     56.3%        0.56 11,611 ( 92%)      4 
Split 6    10,201 (51.0%)     48.2%        0.57 11,498 ( 91%)      5 
Split 7     9,296 (46.5%)     60.0%        0.58 11,454 ( 91%)      3 
Split 8    11,362 (56.8%)     58.0%        0.59 11,426 ( 90%)      3 
Split 9    10,497 (52.5%)     37.0%        0.58 11,364 ( 90%)      6 
Split 10   11,079 (55.4%)     46.7%        0.59 11,374 ( 90%)      4 
Split 11   10,693 (53.5%)     51.3%        0.61 11,421 ( 90%)      3 
Split 12   10,315 (51.6%)     48.9%        0.62 11,219 ( 89%)      3 
Split 13   10,040 (50.2%)     55.0%        0.63 11,231 ( 89%)      2 
Split 14    7,323 (36.6%)     51.4%        0.62 11,020 ( 87%)      2 
Split 15    7,382 (36.9%)     49.2%        0.82 10,231 ( 81%)      2 
Split 16    8,217 (41.1%)     47.0%        0.85 10,344 ( 82%)      2 
Split 17    8,606 (43.0%)     44.7%        0.88 10,212 ( 81%)      2 
Split 18    7,999 (40.0%)     28.5%        0.89 10,212 ( 81%)      4 
Split 19    7,721 (38.6%)     16.2%        0.89 10,070 ( 80%)      7 
Split 20    7,511 (37.6%)     20.5%        0.90  9,928 ( 79%)      5 
Split 21    6,139 (30.7%)     27.0%        0.90  9,890 ( 78%)      3 
Split 22    5,795 (29.0%)     28.9%        0.89  9,685 ( 77%)      2 
Split 23    7,022 (35.1%)     12.9%        0.86  9,368 ( 74%)      5 
Split 24    3,801 (19.0%)      8.3%        0.88  9,295 ( 74%)      6 
Split 25    7,594 (38.0%)      4.3%        0.79  8,445 ( 67%)      4 
Resample    6,728 (33.6%)       NA%        0.87  9,899 ( 78%)     NA 

Sampling diagnostics for SMC run 2 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    17,130 (85.7%)     26.5%        0.43 12,692 (100%)     12 
Split 2    16,248 (81.2%)     33.9%        0.46 11,946 ( 94%)      9 
Split 3    14,307 (71.5%)     46.4%        0.53 12,030 ( 95%)      6 
Split 4    13,826 (69.1%)     51.3%        0.54 11,735 ( 93%)      5 
Split 5    12,392 (62.0%)     44.0%        0.56 11,605 ( 92%)      6 
Split 6     8,731 (43.7%)     42.8%        0.58 11,458 ( 91%)      6 
Split 7    11,778 (58.9%)     53.1%        0.59 11,255 ( 89%)      4 
Split 8     9,826 (49.1%)     39.9%        0.60 11,395 ( 90%)      6 
Split 9    10,473 (52.4%)     29.5%        0.60 11,307 ( 89%)      8 
Split 10    7,213 (36.1%)     40.8%        0.62 11,260 ( 89%)      5 
Split 11   10,142 (50.7%)     44.8%        0.62 11,168 ( 88%)      4 
Split 12   11,178 (55.9%)     48.8%        0.61 11,279 ( 89%)      3 
Split 13   11,641 (58.2%)     25.9%        0.61 11,226 ( 89%)      7 
Split 14    8,025 (40.1%)     32.4%        0.63 11,290 ( 89%)      5 
Split 15    6,956 (34.8%)     35.9%        0.82 10,211 ( 81%)      4 
Split 16    5,186 (25.9%)     40.3%        0.90 10,113 ( 80%)      3 
Split 17    6,912 (34.6%)     44.1%        0.86  9,730 ( 77%)      2 
Split 18    8,259 (41.3%)     28.9%        0.87 10,087 ( 80%)      4 
Split 19    8,480 (42.4%)     32.7%        0.86 10,122 ( 80%)      3 
Split 20    8,082 (40.4%)     30.0%        0.87 10,066 ( 80%)      3 
Split 21    7,691 (38.5%)     22.0%        0.87 10,085 ( 80%)      4 
Split 22    5,491 (27.5%)     23.5%        0.87  9,889 ( 78%)      3 
Split 23    8,147 (40.7%)     25.2%        0.85  9,632 ( 76%)      2 
Split 24    6,260 (31.3%)     19.8%        0.85  9,416 ( 74%)      2 
Split 25    6,201 (31.0%)      2.6%        0.84  8,620 ( 68%)      7 
Resample    5,270 (26.4%)       NA%        0.92  9,635 ( 76%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more
than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low plan diversity or bottlenecks as well, address
those issues first.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
