### PR TITLE
Re-run 2020 California Congressional Districts

### DIFF
--- a/analyses/CA_cd_2020/02_setup_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/02_setup_CA_cd_2020.R
@@ -21,30 +21,30 @@ map <- map %>%
     )
 
 counties_south <- c("Los Angeles County", "San Bernardino County", "Orange County",
-                   "Riverside County", "San Diego County", "Imperial County")
+    "Riverside County", "San Diego County", "Imperial County")
 map_south <- map %>%
     `attr<-`("existing_col", NULL) %>%
     filter(county %in% counties_south) %>%
     `attr<-`("ndists", 29) %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 
-counties_bay <- c("Alameda County", "Contra Costa County", #"Fresno County", "Kings County",
-                  "Madera County", "Madera County", "Merced County", "Monterey County",
-                  "Sacramento County", "San Benito County", "San Francisco County",
-                  "San Joaquin County", "San Mateo County", "Santa Clara County",
-                  "Santa Cruz County", "Solano County", "Stanislaus County", #"Tulare County",
-                  "Yolo County")
+counties_bay <- c("Alameda County", "Contra Costa County", # "Fresno County", "Kings County",
+    "Madera County", "Madera County", "Merced County", "Monterey County",
+    "Sacramento County", "San Benito County", "San Francisco County",
+    "San Joaquin County", "San Mateo County", "Santa Clara County",
+    "Santa Cruz County", "Solano County", "Stanislaus County", # "Tulare County",
+    "Yolo County")
 
 map_bay <- map %>%
     `attr<-`("existing_col", NULL) %>%
     filter(county %in% counties_bay) %>%
-    `attr<-`("ndists", 14) %>%
+    `attr<-`("ndists", 15) %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 
 map <- map %>%
-    mutate(cluster = case_when(county %in% counties_bay ~ 'Bay',
-                               county %in% counties_south ~ 'South',
-                               TRUE ~ 'Remainder'))
+    mutate(cluster = case_when(county %in% counties_bay ~ "Bay",
+        county %in% counties_south ~ "South",
+        TRUE ~ "Remainder"))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CA_2020"

--- a/analyses/CA_cd_2020/02_setup_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/02_setup_CA_cd_2020.R
@@ -13,34 +13,38 @@ map <- map %>%
         pop_muni = get_target(map)))
 
 map <- map %>%
-    mutate(uid = row_number())
+    mutate(
+        uid = row_number(),
+        across(contains(c("_16", "_18", "_20")), \(x) coalesce(x, 0)),
+        ndv = coalesce(ndv, 0),
+        nrv = coalesce(nrv, 0)
+    )
 
-map <- map %>%
-    mutate(across(contains(c("_16", "_18", "_20")), \(x) coalesce(x, 0)))
-map <- map %>%
-    mutate(ndv = coalesce(ndv, 0),
-        nrv = coalesce(nrv, 0))
-
-
+counties_south <- c("Los Angeles County", "San Bernardino County", "Orange County",
+                   "Riverside County", "San Diego County", "Imperial County")
 map_south <- map %>%
     `attr<-`("existing_col", NULL) %>%
-    filter(county %in% c("Los Angeles County", "San Bernardino County", "Orange County",
-        "Riverside County", "San Diego County", "Imperial County")) %>%
+    filter(county %in% counties_south) %>%
     `attr<-`("ndists", 29) %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 
+counties_bay <- c("Alameda County", "Contra Costa County", #"Fresno County", "Kings County",
+                  "Madera County", "Madera County", "Merced County", "Monterey County",
+                  "Sacramento County", "San Benito County", "San Francisco County",
+                  "San Joaquin County", "San Mateo County", "Santa Clara County",
+                  "Santa Cruz County", "Solano County", "Stanislaus County", #"Tulare County",
+                  "Yolo County")
+
 map_bay <- map %>%
     `attr<-`("existing_col", NULL) %>%
-    filter(county %in% c("Alameda County", "Contra Costa County", "Fresno County", "Kings County",
-        "Madera County", "Madera County", "Merced County", "Monterey County",
-        "Sacramento County", "San Benito County", "San Francisco County",
-        "San Joaquin County", "San Mateo County", "Santa Clara County",
-        "Santa Cruz County", "Solano County", "Stanislaus County", "Tulare County",
-        "Yolo County")) %>%
-    `attr<-`("ndists", 17) %>%
+    filter(county %in% counties_bay) %>%
+    `attr<-`("ndists", 14) %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 
-
+map <- map %>%
+    mutate(cluster = case_when(county %in% counties_bay ~ 'Bay',
+                               county %in% counties_south ~ 'South',
+                               TRUE ~ 'Remainder'))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CA_2020"

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -22,9 +22,21 @@ map_south$boundary <- map_south$tract %in% seam_south
 
 cons_south <- redist_constr(map_south) %>%
     add_constr_grp_hinge(
-        strength = 15,
+        strength = 20,
         group_pop = vap_hisp,
-        total_pop = vap
+        total_pop = vap,
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -15,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -15,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .2
     ) %>%
     add_constr_custom(
         strength = 10,
@@ -33,7 +45,6 @@ cons_south <- redist_constr(map_south) %>%
         }
     )
 
-
 set.seed(2020)
 
 plans_south <- redist_smc(
@@ -41,7 +52,7 @@ plans_south <- redist_smc(
     nsims = 5e3, runs = 2L, ncores = 8,
     counties = pseudo_county,
     constraints = cons_south,
-    n_steps = 27
+    n_steps = 27, pop_temper = 0.005, seq_alpha = 0.7
 )
 
 # simulate large bay area ----

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -75,17 +75,12 @@ seam_bay <- sapply(
         c("Stanislaus County", "Calaveras County"),
         c("Stanislaus County", "Tuolumne County"),
         c("Merced County", "Mariposa County"),
-        c('Merced County', 'Fresno County'),
+        c("Merced County", "Fresno County"),
         c("Madera County", "Mariposa County"),
         c("Madera County", "Tuolumne County"),
         c("Madera County", "Mono County"),
-        c('Madera County', 'Fresno County'),
-        c('San Benito County', 'Fresno County'),
-        # c("Fresno County", "Mono County"),
-        # c("Fresno County", "Inyo County"),
-        # c("Tulare County", "Inyo County"),
-        # c("Tulare County", "Kern County"),
-        # c("Kings County", "Kern County"),
+        c("Madera County", "Fresno County"),
+        c("San Benito County", "Fresno County"),
         c("Monterey County", "San Luis Obispo County"),
         c("Monterey County", "Kings County"),
         c("Monterey County", "Kern County")
@@ -148,7 +143,7 @@ plans_bay <- redist_smc(
 )
 
 
-`# pull it all together ----
+# pull it all together ----
 init <- prep_particles(
     map = map,
     map_plan_list = list(
@@ -163,7 +158,7 @@ init <- prep_particles(
     ),
     uid = uid,
     dist_keep = keep,
-    nsims = 1e4 * 2
+    nsims = 1e4*2
 )
 
 
@@ -174,7 +169,7 @@ plans <- redist_smc(
     nsims = 2e4, runs = 2L, ncores = 8,
     counties = county,
     init_particles = init
-    )
+)
 
 attr(plans, "prec_pop") <- map$pop
 
@@ -183,7 +178,7 @@ plans <- plans %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
-plans <- match_numbers(plans, 'cd_2020')
+plans <- match_numbers(plans, "cd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -208,31 +203,31 @@ if (interactive()) {
     library(patchwork)
 
     redist.plot.hist(plans %>% group_by(draw) %>%
-                         mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
+        mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+            mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic > 40% and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+            mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic > 30% and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
+            mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
         labs(x = "Number of Hispanic + Asian and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+            mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic + Asian > 40% and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+            mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic + Asian > 30% and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
+            mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
         labs(x = "Number of Asian and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+            mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Asian > 40% and Dem. Majority") +
         redist.plot.hist(plans %>% group_by(draw) %>%
-                             mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
+            mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
         labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
         theme_bw()
 
@@ -240,60 +235,60 @@ if (interactive()) {
     enac_sum <- plans %>%
         subset_ref() %>%
         mutate(minority = (total_vap - vap_white)/(total_vap),
-               dist_lab = str_pad(district, width = 2, pad = "0"),
-               minority_rank = rank(minority), # ascending order
-               hisp_rank = rank(vap_hisp),
-               asian_rank = rank(vap_asian),
-               ha_rank = rank(vap_hisp + vap_asian),
-               coalition_rank = rank(vap_hisp + vap_asian + vap_black),
-               compact_rank = rank(comp_polsby)
+            dist_lab = str_pad(district, width = 2, pad = "0"),
+            minority_rank = rank(minority), # ascending order
+            hisp_rank = rank(vap_hisp),
+            asian_rank = rank(vap_asian),
+            ha_rank = rank(vap_hisp + vap_asian),
+            coalition_rank = rank(vap_hisp + vap_asian + vap_black),
+            compact_rank = rank(comp_polsby)
         )
 
     redist.plot.distr_qtys(plans, vap_hisp/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Hispanic by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = hisp_rank, label = round(e_dvs, 2)),
-                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
         redist.plot.distr_qtys(plans, vap_asian/total_vap,
-                               color_thresh = NULL,
-                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-                               size = 0.5, alpha = 0.5) +
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Asian by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = asian_rank, label = round(e_dvs, 2)),
-                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
         redist.plot.distr_qtys(plans, (vap_asian + vap_hisp)/total_vap,
-                               color_thresh = NULL,
-                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-                               size = 0.5, alpha = 0.5) +
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Hispanic or Asian by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = ha_rank, label = round(e_dvs, 2)),
-                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
         redist.plot.distr_qtys(plans, (vap_asian + vap_hisp + vap_black)/total_vap,
-                               color_thresh = NULL,
-                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-                               size = 0.5, alpha = 0.5) +
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Coalition by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         redist.plot.distr_qtys(plans %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
-                               color_thresh = NULL,
-                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-                               size = 0.5, alpha = 0.5) +
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Coalition by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -173,6 +173,11 @@ plans <- redist_smc(
 
 attr(plans, "prec_pop") <- map$pop
 
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
 plans <- match_numbers(plans, 'cd_2020')
 
 cli_process_done()
@@ -199,23 +204,32 @@ if (interactive()) {
 
     redist.plot.hist(plans %>% group_by(draw) %>%
         mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
-        labs(x = "Number of Hispanic and Dem. Majority")
-
+        labs(x = "Number of Hispanic and Dem. Majority") +
     redist.plot.hist(plans %>% group_by(draw) %>%
         mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
-        labs(x = "Number of Hispanic > 40% and Dem. Majority")
-
+        labs(x = "Number of Hispanic > 40% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic > 30% and Dem. Majority") +
     redist.plot.hist(plans %>% group_by(draw) %>%
         mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
-        labs(x = "Number of Hispanic + Asian and Dem. Majority")
-
+        labs(x = "Number of Hispanic + Asian and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic + Asian > 40% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic + Asian > 30% and Dem. Majority") +
     redist.plot.hist(plans %>% group_by(draw) %>%
         mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
-        labs(x = "Number of Asian and Dem. Majority")
-
+        labs(x = "Number of Asian and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Asian > 40% and Dem. Majority") +
     redist.plot.hist(plans %>% group_by(draw) %>%
         mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
-        labs(x = "Number of Hispanic + Asian + Black and Dem. Majority")
+        labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
+        theme_bw()
 
 
     enac_sum <- plans %>%
@@ -240,8 +254,7 @@ if (interactive()) {
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = hisp_rank, label = round(e_dvs, 2)),
             vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"))
-
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
     redist.plot.distr_qtys(plans, vap_asian/total_vap,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
@@ -252,8 +265,7 @@ if (interactive()) {
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = asian_rank, label = round(e_dvs, 2)),
             vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"))
-
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
     redist.plot.distr_qtys(plans, (vap_asian + vap_hisp)/total_vap,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
@@ -264,8 +276,7 @@ if (interactive()) {
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = ha_rank, label = round(e_dvs, 2)),
             vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"))
-
+            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
     redist.plot.distr_qtys(plans, (vap_asian + vap_hisp + vap_black)/total_vap,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
@@ -273,8 +284,7 @@ if (interactive()) {
         scale_y_continuous("Percent Coalition by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
-        geom_hline(yintercept = 0.5, linetype = "dotted")
-
+        geom_hline(yintercept = 0.5, linetype = "dotted") +
     redist.plot.distr_qtys(plans %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -22,18 +22,18 @@ map_south$boundary <- map_south$tract %in% seam_south
 
 cons_south <- redist_constr(map_south) %>%
     add_constr_grp_hinge(
-        strength = 20,
+        strength = 10,
         group_pop = vap_hisp,
         total_pop = vap,
     ) %>%
     add_constr_grp_hinge(
-        strength = -15,
+        strength = -7.5,
         group_pop = vap_hisp,
         total_pop = vap,
         tgts_group = .3
     ) %>%
     add_constr_grp_hinge(
-        strength = -15,
+        strength = -7.5,
         group_pop = vap_hisp,
         total_pop = vap,
         tgts_group = .2
@@ -49,10 +49,10 @@ set.seed(2020)
 
 plans_south <- redist_smc(
     map_south,
-    nsims = 5e3, runs = 2L, ncores = 8,
+    nsims = 1e4, runs = 2L, ncores = 8,
     counties = pseudo_county,
     constraints = cons_south,
-    n_steps = 27, pop_temper = 0.005, seq_alpha = 0.7
+    n_steps = 27, pop_temper = 0.005, seq_alpha = 0.95
 )
 
 # simulate large bay area ----
@@ -93,14 +93,38 @@ map_bay$boundary <- map_bay$tract %in% seam_bay
 
 cons_bay <- redist_constr(map_bay) %>%
     add_constr_grp_hinge(
-        strength = 50,
+        strength = 10,
         group_pop = vap_hisp,
-        total_pop = vap
+        total_pop = vap,
     ) %>%
     add_constr_grp_hinge(
-        strength = 50,
+        strength = -7.5,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -7.5,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .2
+    ) %>%
+    add_constr_grp_hinge(
+        strength = 10,
         group_pop = vap_asian,
-        total_pop = vap
+        total_pop = vap,
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -7.5,
+        group_pop = vap_asian,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -7.5,
+        group_pop = vap_asian,
+        total_pop = vap,
+        tgts_group = .2
     ) %>%
     add_constr_custom(
         strength = 10,
@@ -112,14 +136,14 @@ set.seed(2020)
 
 plans_bay <- redist_smc(
     map_bay,
-    nsims = 5e3, runs = 2L, ncores = 8,
+    nsims = 1e4, runs = 2L, ncores = 8,
     counties = pseudo_county,
     constraints = cons_bay,
-    n_steps = 15
+    n_steps = 15, pop_temper = 0.0025
 )
 
 
-# pull it all together ----
+`# pull it all together ----
 init <- prep_particles(
     map = map,
     map_plan_list = list(
@@ -134,7 +158,7 @@ init <- prep_particles(
     ),
     uid = uid,
     dist_keep = keep,
-    nsims = 5e3 * 2
+    nsims = 1e4 * 2
 )
 
 
@@ -142,7 +166,7 @@ set.seed(2020)
 
 plans <- redist_smc(
     map,
-    nsims = 1e4, runs = 2L, ncores = 8,
+    nsims = 2e4, runs = 2L, ncores = 8,
     counties = county,
     init_particles = init
     )

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -22,18 +22,18 @@ map_south$boundary <- map_south$tract %in% seam_south
 
 cons_south <- redist_constr(map_south) %>%
     add_constr_grp_hinge(
-        strength = 10,
+        strength = 9,
         group_pop = vap_hisp,
         total_pop = vap,
     ) %>%
     add_constr_grp_hinge(
-        strength = -7.5,
+        strength = -6.8,
         group_pop = vap_hisp,
         total_pop = vap,
         tgts_group = .3
     ) %>%
     add_constr_grp_hinge(
-        strength = -7.5,
+        strength = -6.8,
         group_pop = vap_hisp,
         total_pop = vap,
         tgts_group = .2
@@ -75,15 +75,20 @@ seam_bay <- sapply(
         c("Stanislaus County", "Calaveras County"),
         c("Stanislaus County", "Tuolumne County"),
         c("Merced County", "Mariposa County"),
+        c('Merced County', 'Fresno County'),
         c("Madera County", "Mariposa County"),
         c("Madera County", "Tuolumne County"),
         c("Madera County", "Mono County"),
-        c("Fresno County", "Mono County"),
-        c("Fresno County", "Inyo County"),
-        c("Tulare County", "Inyo County"),
-        c("Tulare County", "Kern County"),
-        c("Kings County", "Kern County"),
-        c("Monterey County", "San Luis Obispo County")
+        c('Madera County', 'Fresno County'),
+        c('San Benito County', 'Fresno County'),
+        # c("Fresno County", "Mono County"),
+        # c("Fresno County", "Inyo County"),
+        # c("Tulare County", "Inyo County"),
+        # c("Tulare County", "Kern County"),
+        # c("Kings County", "Kern County"),
+        c("Monterey County", "San Luis Obispo County"),
+        c("Monterey County", "Kings County"),
+        c("Monterey County", "Kern County")
     ),
     FUN = \(x) seam_geom(adj = map$adj, shp = map, admin = "county", seam = x) %>%
         pull(tract)
@@ -139,7 +144,7 @@ plans_bay <- redist_smc(
     nsims = 1e4, runs = 2L, ncores = 8,
     counties = pseudo_county,
     constraints = cons_bay,
-    n_steps = 15, pop_temper = 0.0025
+    n_steps = 13, pop_temper = 0.0025
 )
 
 
@@ -203,31 +208,31 @@ if (interactive()) {
     library(patchwork)
 
     redist.plot.hist(plans %>% group_by(draw) %>%
-        mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
+                         mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
-        mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic > 40% and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
+        redist.plot.hist(plans %>% group_by(draw) %>%
                              mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic > 30% and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
-        mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
+        redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
         labs(x = "Number of Hispanic + Asian and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
+        redist.plot.hist(plans %>% group_by(draw) %>%
                              mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic + Asian > 40% and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
+        redist.plot.hist(plans %>% group_by(draw) %>%
                              mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Hispanic + Asian > 30% and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
-        mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
+        redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
         labs(x = "Number of Asian and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
+        redist.plot.hist(plans %>% group_by(draw) %>%
                              mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
         labs(x = "Number of Asian > 40% and Dem. Majority") +
-    redist.plot.hist(plans %>% group_by(draw) %>%
-        mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
+        redist.plot.hist(plans %>% group_by(draw) %>%
+                             mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
         labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
         theme_bw()
 
@@ -235,60 +240,60 @@ if (interactive()) {
     enac_sum <- plans %>%
         subset_ref() %>%
         mutate(minority = (total_vap - vap_white)/(total_vap),
-            dist_lab = str_pad(district, width = 2, pad = "0"),
-            minority_rank = rank(minority), # ascending order
-            hisp_rank = rank(vap_hisp),
-            asian_rank = rank(vap_asian),
-            ha_rank = rank(vap_hisp + vap_asian),
-            coalition_rank = rank(vap_hisp + vap_asian + vap_black),
-            compact_rank = rank(comp_polsby)
+               dist_lab = str_pad(district, width = 2, pad = "0"),
+               minority_rank = rank(minority), # ascending order
+               hisp_rank = rank(vap_hisp),
+               asian_rank = rank(vap_asian),
+               ha_rank = rank(vap_hisp + vap_asian),
+               coalition_rank = rank(vap_hisp + vap_asian + vap_black),
+               compact_rank = rank(comp_polsby)
         )
 
     redist.plot.distr_qtys(plans, vap_hisp/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Hispanic by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = hisp_rank, label = round(e_dvs, 2)),
-            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
-    redist.plot.distr_qtys(plans, vap_asian/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans, vap_asian/total_vap,
+                               color_thresh = NULL,
+                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                               size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Asian by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = asian_rank, label = round(e_dvs, 2)),
-            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
-    redist.plot.distr_qtys(plans, (vap_asian + vap_hisp)/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans, (vap_asian + vap_hisp)/total_vap,
+                               color_thresh = NULL,
+                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                               size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Hispanic or Asian by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
         geom_text(data = enac_sum, aes(x = ha_rank, label = round(e_dvs, 2)),
-            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
-            color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
-    redist.plot.distr_qtys(plans, (vap_asian + vap_hisp + vap_black)/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+                  vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+                  color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans, (vap_asian + vap_hisp + vap_black)/total_vap,
+                               color_thresh = NULL,
+                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                               size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Coalition by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted") +
-    redist.plot.distr_qtys(plans %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
+        redist.plot.distr_qtys(plans %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
+                               color_thresh = NULL,
+                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                               size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Coalition by VAP") +
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +

--- a/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
+++ b/analyses/CA_cd_2020/03_sim_CA_cd_2020.R
@@ -22,7 +22,7 @@ map_south$boundary <- map_south$tract %in% seam_south
 
 cons_south <- redist_constr(map_south) %>%
     add_constr_grp_hinge(
-        strength = 30,
+        strength = 15,
         group_pop = vap_hisp,
         total_pop = vap
     ) %>%
@@ -32,10 +32,16 @@ cons_south <- redist_constr(map_south) %>%
             as.numeric(!any(plan[map_south$boundary] == 0))
         }
     )
-set.seed(1)
+
+
+set.seed(2020)
+
 plans_south <- redist_smc(
-    map_south, nsims = 5e3, counties = pseudo_county,
-    constraints = cons_south, n_steps = 27
+    map_south,
+    nsims = 5e3, runs = 2L, ncores = 8,
+    counties = pseudo_county,
+    constraints = cons_south,
+    n_steps = 27
 )
 
 # simulate large bay area ----
@@ -91,10 +97,14 @@ cons_bay <- redist_constr(map_bay) %>%
             as.numeric(!any(plan[map_bay$boundary] == 0))
         }
     )
-set.seed(1)
+set.seed(2020)
+
 plans_bay <- redist_smc(
-    map_bay, nsims = 5e3, counties = pseudo_county,
-    constraints = cons_bay, n_steps = 15
+    map_bay,
+    nsims = 5e3, runs = 2L, ncores = 8,
+    counties = pseudo_county,
+    constraints = cons_bay,
+    n_steps = 15
 )
 
 
@@ -113,15 +123,22 @@ init <- prep_particles(
     ),
     uid = uid,
     dist_keep = keep,
-    nsims = 5e3
+    nsims = 5e3 * 2
 )
 
 
-set.seed(1)
-plans <- redist_smc(map, nsims = 5e3, counties = county,
-    init_particles = init)
+set.seed(2020)
+
+plans <- redist_smc(
+    map,
+    nsims = 1e4, runs = 2L, ncores = 8,
+    counties = county,
+    init_particles = init
+    )
 
 attr(plans, "prec_pop") <- map$pop
+
+plans <- match_numbers(plans, 'cd_2020')
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/CA_cd_2020/doc_CA_cd_2020.md
+++ b/analyses/CA_cd_2020/doc_CA_cd_2020.md
@@ -21,7 +21,11 @@ Data for California comes from the ALARM Project's [2020 Redistricting Data File
 Islands were connected to their nearest point within county on the mainland.
 
 ## Simulation Notes
-We sample 5,000 districting plans for California. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
+We sample 10,000 districting plans in each cluster across 2 indpenednet runs of the SMC algorithm.
+We next sample 20,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
+We then thin the sample to down to 5,000 plans.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
+A small population tempering value was used for each cluster to avoid losing diversity at the final step based on initial runs.
 
 ### 1. Clustering Procedure
 First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:

--- a/analyses/CA_cd_2020/doc_CA_cd_2020.md
+++ b/analyses/CA_cd_2020/doc_CA_cd_2020.md
@@ -21,8 +21,8 @@ Data for California comes from the ALARM Project's [2020 Redistricting Data File
 Islands were connected to their nearest point within county on the mainland.
 
 ## Simulation Notes
-We sample 10,000 districting plans in each cluster across 2 indpenednet runs of the SMC algorithm.
-We next sample 20,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
+We sample 20,000 districting plans in each cluster across 2 indpenednet runs of the SMC algorithm.
+We next sample 40,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
 We then thin the sample to down to 5,000 plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
 A small population tempering value was used for each cluster to avoid losing diversity at the final step based on initial runs.


### PR DESCRIPTION
## Redistricting requirements
In California, under [Article XXI](https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?lawCode=CONS&division=&title=&part=&chapter=&article=XXI), districts must:

1. be contiguous (2d3)
1. have equal populations (2d1) 
1. be geographically compact (2d5)
1. preserve city, county, neighborhood, and community of interest boundaries as much as possible (2d4)
1. not favor or discriminate against incumbents, candidates, or parties (2e)
1. comply with the Voting Rights Act (2d2)


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We add a pseudo-county constraint, as described below. We add VRA constraints encouraging Hispanic VAP and Asian VAP majorities in districts.

## Data Sources
Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Islands were connected to their nearest point within county on the mainland.

## Simulation Notes
We sample 20,000 districting plans in each cluster across 2 indpenednet runs of the SMC algorithm.
We next sample 40,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
We then thin the sample to down to 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
A small population tempering value was used for each cluster to avoid losing diversity at the final step based on initial runs.

### 1. Clustering Procedure
First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:

* Los Angeles, San Bernardino, Orange, Riverside, San Diego, and Imperial

* Alameda, Contra Costa, Fresno, Kings, Madera, Madera, Merced, Monterey, Sacramento, San Benito, San Francisco, San Joaquin, San Mateo, Santa Clara, Santa Cruz, Solano, Stanislaus, Tulare, and Yolo

We sample in each of these regions with a population deviation of 0.5%. We sample 27 districts in the southern region and 15 districts in the Bay Area. Because each cluster will have leftover population, we apply an additional constraint that
incentivizes leaving any unassigned areas on the edge of these clusters to
avoid discontiguities. For each cluster, we add VRA constraints encouraging Hispanic VAP and Asian VAP concentrations in districts, in line with the enacted plan.

### 2. Combination Procedure
Then, these partial map simulations are combined to run statewide simulations. We sample 10 districts in the remainder.

## Validation

![validation_20220715_2103](https://user-images.githubusercontent.com/28026893/179328545-68a96367-f570-413f-8300-6e1e0db5c211.png)

```
SMC: 40,000 sampled plans of 52 districts on 9,129 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.39 to 0.87

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp 
     1.0206726      1.0006993      1.0003950      1.0031552      1.0063495      1.0042640 
     pop_white      pop_black       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0008380      1.0003189      0.9999905      1.0015601      1.0032105      1.0020453 
       pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian 
     1.0008742      1.0047342      1.0007322      1.0006367      1.0000615      1.0017646 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid 
     1.0026712      1.0005083      1.0001460      1.0039224      1.0002809      1.0056975 
pre_20_rep_tru         arv_16         adv_16         arv_20         adv_20  county_splits 
     1.0049327      1.0002809      1.0039224      1.0049327      1.0056975      1.0014315 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
     1.0049442      1.0055980      1.0059087      1.0015216      1.0016879      1.0015121 
         e_dem          pbias           egap 
     1.0205089      1.0028718      1.0144812 

Sampling diagnostics for SMC run 1 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    15,843 (79.2%)     16.1%        0.64 11,775 ( 93%)      5 
Split 2    15,711 (78.6%)     15.5%        0.69 11,703 ( 93%)      4 
Split 3    16,245 (81.2%)     17.9%        0.68 11,672 ( 92%)      3 
Split 4    16,242 (81.2%)     15.8%        0.67 11,538 ( 91%)      3 
Split 5    16,190 (81.0%)     19.3%        0.67 11,564 ( 91%)      2 
Split 6    16,623 (83.1%)      7.1%        0.65 11,392 ( 90%)      5 
Split 7    16,739 (83.7%)      9.0%        0.63 11,074 ( 88%)      3 
Split 8    16,659 (83.3%)      6.9%        0.63 10,806 ( 85%)      3 
Split 9    15,981 (79.9%)      3.7%        0.68 10,003 ( 79%)      2 
Resample    7,662 (38.3%)       NA%        0.68 10,645 ( 84%)     NA 

Sampling diagnostics for SMC run 2 of 2 (20,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    15,774 (78.9%)     13.6%        0.64 11,889 ( 94%)      6 
Split 2    15,540 (77.7%)     15.5%        0.70 11,719 ( 93%)      4 
Split 3    16,016 (80.1%)     17.8%        0.70 11,633 ( 92%)      3 
Split 4    16,169 (80.8%)      8.0%        0.68 11,650 ( 92%)      6 
Split 5    16,436 (82.2%)     10.3%        0.66 11,517 ( 91%)      4 
Split 6    16,317 (81.6%)      8.7%        0.66 11,306 ( 89%)      4 
Split 7    16,723 (83.6%)      9.3%        0.64 11,088 ( 88%)      3 
Split 8    16,812 (84.1%)     10.3%        0.63 10,889 ( 86%)      2 
Split 9    16,707 (83.5%)      1.9%        0.63 10,165 ( 80%)      4 
Resample   10,884 (54.4%)       NA%        0.63 11,055 ( 87%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std.
devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values
for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes:

Summary for south region:
```
SMC: 20,000 sampled plans of 28 districts on 4,873 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.005

Plan diversity 80% range: 0.38 to 0.99

Sampling diagnostics for SMC run 1 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,168 (31.7%)     17.3%        0.28 6,395 (101%)     11 
Split 2     2,928 (29.3%)     26.2%        0.31 3,843 ( 61%)      7 
Split 3     2,776 (27.8%)     34.6%        0.37 3,713 ( 59%)      5 
Split 4     2,580 (25.8%)     32.9%        0.38 3,685 ( 58%)      5 
Split 5     2,457 (24.6%)     31.5%        0.39 3,583 ( 57%)      5 
Split 6     2,267 (22.7%)     29.9%        0.40 3,609 ( 57%)      5 
Split 7     2,145 (21.5%)     28.2%        0.42 3,615 ( 57%)      5 
Split 8     2,039 (20.4%)     32.6%        0.43 3,550 ( 56%)      4 
Split 9     1,816 (18.2%)     31.8%        0.45 3,471 ( 55%)      4 
Split 10    1,545 (15.4%)     37.5%        0.48 3,444 ( 54%)      3 
Split 11    1,510 (15.1%)     47.6%        0.49 3,395 ( 54%)      2 
Split 12    1,547 (15.5%)     26.5%        0.51 3,426 ( 54%)      4 
Split 13    1,613 (16.1%)     32.5%        0.53 3,518 ( 56%)      3 
Split 14    1,228 (12.3%)     41.3%        0.53 3,666 ( 58%)      2 
Split 15    1,176 (11.8%)     40.3%        0.63 3,422 ( 54%)      2 
Split 16       742 (7.4%)     37.9%        0.63 3,500 ( 55%)      2 
Split 17    1,097 (11.0%)     35.0%        0.62 3,549 ( 56%)      2 
Split 18    1,135 (11.4%)     24.4%        0.65 3,527 ( 56%)      3 
Split 19    1,245 (12.5%)     30.7%        0.63 3,551 ( 56%)      2 
Split 20       616 (6.2%)     28.2%        0.63 3,732 ( 59%)      2 
Split 21       825 (8.2%)     25.8%        0.66 3,550 ( 56%)      2 
Split 22       781 (7.8%)      9.6%        0.68 3,677 ( 58%)      5 
Split 23    1,084 (10.8%)     14.0%        0.70 3,759 ( 59%)      3 
Split 24       897 (9.0%)      9.2%        0.73 3,539 ( 56%)      4 
Split 25    1,092 (10.9%)      9.3%        0.73 3,687 ( 58%)      3 
Split 26    1,315 (13.1%)     17.9%        0.64 3,482 ( 55%)      2 
Split 27    1,525 (15.2%)     10.6%        0.66 2,779 ( 44%)      2 
Resample    1,497 (15.0%)       NA%       10.00 3,394 ( 54%)     NA 

Sampling diagnostics for SMC run 2 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,169 (31.7%)     19.0%        0.28 6,348 (100%)     10 
Split 2     3,041 (30.4%)     22.6%        0.31 3,798 ( 60%)      8 
Split 3     2,821 (28.2%)     33.7%        0.37 3,796 ( 60%)      5 
Split 4     2,606 (26.1%)     24.0%        0.38 3,680 ( 58%)      7 
Split 5     2,463 (24.6%)     37.6%        0.39 3,616 ( 57%)      4 
Split 6     2,342 (23.4%)     36.5%        0.40 3,517 ( 56%)      4 
Split 7     2,116 (21.2%)     28.7%        0.41 3,506 ( 55%)      5 
Split 8     2,046 (20.5%)     33.4%        0.43 3,536 ( 56%)      4 
Split 9     1,767 (17.7%)     39.3%        0.45 3,555 ( 56%)      3 
Split 10    1,816 (18.2%)     29.7%        0.45 3,470 ( 55%)      4 
Split 11    1,681 (16.8%)     36.9%        0.48 3,572 ( 57%)      3 
Split 12    1,635 (16.4%)     26.7%        0.50 3,535 ( 56%)      4 
Split 13    1,663 (16.6%)     32.7%        0.51 3,541 ( 56%)      3 
Split 14    1,426 (14.3%)     23.9%        0.52 3,560 ( 56%)      4 
Split 15    1,225 (12.3%)     29.3%        0.61 3,510 ( 56%)      3 
Split 16    1,377 (13.8%)     37.6%        0.65 3,514 ( 56%)      2 
Split 17    1,259 (12.6%)     25.5%        0.65 3,661 ( 58%)      3 
Split 18    1,398 (14.0%)     18.1%        0.66 3,730 ( 59%)      4 
Split 19    1,389 (13.9%)     21.9%        0.82 3,666 ( 58%)      3 
Split 20    1,208 (12.1%)     27.2%        0.71 3,544 ( 56%)      2 
Split 21    1,289 (12.9%)     23.5%        0.70 3,690 ( 58%)      2 
Split 22    1,402 (14.0%)     20.7%        0.69 3,858 ( 61%)      2 
Split 23    1,270 (12.7%)      9.8%        0.73 3,753 ( 59%)      4 
Split 24    2,042 (20.4%)     11.7%        0.81 3,710 ( 59%)      3 
Split 25    1,158 (11.6%)      8.6%        0.74 3,530 ( 56%)      2 
Split 26    1,517 (15.2%)      8.0%        0.71 3,171 ( 50%)      2 
Split 27    1,074 (10.7%)      4.3%        0.70 2,921 ( 46%)      2 
Resample    1,161 (11.6%)       NA%        9.93 3,199 ( 51%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std.
devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values
for summary statistics should be between 1 and 1.05.
```

Summary for Bay region:
```
SMC: 20,000 sampled plans of 16 districts on 2,891 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0.0025

Plan diversity 80% range: 0.23 to 0.83

Sampling diagnostics for SMC run 1 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k    
Split 1     2,538 (25.4%)     13.1%        0.37 6,340 (100%)      8    
Split 2     3,665 (36.6%)     20.7%        1.28 3,788 ( 60%)      5    
Split 3     2,724 (27.2%)     24.6%        1.18 4,450 ( 70%)      4    
Split 4     2,330 (23.3%)     23.0%        1.32 4,393 ( 69%)      4    
Split 5     2,346 (23.5%)     21.8%        1.35 4,251 ( 67%)      4    
Split 6     2,574 (25.7%)     20.4%        1.34 4,357 ( 69%)      4    
Split 7     3,002 (30.0%)     24.2%        1.30 4,680 ( 74%)      3    
Split 8     3,043 (30.4%)     30.5%        1.20 4,805 ( 76%)      2    
Split 9     4,262 (42.6%)     28.0%        1.20 4,982 ( 79%)      2    
Split 10    4,223 (42.2%)     26.2%        1.02 5,077 ( 80%)      2    
Split 11    3,356 (33.6%)     16.8%        1.05 5,151 ( 81%)      3    
Split 12    3,091 (30.9%)     21.9%        1.18 4,954 ( 78%)      2    
Split 13    4,464 (44.6%)     19.7%        1.10 4,748 ( 75%)      2    
Split 14    4,414 (44.1%)     11.2%        0.98 4,875 ( 77%)      3    
Split 15    2,819 (28.2%)     15.5%        0.99 4,569 ( 72%)      2    
Resample        49 (0.5%)       NA%        8.82 2,424 ( 38%)     NA  * 

Sampling diagnostics for SMC run 2 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,595 (26.0%)     13.1%        0.37 6,342 (100%)      8 
Split 2     3,678 (36.8%)     16.8%        1.26 3,786 ( 60%)      6 
Split 3     2,596 (26.0%)     24.6%        1.16 4,515 ( 71%)      4 
Split 4     2,244 (22.4%)     30.1%        1.31 4,450 ( 70%)      3 
Split 5     2,517 (25.2%)     14.5%        1.38 4,168 ( 66%)      6 
Split 6     3,420 (34.2%)     20.3%        1.34 4,332 ( 69%)      4 
Split 7     3,362 (33.6%)     24.2%        1.16 4,881 ( 77%)      3 
Split 8     3,004 (30.0%)     22.1%        1.18 4,965 ( 79%)      3 
Split 9     3,130 (31.3%)     28.0%        1.24 4,968 ( 79%)      2 
Split 10    3,604 (36.0%)     26.2%        1.22 4,906 ( 78%)      2 
Split 11    4,439 (44.4%)     16.3%        1.12 4,953 ( 78%)      3 
Split 12    4,836 (48.4%)     20.7%        0.99 5,102 ( 81%)      2 
Split 13    4,535 (45.3%)     13.0%        1.00 5,070 ( 80%)      3 
Split 14    4,420 (44.2%)     17.6%        1.01 4,920 ( 78%)      2 
Split 15    5,348 (53.5%)     17.0%        0.91 4,842 ( 77%)      2 
Resample    1,505 (15.1%)       NA%        7.80 3,884 ( 61%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std.
devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values
for summary statistics should be between 1 and 1.05.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the
population tolerance. If the accpetance rate drops quickly in the final splits, try
increasing `pop_temper` by 0.01. To visualize what geographic areas may be causing problems,
try running the following code. Highlighted areas are those that may be causing the
bottleneck.
    plot(<map object>, rowMeans(as.matrix(plans_bay) == <bottleneck iteration>))
```

![image (6)](https://user-images.githubusercontent.com/28026893/179328812-c40442e1-1ae8-48e3-9676-6e8cfc409820.png)
![image (7)](https://user-images.githubusercontent.com/28026893/179328818-0484a269-9ff4-4f3c-bd70-d1f87a123d29.png)

