### PR TITLE
2020 New Mexico Congressional Districts Un-Merge

### DIFF
--- a/analyses/NM_cd_2020/01_prep_NM_cd_2020.R
+++ b/analyses/NM_cd_2020/01_prep_NM_cd_2020.R
@@ -64,7 +64,7 @@ if (!file.exists(here(shp_path))) {
         .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
-    redist.prep.polsbypopper(shp = nm_shp,
+    redistmetrics::prep_perims(shp = nm_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 

--- a/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
+++ b/analyses/NM_cd_2020/02_setup_NM_cd_2020.R
@@ -10,9 +10,10 @@ map <- redist_map(nm_shp, pop_tol = 0.005,
 
 # Set up cores objects
 map <- map %>%
-    mutate(cores = make_cores(boundary = 2)) %>%
-    # merge by both cores and county to preserve county contiguity
-    merge_by(cores, county, drop_geom = FALSE)
+    mutate(cores = make_cores(boundary = 2))
+
+# merge by both cores and county to preserve county contiguity
+map_cores <- merge_by(map, cores, county)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NM_2020"


### PR DESCRIPTION
# 2020 New Mexico Congressional Districts

## Redistricting requirements
In New Mexico, districts must, under [legislation code SB 304](https://www.nmlegis.gov/Legislation/Legislation?Chamber=S&LegType=B&LegNo=304&year=21):

1. be contiguous
2. be reasonably compact
3. be as equal in population as practicable
4. to the extent feasible, preserve communities of interest and take into consideration political and geographic boundaries
5. to the extent feasible, preserve the core of existing districts

Additionally, race-neutral districting principles shall not be subordinated to racial considerations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We constrain the number of county divisions to 1 less than the number of Congressional Districts.
We perform cores-based simulations, thereby preserving cores of prior districts.


## Data Sources
Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
Data for New Mexico' 2020 congressional district map comes from New Mexico Legislature's [Maps and Data](https://www.nmlegis.gov/Redistricting2021/Maps_And_Data?ID202=221711.1).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2010 plan.

## Simulation Notes
We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.


## Validation

![validation_20220725_2319](https://user-images.githubusercontent.com/28026893/180916226-07304f6a-3449-4756-8564-bd16acc02fa3.png)

```
SMC: 5,000 sampled plans of 3 districts on 1,977 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.15 to 0.57

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby       pop_hisp      pop_white      pop_black       pop_aian      pop_asian       pop_nhpi 
     1.0001103      0.9999884      1.0014814      0.9999584      1.0001771      0.9999293      1.0051982      1.0026319      1.0026597      1.0022880      1.0003318 
     pop_other        pop_two       vap_hisp      vap_white      vap_black       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two pre_16_rep_tru 
     0.9998703      1.0035517      0.9999937      1.0037752      1.0026977      1.0027068      1.0020478      1.0011104      0.9998814      1.0072249      1.0029938 
pre_16_dem_cli sos_16_rep_esp sos_16_dem_oli uss_18_dem_hei uss_18_rep_ric gov_18_dem_luj gov_18_rep_pea atg_18_dem_bal atg_18_rep_hen sos_18_dem_tou sos_18_rep_cla 
     1.0000361      1.0028131      1.0008709      1.0010915      1.0037262      1.0012439      1.0026990      1.0015887      1.0035630      1.0009648      1.0032759 
        arv_16         adv_16         arv_18         adv_18  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
     1.0029486      1.0006736      1.0032911      1.0010832      1.0000568      0.9999569      1.0006526      1.0031720      1.0017154      1.0017313      1.0012026 
         e_dem          pbias           egap 
     1.0001724      0.9999065      1.0006846 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,452 (98.1%)      4.1%        0.29 1,591 (101%)     11 
Split 2     2,410 (96.4%)      2.5%        0.37 1,403 ( 89%)      6 
Resample    2,090 (83.6%)       NA%        0.38 1,531 ( 97%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,450 (98.0%)      5.5%        0.30 1,569 ( 99%)      8 
Split 2     2,380 (95.2%)      2.9%        0.40 1,427 ( 90%)      5 
Resample    1,863 (74.5%)       NA%        0.41 1,491 ( 94%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low numbers of unique
plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes
- This doesn't change anything substantive, just undoes the merge save.