### PR TITLE
Re-run 2020 North Carolina Congressional Districts

### DIFF
--- a/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
+++ b/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
@@ -7,9 +7,9 @@
 cli_process_start("Running simulations for {.pkg NC_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(15, vap_black, vap, 0.33) %>%
-    add_constr_grp_hinge(-15, vap_black, vap, 0.30) %>%
-    add_constr_grp_inv_hinge(10, vap_black, vap, 0.37)
+    add_constr_grp_hinge(35, vap_black, vap, 0.33) %>%
+    add_constr_grp_hinge(-35, vap_black, vap, 0.30) %>%
+    add_constr_grp_inv_hinge(20, vap_black, vap, 0.37)
 
 set.seed(2020)
 plans <- redist_smc(map, nsims = 10e3,
@@ -17,27 +17,29 @@ plans <- redist_smc(map, nsims = 10e3,
     compactness = 1,
     counties = pseudo_county,
     constraints = constr,
-    pop_temper = 0.01) %>%
+    pop_temper = 0.01)
+
+plans_5k <- plans %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
-plans <- match_numbers(plans, "cd_2020")
+plans_5k <- match_numbers(plans_5k, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 # Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/NC_2020/NC_cd_2020_plans.rds"), compress = "xz")
+write_rds(plans_5k, here("data-out/NC_2020/NC_cd_2020_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg NC_cd_2020}")
 
-plans <- add_summary_stats(plans, map)
+plans_5k <- add_summary_stats(plans_5k, map)
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/NC_2020/NC_cd_2020_stats.csv")
+save_summary_stats(plans_5k, "data-out/NC_2020/NC_cd_2020_stats.csv")
 
 cli_process_done()
 
@@ -46,20 +48,29 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    redist.plot.distr_qtys(plans, vap_black/total_vap,
+    redist.plot.distr_qtys(plans_5k, vap_black/total_vap,
         color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        color = ifelse(subset_sampled(plans_5k)$ndv > subset_sampled(plans_5k)$nrv, "#3D77BB", "#B25D4C"),
         size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
         labs(title = "North Carolina Proposed Plan versus Simulations") +
         scale_color_manual(values = c(cd_2020_prop = "black"))
 
-    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
-        scale_y_continuous("Percent Black by VAP") +
-        labs(title = "North Carolina Proposed Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020_prop = "black"))
+    # Dem seats by BVAP rank -- numeric
+    plans_5k %>%
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans_5k %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
 
 }

--- a/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
+++ b/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
@@ -7,13 +7,12 @@
 cli_process_start("Running simulations for {.pkg NC_cd_2020}")
 
 constr <- redist_constr(map) %>%
-    add_constr_splits(1, admin = county) %>%
-    add_constr_grp_hinge(23, vap_black, vap, 0.34) %>%
-    add_constr_grp_hinge(-20, vap_black, vap, 0.3) %>%
-    add_constr_grp_inv_hinge(10, vap_black, vap, 0.38)
+    add_constr_grp_hinge(15, vap_black, vap, 0.33) %>%
+    add_constr_grp_hinge(-15, vap_black, vap, 0.30) %>%
+    add_constr_grp_inv_hinge(10, vap_black, vap, 0.37)
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = 15e3,
+plans <- redist_smc(map, nsims = 10e3,
     runs = 2L,
     compactness = 1,
     counties = pseudo_county,

--- a/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
+++ b/analyses/NC_cd_2020/03_sim_NC_cd_2020.R
@@ -8,12 +8,12 @@ cli_process_start("Running simulations for {.pkg NC_cd_2020}")
 
 constr <- redist_constr(map) %>%
     add_constr_splits(1, admin = county) %>%
-    add_constr_grp_hinge(25, vap_black, vap, 0.34) %>%
-    add_constr_grp_hinge(-25, vap_black, vap, 0.3) %>%
-    add_constr_grp_inv_hinge(15, vap_black, vap, 0.39)
+    add_constr_grp_hinge(23, vap_black, vap, 0.34) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(10, vap_black, vap, 0.38)
 
 set.seed(2020)
-plans <- redist_smc(map, nsims = 5e3,
+plans <- redist_smc(map, nsims = 15e3,
     runs = 2L,
     compactness = 1,
     counties = pseudo_county,

--- a/analyses/NC_cd_2020/doc_NC_cd_2020.md
+++ b/analyses/NC_cd_2020/doc_NC_cd_2020.md
@@ -11,7 +11,6 @@ In North Carolina, under [North Carolina State Constitution Article II Sections 
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
-We add a county constraint.
 We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
 
 ## Data Sources

--- a/analyses/NC_cd_2020/doc_NC_cd_2020.md
+++ b/analyses/NC_cd_2020/doc_NC_cd_2020.md
@@ -21,4 +21,4 @@ Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data 
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 6,000 districting plans for North Carolina and subset to 5,000 which contain at least two majority-minority districts.
+We sample 36,000 districting plans for North Carolina across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.

--- a/analyses/NC_cd_2020/doc_NC_cd_2020.md
+++ b/analyses/NC_cd_2020/doc_NC_cd_2020.md
@@ -12,7 +12,7 @@ In North Carolina, under [North Carolina State Constitution Article II Sections 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
 We add a county constraint.
-We add a VRA constraint targeting two majority-minority districts.
+We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
 
 ## Data Sources
 Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 North Carolina ratified congressional map comes from the [North Carolina General Assembly](https://www.ncleg.gov/Redistricting).
@@ -21,4 +21,4 @@ Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data 
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 36,000 districting plans for North Carolina across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.
+We sample 20,000 districting plans for North Carolina across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.


### PR DESCRIPTION
## Redistricting requirements
In North Carolina, under [North Carolina State Constitution Article II Sections 3 & 5](https://www.ncleg.gov/Laws/Constitution/Article2), districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county boundaries as much as possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.

## Data Sources
Data for North Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2022 North Carolina ratified congressional map comes from the [North Carolina General Assembly](https://www.ncleg.gov/Redistricting).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for North Carolina across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.

## Validation

![image](https://user-images.githubusercontent.com/55368740/175795614-843f9852-83e9-499c-b7b0-c2d31ea3b222.png)

```
SMC: 20,000 sampled plans of 14 districts on 2,666 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0.01

Plan diversity 80% range: 0.69 to 0.87

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian 
      1.011740       1.004010       1.016022       1.006402       1.007232       1.011292       1.001015       1.008898       1.000115 
     pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
      1.027659       1.001441       1.040853       1.000344       1.011211       1.001468       1.005998       1.000307       1.030569 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli uss_16_rep_bur uss_16_dem_ros gov_16_rep_mcc gov_16_dem_coo 
      1.006742       1.039742       1.003739       1.014649       1.041666       1.011259       1.037633       1.011370       1.036032 
atg_16_rep_new atg_16_dem_ste sos_16_rep_lap sos_16_dem_mar pre_20_rep_tru pre_20_dem_bid uss_20_rep_til uss_20_dem_cun gov_20_rep_for 
      1.012634       1.036626       1.010377       1.033683       1.012790       1.048726       1.009076       1.047310       1.013620 
gov_20_dem_coo atg_20_rep_one atg_20_dem_ste sos_20_rep_syk sos_20_dem_mar         arv_16         adv_16         arv_20         adv_20 
      1.046216       1.009898       1.044914       1.009182       1.044455       1.010635       1.036324       1.010868       1.046275 
 county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
      1.004991       1.014032       1.043048       1.012762       1.028974       1.028886       1.044242       1.006234       1.006050 
          egap 
      1.004837 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,041 (80.4%)     11.5%        0.43 6,354 (101%)     12 
Split 2     7,829 (78.3%)     17.7%        0.54 5,974 ( 95%)      7 
Split 3     7,698 (77.0%)     22.3%        0.61 5,852 ( 93%)      5 
Split 4     7,560 (75.6%)     31.0%        0.65 5,867 ( 93%)      3 
Split 5     7,423 (74.2%)     18.4%        0.68 5,671 ( 90%)      5 
Split 6     7,445 (74.5%)     20.7%        0.70 5,740 ( 91%)      4 
Split 7     7,552 (75.5%)     19.2%        0.72 5,709 ( 90%)      4 
Split 8     7,442 (74.4%)     23.1%        0.71 5,675 ( 90%)      3 
Split 9     7,390 (73.9%)     21.1%        0.73 5,696 ( 90%)      3 
Split 10    7,515 (75.2%)     14.3%        0.73 5,664 ( 90%)      4 
Split 11    7,669 (76.7%)     15.5%        0.72 5,482 ( 87%)      3 
Split 12    7,820 (78.2%)     11.8%        0.70 5,334 ( 84%)      3 
Split 13    7,423 (74.2%)      4.0%        0.77 4,850 ( 77%)      3 
Resample    2,891 (28.9%)       NA%        1.21 4,691 ( 74%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,087 (80.9%)     15.5%        0.43 6,267 ( 99%)      9 
Split 2     7,872 (78.7%)     20.2%        0.54 5,938 ( 94%)      6 
Split 3     7,650 (76.5%)     21.9%        0.60 5,908 ( 93%)      5 
Split 4     7,565 (75.7%)     24.5%        0.65 5,812 ( 92%)      4 
Split 5     7,380 (73.8%)     18.5%        0.68 5,786 ( 92%)      5 
Split 6     7,431 (74.3%)     27.1%        0.71 5,693 ( 90%)      3 
Split 7     7,455 (74.6%)     19.4%        0.73 5,683 ( 90%)      4 
Split 8     7,509 (75.1%)     23.0%        0.73 5,720 ( 90%)      3 
Split 9     7,523 (75.2%)     12.8%        0.71 5,734 ( 91%)      5 
Split 10    7,509 (75.1%)     13.9%        0.70 5,664 ( 90%)      4 
Split 11    7,403 (74.0%)      9.4%        0.74 5,542 ( 88%)      5 
Split 12    7,589 (75.9%)     11.9%        0.73 5,351 ( 85%)      3 
Split 13    7,744 (77.4%)      4.1%        0.72 4,926 ( 78%)      3 
Resample    3,593 (35.9%)       NA%        1.15 4,889 ( 77%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Performance plot for BVAP.
![image](https://user-images.githubusercontent.com/55368740/175795663-d4e76a9e-280f-436f-8c9f-f72d08202c7c.png)


@kuriwaki
@christopherkenny 