### PR TITLE
Rerun 2020 Illinois Congressional Districts

### DIFF
--- a/analyses/IL_cd_2020/01_prep_IL_cd_2020.R
+++ b/analyses/IL_cd_2020/01_prep_IL_cd_2020.R
@@ -62,7 +62,7 @@ if (!file.exists(here(shp_path))) {
         .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = il_shp,
+    redistmetrics::prep_perims(shp = il_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/IL_cd_2020/02_setup_IL_cd_2020.R
+++ b/analyses/IL_cd_2020/02_setup_IL_cd_2020.R
@@ -9,7 +9,7 @@ map <- redist_map(il_shp, pop_tol = 0.005,
 
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "IL_2020"

--- a/analyses/IL_cd_2020/03_sim_IL_cd_2020.R
+++ b/analyses/IL_cd_2020/03_sim_IL_cd_2020.R
@@ -8,10 +8,18 @@ cli_process_start("Running simulations for {.pkg IL_cd_2020}")
 
 constr <- redist_constr(map) %>%
     add_constr_grp_hinge(20, vap_black, vap, tgts_group = 0.55) %>%
-    add_constr_grp_hinge(20, vap_hisp, vap, tgts_group = 0.55)
+    add_constr_grp_hinge(-20, vap_black, vap, tgts_group = 0.45) %>%
+    add_constr_grp_inv_hinge(10, vap_black, vap, tgts_group = 0.60) %>%
+    add_constr_grp_hinge(20, vap_hisp, vap, tgts_group = 0.55) %>%
+    add_constr_grp_hinge(-20, vap_hisp, vap, tgts_group = 0.44)
 
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county,
-    constraints = constr)
+set.seed(2020)
+plans <- redist_smc(map, nsims = 3e4, runs = 2L, counties = pseudo_county,
+    pop_temper = 0.01) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -24,6 +32,8 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg IL_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
+
+summary(plans)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/IL_2020/IL_cd_2020_stats.csv")
@@ -47,19 +57,19 @@ if (interactive()) {
         ggredist::theme_r21()
     ggsave("figs/performance.pdf", height = 7, width = 7)
 
-    fake_map <- map
-    fake_map$Enacted <- get_plans_matrix(plans)[,1000]
-    fake_map %>%
-        group_by(Enacted) %>%
-        summarize(geometry = st_union(geometry),
-                  hisp = sum(vap_hisp) / sum(vap)) %>%
-        ggplot() +
-        geom_sf(aes(fill = hisp), lwd = 0.25) +
-        # geom_sf(data = ctys, fill = NA, lwd = 2.5, alpha = 0.3, color = "grey") +
-        # geom_sf(data = dists, fill = NA, lwd = 1) +
-        geom_sf(data = fake_map, fill = NA, lwd = 0) +
-        theme_void()
-    # coord_sf(xlim=c(bbox$xmin, bbox$xmax),
-    #          ylim=c(bbox$ymin, bbox$ymax))
-    ggsave("figs/il_hisp.pdf", height = 10, width = 10)
+    # fake_map <- map
+    # fake_map$Enacted <- get_plans_matrix(plans)[,1000]
+    # fake_map %>%
+    #     group_by(Enacted) %>%
+    #     summarize(geometry = st_union(geometry),
+    #               hisp = sum(vap_hisp) / sum(vap)) %>%
+    #     ggplot() +
+    #     geom_sf(aes(fill = hisp), lwd = 0.25) +
+    #     # geom_sf(data = ctys, fill = NA, lwd = 2.5, alpha = 0.3, color = "grey") +
+    #     # geom_sf(data = dists, fill = NA, lwd = 1) +
+    #     geom_sf(data = fake_map, fill = NA, lwd = 0) +
+    #     theme_void()
+    # # coord_sf(xlim=c(bbox$xmin, bbox$xmax),
+    # #          ylim=c(bbox$ymin, bbox$ymax))
+    # ggsave("figs/il_hisp.pdf", height = 10, width = 10)
 }

--- a/analyses/IL_cd_2020/03_sim_IL_cd_2020.R
+++ b/analyses/IL_cd_2020/03_sim_IL_cd_2020.R
@@ -47,29 +47,13 @@ if (interactive()) {
 
     validate_analysis(plans, map)
 
-    redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
         size = 0.5, alpha = 0.5) +
-        scale_y_continuous("Percent Hispanic by VAP") +
+        scale_y_continuous("Percent Black by VAP") +
         labs(title = "Approximate Performance") +
         scale_color_manual(values = c(cd_2020_prop = "black")) +
         ggredist::theme_r21()
     ggsave("figs/performance.pdf", height = 7, width = 7)
-
-    # fake_map <- map
-    # fake_map$Enacted <- get_plans_matrix(plans)[,1000]
-    # fake_map %>%
-    #     group_by(Enacted) %>%
-    #     summarize(geometry = st_union(geometry),
-    #               hisp = sum(vap_hisp) / sum(vap)) %>%
-    #     ggplot() +
-    #     geom_sf(aes(fill = hisp), lwd = 0.25) +
-    #     # geom_sf(data = ctys, fill = NA, lwd = 2.5, alpha = 0.3, color = "grey") +
-    #     # geom_sf(data = dists, fill = NA, lwd = 1) +
-    #     geom_sf(data = fake_map, fill = NA, lwd = 0) +
-    #     theme_void()
-    # # coord_sf(xlim=c(bbox$xmin, bbox$xmax),
-    # #          ylim=c(bbox$ymin, bbox$ymax))
-    # ggsave("figs/il_hisp.pdf", height = 10, width = 10)
 }

--- a/analyses/IL_cd_2020/doc_IL_cd_2020.md
+++ b/analyses/IL_cd_2020/doc_IL_cd_2020.md
@@ -17,6 +17,6 @@ Data for Illinois comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 20,000 districting plans for Illinois across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
+We sample 60,000 districting plans for Illinois across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. These are counties outside of Cook County and DuPage County. Within Cook County and DuPage County, each municipality is its own pseudocounty as well. Cook County and DuPage County were chosen since they are necessarily split by congressional districts.
-To comply with the federal VRA and to respect communities of interest, we add hinge constraints of strength 20 targeting one majority-Black district (IL-01) and one majority-Hispanic district (IL-04).
+To comply with the federal VRA and to respect communities of interest, we add hinge Gibbs constraints of strength 20 targeting one majority-Black district (IL-01) and one majority-Hispanic district (IL-04), focusing on districts with relatively higher proportions of Black and Hispanic voters. We also apply a hinge Gibbs constraint of strength 10 to discourage packing of Black voters.

--- a/analyses/IL_cd_2020/doc_IL_cd_2020.md
+++ b/analyses/IL_cd_2020/doc_IL_cd_2020.md
@@ -17,6 +17,6 @@ Data for Illinois comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Illinois.
+We sample 20,000 districting plans for Illinois across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. These are counties outside of Cook County and DuPage County. Within Cook County and DuPage County, each municipality is its own pseudocounty as well. Cook County and DuPage County were chosen since they are necessarily split by congressional districts.
-To comply with the federal VRA and to respect communities of interest, we add weak VRA constraints targeting one majority-Black district (IL-01) and one majority-Hispanic district (IL-04).
+To comply with the federal VRA and to respect communities of interest, we add hinge constraints of strength 20 targeting one majority-Black district (IL-01) and one majority-Hispanic district (IL-04).


### PR DESCRIPTION
## Redistricting requirements
In Illinois, districts must, under Ill. Const. Art. IV, § 3:

1. be contiguous
2. have equal populations
3. be geographically compact

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Illinois comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 60,000 districting plans for Illinois across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. These are counties outside of Cook County and DuPage County. Within Cook County and DuPage County, each municipality is its own pseudocounty as well. Cook County and DuPage County were chosen since they are necessarily split by congressional districts.
To comply with the federal VRA and to respect communities of interest, we add hinge Gibbs constraints of strength 20 targeting one majority-Black district (IL-01) and one majority-Hispanic district (IL-04), focusing on districts with relatively higher proportions of Black and Hispanic voters. We also apply a hinge Gibbs constraint of strength 10 to discourage packing of Black voters.

## Validation

![validation_20220625_1553](https://user-images.githubusercontent.com/26680063/175788783-fc813163-ae79-48b6-8dfd-fd3e121a9ed8.png)

```
SMC: 5,000 sampled plans of 17 districts on 10,084 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5      
`est_label_mult`=1 • `pop_temper`=0.01        
ℹ Computing summary statistics for IL_cd_2020
Plan diversity 80% range: 0.82 to 0.98        
ℹ Computing summary statistics for IL_cd_2020
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white 
      1.001063       1.001688       1.010689       1.001726       1.023150       1.003121       1.011168 
     pop_black       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two       vap_hisp 
      1.023854       1.014258       1.002458       1.004661       1.011960       1.015186       1.004749 
     vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.012793       1.023345       1.008823       1.002860       1.002031       1.011035       1.020414 
pre_16_dem_cli pre_16_rep_tru uss_16_dem_duc uss_16_rep_kir gov_18_dem_pri gov_18_rep_rau atg_18_dem_rao 
      1.031037       1.006155       1.035278       1.006288       1.027198       1.005381       1.029615 
atg_18_rep_har sos_18_dem_whi sos_18_rep_hel pre_20_dem_bid pre_20_rep_tru uss_20_dem_dur uss_20_rep_cur 
      1.005372       1.023649       1.005170       1.020399       1.006772       1.010921       1.004938 
        arv_16         adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
      1.006645       1.034761       1.005206       1.020984       1.005843       1.019833       1.005097 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
      1.000192       1.019391       1.005194       1.006724       1.006712       1.016705       1.000965 
         pbias           egap 
      1.002688       1.000751 

Sampling diagnostics for SMC run 1 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd    Max. unique Est. k 
Split 1  28,776 (1151.0%)     15.6%        0.41 19,029 (1204%)     17 
Split 2  28,384 (1135.4%)     24.9%        0.47 18,809 (1190%)     10 
Split 3  27,937 (1117.5%)     35.9%        0.53 18,580 (1176%)      6 
Split 4  27,606 (1104.2%)     44.3%        0.58 18,579 (1176%)      4 
Split 5  27,265 (1090.6%)     48.7%        0.62 18,504 (1171%)      3 
Split 6  27,168 (1086.7%)     53.6%        0.64 18,452 (1168%)      2 
Split 7  27,170 (1086.8%)     50.6%        0.64 18,315 (1159%)      2 
Split 8  26,860 (1074.4%)     47.6%        0.64 18,410 (1165%)      2 
Split 9  26,811 (1072.4%)     44.6%        0.64 18,305 (1158%)      2 
Split 10 26,828 (1073.1%)     41.8%        0.65 18,241 (1154%)      2 
Split 11 26,877 (1075.1%)     39.0%        0.64 18,271 (1156%)      2 
Split 12 26,832 (1073.3%)     36.3%        0.63 18,034 (1141%)      2 
Split 13 26,527 (1061.1%)     34.1%        0.65 18,005 (1139%)      2 
Split 14 25,903 (1036.1%)     29.9%        0.64 17,714 (1121%)      2 
Split 15 25,693 (1027.7%)     23.9%        0.68 16,851 (1066%)      2 
Split 16 25,765 (1030.6%)      8.6%        0.70  14,851 (940%)      2 
Resample  13,282 (531.3%)       NA%        0.73 15,996 (1012%)     NA 

Sampling diagnostics for SMC run 2 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd    Max. unique Est. k 
Split 1  28,789 (1151.6%)     14.6%        0.40 18,972 (1201%)     18 
Split 2  28,393 (1135.7%)     22.5%        0.47 18,673 (1182%)     11 
Split 3  28,038 (1121.5%)     28.4%        0.53 18,672 (1182%)      8 
Split 4  27,585 (1103.4%)     38.7%        0.59 18,564 (1175%)      5 
Split 5  27,076 (1083.0%)     48.8%        0.64 18,418 (1165%)      3 
Split 6  26,788 (1071.5%)     39.8%        0.66 18,403 (1165%)      4 
Split 7  26,863 (1074.5%)     32.0%        0.66 18,246 (1155%)      5 
Split 8  26,739 (1069.5%)     40.6%        0.66 18,388 (1164%)      3 
Split 9  26,270 (1050.8%)     27.1%        0.67 18,159 (1149%)      5 
Split 10 26,414 (1056.5%)     29.5%        0.67 18,135 (1148%)      4 
Split 11 26,451 (1058.0%)     14.7%        0.66 17,960 (1136%)      8 
Split 12 26,515 (1060.6%)     21.0%        0.64 18,006 (1139%)      5 
Split 13 26,668 (1066.7%)     27.5%        0.63 17,748 (1123%)      3 
Split 14 26,196 (1047.8%)     29.5%        0.63 17,680 (1119%)      2 
Split 15 26,056 (1042.2%)     10.7%        0.65 16,846 (1066%)      6 
Split 16 26,304 (1052.2%)      5.3%        0.67  15,326 (970%)      4 
Resample  16,126 (645.1%)       NA%        0.70 16,299 (1031%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
