### PR TITLE
Re-run 2020 Texas Congressional Districts

### DIFF
--- a/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
@@ -57,7 +57,7 @@ n_steps <- (sum(m1$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2020)
 houston_plans <- redist_smc(m1, counties = county,
-    nsims = nsims, n_steps = n_steps,
+    nsims = nsims, n_steps = n_steps, runs = 2L,
     constraints = constraints)
 
 #############################################################
@@ -102,7 +102,7 @@ n_steps <- (sum(m2$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2020)
 austin_plans <- redist_smc(m2, counties = county,
-    nsims = nsims, n_steps = n_steps,
+    nsims = nsims, n_steps = n_steps, runs = 2L,
     constraints = constraints)
 
 #########################################################################
@@ -150,7 +150,7 @@ n_steps <- (sum(m3$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2020)
 dallas_plans <- redist_smc(m3, counties = county,
-    nsims = nsims, n_steps = n_steps,
+    nsims = nsims, n_steps = n_steps, runs = 2L,
     constraints = constraints)
 
 #############################################################
@@ -196,7 +196,7 @@ constraints <- redist_constr(map) %>%
         tgts_group = c(0.45))
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = nsims,
+plans <- redist_smc(map, nsims = nsims, runs = 2L,
     counties = county, verbose = TRUE,
     constraints = constraints, init_particles = prep_mat,
     pop_temper = 0.01)

--- a/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
@@ -55,6 +55,7 @@ constraints <- redist_constr(m1) %>%
 
 n_steps <- (sum(m1$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
+set.seed(2020)
 houston_plans <- redist_smc(m1, counties = county,
     nsims = nsims, n_steps = n_steps,
     constraints = constraints)
@@ -99,6 +100,7 @@ constraints <- redist_constr(m2) %>%
 
 n_steps <- (sum(m2$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
+set.seed(2020)
 austin_plans <- redist_smc(m2, counties = county,
     nsims = nsims, n_steps = n_steps,
     constraints = constraints)
@@ -146,6 +148,7 @@ constraints <- redist_constr(m3) %>%
 
 n_steps <- (sum(m3$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
+set.seed(2020)
 dallas_plans <- redist_smc(m3, counties = county,
     nsims = nsims, n_steps = n_steps,
     constraints = constraints)
@@ -192,6 +195,7 @@ constraints <- redist_constr(map) %>%
         total_pop = cvap,
         tgts_group = c(0.45))
 
+set.seed(2020)
 plans <- redist_smc(map, nsims = nsims,
     counties = county, verbose = TRUE,
     constraints = constraints, init_particles = prep_mat,

--- a/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
@@ -291,6 +291,11 @@ plans <- plans %>%
     mutate(district = as.numeric(district)) %>%
     add_reference(ref_plan = as.numeric(map$cd_2020))
 
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
@@ -303,13 +308,6 @@ cli_process_start("Computing summary statistics for {.pkg TX_cd_2020}")
 
 plans <- add_summary_stats(plans, map) %>%
     mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
-
-summary(plans)
-
-plans <- plans %>%
-    group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
-    ungroup()
 
 summary(plans)
 

--- a/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
@@ -48,13 +48,13 @@ constraints <- redist_constr(m1) %>%
         tgts_group = c(0.45)
     ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_hisp,
-                         cvap,
-                         0.35) %>%
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_hisp,
-                             cvap,
-                             0.70) %>%
+        cvap_hisp,
+        cvap,
+        0.70) %>%
     #########################################################
     # BLACK
     add_constr_grp_hinge(
@@ -76,10 +76,10 @@ houston_plans <- redist_smc(m1, counties = county,
 
 houston_plans <- houston_plans %>%
     mutate(hvap = group_frac(m1, cvap_hisp, cvap),
-            bvap = group_frac(m1, cvap_black, cvap),
-            dem16 = group_frac(m1, adv_16, arv_16 + adv_16),
-            dem18 = group_frac(m1, adv_18, arv_18 + adv_18),
-            dem20 = group_frac(m1, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m1, cvap_black, cvap),
+        dem16 = group_frac(m1, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m1, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m1, adv_20, arv_20 + adv_20))
 
 summary(houston_plans)
 
@@ -119,14 +119,14 @@ constraints <- redist_constr(m2) %>%
         total_pop = cvap,
         tgts_group = c(0.45)
     ) %>%
-        add_constr_grp_hinge(-3,
-                             cvap_hisp,
-                             cvap,
-                             0.35) %>%
-        add_constr_grp_inv_hinge(3,
-                                 cvap_hisp,
-                                 cvap,
-                                 0.70) %>%
+    add_constr_grp_hinge(-3,
+        cvap_hisp,
+        cvap,
+        0.35) %>%
+    add_constr_grp_inv_hinge(3,
+        cvap_hisp,
+        cvap,
+        0.70) %>%
     #########################################################
     add_constr_custom(strength = 10, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
@@ -141,10 +141,10 @@ austin_plans <- redist_smc(m2, counties = county,
 
 austin_plans <- austin_plans %>%
     mutate(hvap = group_frac(m2, cvap_hisp, cvap),
-           bvap = group_frac(m2, cvap_black, cvap),
-           dem16 = group_frac(m2, adv_16, arv_16 + adv_16),
-           dem18 = group_frac(m2, adv_18, arv_18 + adv_18),
-           dem20 = group_frac(m2, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m2, cvap_black, cvap),
+        dem16 = group_frac(m2, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m2, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m2, adv_20, arv_20 + adv_20))
 
 summary(austin_plans)
 #########################################################################
@@ -181,14 +181,14 @@ constraints <- redist_constr(m3) %>%
         total_pop = cvap,
         tgts_group = c(0.45)
     ) %>%
-        add_constr_grp_hinge(-3,
-                             cvap_hisp,
-                             cvap,
-                             0.35) %>%
-        add_constr_grp_inv_hinge(3,
-                                 cvap_hisp,
-                                 cvap,
-                                 0.70) %>%
+    add_constr_grp_hinge(-3,
+        cvap_hisp,
+        cvap,
+        0.35) %>%
+    add_constr_grp_inv_hinge(3,
+        cvap_hisp,
+        cvap,
+        0.70) %>%
 
     add_constr_grp_hinge(
         5,
@@ -208,10 +208,10 @@ dallas_plans <- redist_smc(m3, counties = county,
 
 dallas_plans <- dallas_plans %>%
     mutate(hvap = group_frac(m3, cvap_hisp, cvap),
-           bvap = group_frac(m3, cvap_black, cvap),
-           dem16 = group_frac(m3, adv_16, arv_16 + adv_16),
-           dem18 = group_frac(m3, adv_18, arv_18 + adv_18),
-           dem20 = group_frac(m3, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m3, cvap_black, cvap),
+        dem16 = group_frac(m3, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m3, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m3, adv_20, arv_20 + adv_20))
 
 summary(dallas_plans)
 
@@ -227,7 +227,7 @@ tx_plan_list <- list(list(map = m1, plans = houston_plans),
     list(map = m3, plans = dallas_plans))
 
 prep_mat <- prep_particles(map = map, map_plan_list = tx_plan_list,
-    uid = row_id, dist_keep = dist_keep, nsims = nsims * 2)
+    uid = row_id, dist_keep = dist_keep, nsims = nsims*2)
 
 ## Check contiguity
 if (FALSE) {
@@ -253,14 +253,14 @@ constraints <- redist_constr(map) %>%
         total_pop = cvap,
         tgts_group = c(0.45)
     ) %>%
-        add_constr_grp_hinge(-3,
-                             cvap_hisp,
-                             cvap,
-                             0.35) %>%
-        add_constr_grp_inv_hinge(3,
-                                 cvap_hisp,
-                                 cvap,
-                                 0.70) %>%
+    add_constr_grp_hinge(-3,
+        cvap_hisp,
+        cvap,
+        0.35) %>%
+    add_constr_grp_inv_hinge(3,
+        cvap_hisp,
+        cvap,
+        0.70) %>%
     add_constr_grp_hinge(
         3,
         cvap_black,
@@ -268,17 +268,17 @@ constraints <- redist_constr(map) %>%
         tgts_group = c(0.45)
     ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_black,
-                         cvap,
-                         0.35) %>%
+        cvap_black,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_black,
-                             cvap,
-                             0.70)
+        cvap_black,
+        cvap,
+        0.70)
 
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = nsims * 2, runs = 2L,
+plans <- redist_smc(map, nsims = nsims*2, runs = 2L,
     counties = county, verbose = TRUE,
     constraints = constraints, init_particles = prep_mat,
     pop_temper = pop_temp, seq_alpha = sa)
@@ -302,12 +302,12 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg TX_cd_2020}")
 
 plans <- add_summary_stats(plans, map) %>%
-    mutate(total_cvap = tally_var(map, cvap), .after=total_vap)
+    mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
 
 summary(plans)
 
 # cvap columns
-cvap_cols = names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
+cvap_cols <- names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
 for (col in rev(cvap_cols)) {
     plans <- mutate(plans, {{ col }} := tally_var(map, map[[col]]), .after = vap_two)
 }
@@ -318,4 +318,3 @@ save_summary_stats(plans, "data-out/TX_2020/TX_cd_2020_stats.csv")
 cli_process_done()
 
 validate_analysis(plans, map)
-

--- a/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/03_sim_TX_cd_2020.R
@@ -306,6 +306,13 @@ plans <- add_summary_stats(plans, map) %>%
 
 summary(plans)
 
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+summary(plans)
+
 # cvap columns
 cvap_cols <- names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
 for (col in rev(cvap_cols)) {

--- a/analyses/TX_cd_2020/04_diagnostics_TX_cd_2020.R
+++ b/analyses/TX_cd_2020/04_diagnostics_TX_cd_2020.R
@@ -8,27 +8,27 @@ library(patchwork)
 i <- 25
 p1 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 35
 p2 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 45
 p3 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 11
 p4 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 8
 p5 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 5
 p6 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 
 ggsave("data-raw/houston.pdf", (p1 + p2 + p3)/(p4 + p5 + p6), width = 20, height = 20)
 
@@ -112,9 +112,9 @@ psum <- plans %>%
     summarise(
         all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
         dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (nrv > ndv))
+            (nrv > ndv))
     )
 
 p1 <- redist.plot.hist(psum, all_hcvap)
@@ -129,14 +129,14 @@ psum <- plans %>%
     summarise(
         all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
         dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (nrv > ndv)),
+            (nrv > ndv)),
         all_bcvap = sum((cvap_black/total_cvap) > 0.4),
         dem_bcvap = sum((cvap_black/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_bcvap = sum((cvap_black/total_cvap) > 0.4 &
-                            (nrv > ndv)),
+            (nrv > ndv)),
         mmd_all = sum(cvap_nonwhite/total_cvap > 0.5),
         mmd_coalition = sum(((
             cvap_hisp + cvap_black
@@ -163,7 +163,7 @@ ggsave("bcvap_zoom.pdf", p)
 p <- plans %>%
     group_by(draw) %>%
     mutate(cvap_nonwhite = total_cvap - cvap_white,
-           cvap_nw_prop = cvap_nonwhite/total_cvap)  %>%
+        cvap_nw_prop = cvap_nonwhite/total_cvap)  %>%
     redist.plot.distr_qtys(
         cvap_nw_prop,
         color = ifelse(

--- a/analyses/TX_cd_2020/doc_TX_cd_2020.md
+++ b/analyses/TX_cd_2020/doc_TX_cd_2020.md
@@ -16,7 +16,7 @@ R package.
 We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
 
 ## Simulation Notes
-We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm.
+We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm, then filter down to 5,000 total plans.
 Due to the size and complexity of Texas, we split the simulations into
 multiple steps.
 

--- a/analyses/TX_cd_2020/doc_TX_cd_2020.md
+++ b/analyses/TX_cd_2020/doc_TX_cd_2020.md
@@ -13,10 +13,10 @@ Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](ht
 ## Pre-processing Notes
 We estimate CVAP populations with the [`cvap`](https://github.com/christopherkenny/cvap)
 R package.
-We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of redistrict plans that will be sampled.
+We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Texas.
+We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm.
 Due to the size and complexity of Texas, we split the simulations into
 multiple steps.
 
@@ -43,13 +43,13 @@ Because each cluster will have leftover population, we apply an additional const
 incentivizes leaving any unassigned areas on the edge of these clusters to
 avoid discontiguities.
 
-In each cluster, we apply hinge Gibbs constraints of strength 20 to encourage
+In each cluster, we apply hinge Gibbs constraints of strength 3 to encourage
 the formation of Hispanic CVAP opportunity districts.
-In Houston, we also apply a hinge Gibbs constraint of strength 10 to encourage
+In Houston, we also apply a hinge Gibbs constraint of strength 3 to encourage
 the formation of Black CVAP opportunity districts.
+These districts nudge the formation of opportunity districts are above 35%, and penalize districts with minority populations above 70%.
 
 ### 2. Combination procedure
 Then, these partial map simulations are combined to run statewide simulations.
 We again apply Gibbs hing constraints to encourage the formation of minority
-opportunity districts, though with weaker strength since most of these
-districts are found in our clusters.
+opportunity districts.


### PR DESCRIPTION
## Redistricting requirements
In Texas, districts must meet US constitutional requirements, but there are 
[no state-specific statutes](https://redistricting.capitol.texas.gov/reqs#congress-section).

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
We estimate CVAP populations with the [`cvap`](https://github.com/christopherkenny/cvap)
R package.
We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.

## Simulation Notes
We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm.
Due to the size and complexity of Texas, we split the simulations into
multiple steps.

### 1. Clustering procedure
First, we run simulations in three major metropolitan areas:
Greater Houston, a combination of Greater San Antonio and Austin, and
Dallas-Fort Worth. We use collections of counties that define the
Metropolitan Statistical Areas.
The counties in each cluster are those in each Census MSA:

* Houston–The Woodlands–Sugar Land: Austin, Brazoria, Chambers, Fort Bend,
Galveston, Harris, Liberty, Montgomery, Waller.

* Austin–Round Rock-Georgetown: Bastrop, Caldwell, Hays, Travis, Williamson.

* San Antonio–New Braunfels: Atascosa, Bandera, Bexar, Comal, Guadalupe,
    Kendall, Medina, Wilson.
    
* Dallas–Fort Worth–Arlington: Collin, Dallas, Denton, Ellis, Hunt,
Kaufman, Rockwall, Johnson, Parker, Tarrant, Wise.

These simulations run the SMC algorithm within each cluster with a 0.25% population tolerance.
Because each cluster will have leftover population, we apply an additional constraint that
incentivizes leaving any unassigned areas on the edge of these clusters to
avoid discontiguities.

In each cluster, we apply hinge Gibbs constraints of strength 3 to encourage
the formation of Hispanic CVAP opportunity districts.
In Houston, we also apply a hinge Gibbs constraint of strength 3 to encourage
the formation of Black CVAP opportunity districts.
These districts nudge the formation of opportunity districts are above 35%, and penalize districts with minority populations above 70%.

### 2. Combination procedure
Then, these partial map simulations are combined to run statewide simulations.
We again apply Gibbs hing constraints to encourage the formation of minority
opportunity districts.


## Validation

![validation_20220623_1107](https://user-images.githubusercontent.com/4583367/175359979-a5031c04-5d5f-4b5d-b521-9b83e07cf061.png)

![image](https://user-images.githubusercontent.com/4583367/175360034-7c65ee22-a8b6-4b80-a3d3-ec593d059803.png)


```
SMC: 50,000 sampled plans of 38 districts on 9,007 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.03

Plan diversity 80% range: 0.79 to 0.89

R-hat values for summary statistics:
   pop_overlap      total_vap     total_cvap       plan_dev 
      1.009922       1.025592       1.018034       1.007017 
     comp_edge    comp_polsby       pop_hisp      pop_white 
      1.003834       1.005717       1.004403       1.012172 
     pop_black       pop_aian      pop_asian       pop_nhpi 
      1.019157       1.001467       1.005970       1.002071 
     pop_other        pop_two       vap_hisp      vap_white 
      1.002121       1.000102       1.006503       1.012468 
     vap_black       vap_aian      vap_asian       vap_nhpi 
      1.016500       1.000702       1.009907       1.020889 
     vap_other        vap_two     cvap_white     cvap_black 
      1.005935       1.002453       1.002304       1.021917 
     cvap_hisp     cvap_asian      cvap_aian      cvap_nhpi 
      1.008579       1.028057       1.000806       1.004785 
      cvap_two     cvap_other pre_16_rep_tru pre_16_dem_cli 
      1.000146       1.016484       1.008993       1.010982 
uss_18_rep_cru uss_18_dem_oro gov_18_rep_abb gov_18_dem_val 
      1.012814       1.061978       1.015099       1.046836 
atg_18_rep_pax atg_18_dem_nel pre_20_rep_tru pre_20_dem_bid 
      1.013984       1.054138       1.016592       1.040385 
uss_20_rep_cor uss_20_dem_heg         arv_16         adv_16 
      1.019423       1.039547       1.008993       1.010982 
        arv_18         adv_18         arv_20         adv_20 
      1.013342       1.055268       1.016730       1.041282 
 county_splits    muni_splits            ndv            nrv 
      1.025081       1.014260       1.043716       1.015216 
       ndshare          e_dvs          e_dem          pbias 
      1.007986       1.008231       1.019652       1.023839 
          egap 
      1.029078 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    13,837 (55.3%)     23.3%        0.55 15,809 (100%)      7 
Split 2    12,745 (51.0%)     28.2%        0.64 13,598 ( 86%)      5 
Split 3    11,201 (44.8%)     18.9%        0.65 13,138 ( 83%)      7 
Split 4    10,533 (42.1%)     11.1%        0.68 13,032 ( 82%)     11 
Split 5     9,340 (37.4%)     15.7%        0.69 12,722 ( 81%)      7 
Split 6     7,665 (30.7%)     16.7%        0.71 12,296 ( 78%)      6 
Split 7     7,968 (31.9%)     21.5%        0.71 11,792 ( 75%)      4 
Split 8     8,271 (33.1%)     23.7%        0.72 11,767 ( 74%)      3 
Split 9     7,850 (31.4%)     26.3%        0.72 11,580 ( 73%)      2 
Split 10    7,846 (31.4%)     17.0%        0.73 11,149 ( 71%)      3 
Split 11    7,281 (29.1%)     11.5%        0.78 10,520 ( 67%)      4 
Split 12    7,058 (28.2%)     10.1%        0.80 10,197 ( 65%)      3 
Split 13    4,406 (17.6%)      3.2%        0.73  9,618 ( 61%)      2 
Resample    2,961 (11.8%)       NA%        1.44  8,915 ( 56%)     NA 

Sampling diagnostics for SMC run 2 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    14,235 (56.9%)     16.6%        0.55 15,810 (100%)     10 
Split 2    12,875 (51.5%)     23.9%        0.64 13,538 ( 86%)      6 
Split 3    11,304 (45.2%)     30.2%        0.65 13,227 ( 84%)      4 
Split 4    11,586 (46.3%)     34.0%        0.67 12,938 ( 82%)      3 
Split 5    10,172 (40.7%)     15.7%        0.67 12,753 ( 81%)      7 
Split 6     8,921 (35.7%)     23.6%        0.70 12,437 ( 79%)      4 
Split 7     8,191 (32.8%)     21.5%        0.71 11,894 ( 75%)      4 
Split 8     7,489 (30.0%)     24.2%        0.73 11,616 ( 74%)      3 
Split 9     7,201 (28.8%)     26.7%        0.72 11,422 ( 72%)      2 
Split 10    7,459 (29.8%)      8.2%        0.73 11,060 ( 70%)      7 
Split 11    7,404 (29.6%)     12.6%        0.78 10,219 ( 65%)      4 
Split 12    7,128 (28.5%)      9.1%        0.74 10,889 ( 69%)      3 
Split 13    4,214 (16.9%)      2.0%        0.73  8,795 ( 56%)      4 
Resample    3,413 (13.7%)       NA%        1.50  9,242 ( 58%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less
than 1%), large std. devs. of the log weights (more than 3 or so), and
low numbers of unique plans. R-hat values for summary statistics should
be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are
experiencing low plan diversity or bottlenecks as well, address those
issues first.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
@christopherkenny
