### PR TITLE
2010 Nevada Congressional Districts

### DIFF
--- a/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Download and prepare data for `NV_cd_2010` analysis
+# © ALARM Project, September 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NV_cd_2010}")
+
+path_data <- download_redistricting_file("NV", "data-raw/NV", year = 2010)
+
+# Download the enacted plan
+url <- "https://redistricting.lls.edu/wp-content/uploads/nv_2010_congress_2011-10-27_2021-12-31.zip"
+path_enacted <- "data-raw/NV/NV_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NV_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NV/NV_enacted/Congressional.shp" # TODO use actual SHP
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NV_2010/shp_vtd.rds"
+perim_path <- "data-out/NV_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NV} shapefile")
+
+    # Read in redistricting data
+    nv_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$NV)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # Add municipalities
+    d_muni <- make_from_baf("NV", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("NV"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("NV", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("NV"), vtd),
+                  cd_2000 = as.integer(cd))
+    nv_shp <- left_join(nv_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+
+    # Add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    nv_shp <- nv_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District)[
+            geo_match(nv_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    prep_perims(shp = nv_shp,
+                perim_path = here(perim_path)) %>%
+        invisible()
+
+    # Simplify geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nv_shp <- rmapshaper::ms_simplify(nv_shp, keep = 0.05,
+                                          keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # Create adjacency graph
+    nv_shp$adj <- redist.adjacency(nv_shp)
+
+    nv_shp <- nv_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nv_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nv_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NV} shapefile")
+}

--- a/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
@@ -46,7 +46,7 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("NV", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("NV"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     nv_shp <- left_join(nv_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
@@ -58,17 +58,17 @@ if (!file.exists(here(shp_path))) {
     nv_shp <- nv_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$District)[
             geo_match(nv_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     prep_perims(shp = nv_shp,
-                perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # Simplify geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         nv_shp <- rmapshaper::ms_simplify(nv_shp, keep = 0.05,
-                                          keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/01_prep_NV_cd_2010.R
@@ -25,7 +25,7 @@ path_enacted <- "data-raw/NV/NV_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NV_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/NV/NV_enacted/Congressional.shp" # TODO use actual SHP
+path_enacted <- "data-raw/NV/NV_enacted/Congressional.shp"
 
 # Compile raw data into a final shapefile for analysis -----
 shp_path <- "data-out/NV_2010/shp_vtd.rds"

--- a/analyses/NV_cd_2010/02_setup_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/02_setup_NV_cd_2010.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `NV_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NV_cd_2010}")
+
+map <- redist_map(nv_shp, pop_tol = 0.005,
+                  existing_plan = cd_2010, adj = nv_shp$adj)
+
+# Make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NV_2010"
+
+# Fix state label
+map$state <- "NV"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NV_2010/NV_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NV_cd_2010/02_setup_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/02_setup_NV_cd_2010.R
@@ -5,7 +5,7 @@
 cli_process_start("Creating {.cls redist_map} object for {.pkg NV_cd_2010}")
 
 map <- redist_map(nv_shp, pop_tol = 0.005,
-                  existing_plan = cd_2010, adj = nv_shp$adj)
+    existing_plan = cd_2010, adj = nv_shp$adj)
 
 # Make pseudo counties with default settings
 map <- map %>%

--- a/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
@@ -1,0 +1,31 @@
+###############################################################################
+# Simulate plans for `NV_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NV_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map,
+                    nsims = 5e3,
+                    runs = 2L,
+                    counties = pseudo_county) %>%
+    match_numbers("cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NV_2010/NV_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NV_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NV_2010/NV_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
@@ -8,9 +8,9 @@ cli_process_start("Running simulations for {.pkg NV_cd_2010}")
 
 set.seed(2010)
 plans <- redist_smc(map,
-                    nsims = 5e3,
-                    runs = 2L,
-                    counties = pseudo_county) %>%
+    nsims = 5e3,
+    runs = 2L,
+    counties = pseudo_county) %>%
     match_numbers("cd_2010")
 
 cli_process_done()

--- a/analyses/NV_cd_2010/doc_NV_cd_2010.md
+++ b/analyses/NV_cd_2010/doc_NV_cd_2010.md
@@ -1,0 +1,30 @@
+# 2010 Nevada Congressional Districts
+
+## Redistricting requirements
+
+In Nevada, districts must (per [judicial order](https://www.ncsl.org/Portals/1/Documents/Redistricting/NV_11-OC-00042-1B_2011-09-21_Order_Re-Redistricting_20076.pdf) for the 2010 cycle):
+
+1.  be contiguous
+2.  have equal populations
+3.  be geographically compact
+4.  preserve county and municipality boundaries as much as possible
+5.  preserve communities of interest
+6.  avoid pairing incumbents "to the extent practicable"
+
+### Algorithmic Constraints
+
+1.  We enforce a maximum population deviation of 0.5%.
+2.  We use a county constraint (with pseudo-counties in Clark County) to preserve communities of interests, municipalities, and counties.
+3.  We **do not** include a restriction for avoiding incumbent pairings.
+
+## Data Sources
+
+Data for Nevada comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+
+We sample 5,000 districting plans for Nevada across 2 independent runs of the sequential Markov Chain algorithm. No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2010 Nevada Congressional Districts

## Redistricting requirements

In Nevada, districts must (per [judicial order](https://www.ncsl.org/Portals/1/Documents/Redistricting/NV_11-OC-00042-1B_2011-09-21_Order_Re-Redistricting_20076.pdf) for the 2010 cycle):

1.  be contiguous
2.  have equal populations
3.  be geographically compact
4.  preserve county and municipality boundaries as much as possible
5.  preserve communities of interest
6.  avoid pairing incumbents "to the extent practicable"

### Algorithmic Constraints

1.  We enforce a maximum population deviation of 0.5%.
2.  We use a county constraint (with pseudo-counties in Clark County) to preserve communities of interests, municipalities, and counties.
3.  We **do not** include a restriction for avoiding incumbent pairings.

## Data Sources

Data for Nevada comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes

No manual pre-processing decisions were necessary.

## Simulation Notes

We sample 5,000 districting plans for Nevada across 2 independent runs of the sequential Markov Chain algorithm. No special techniques were needed to produce the sample.

## Validation

<img width="536" alt="image" src="https://user-images.githubusercontent.com/5815717/191852898-e40cccec-bf88-473b-b060-e7d0fba24878.png">

```
SMC: 10,000 sampled plans of 4 districts on 2,126 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
Plan diversity 80% range: 0.40 to 0.71
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0002063      1.0002810      1.0006149      0.9999139      0.9999444      1.0001142      1.0012686 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0001121      1.0014044      1.0004709      1.0020534      1.0002993      0.9999197      1.0001148 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0011788      1.0000836      1.0012117      1.0005095      1.0003058      1.0003143      0.9999955 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_cor uss_16_rep_hec uss_18_dem_ros 
     1.0007432      1.0000296      1.0010173      0.9999957      1.0007206      1.0000501      1.0011719 
uss_18_rep_hel gov_18_dem_sis gov_18_rep_lax atg_18_dem_for atg_18_rep_dun sos_18_dem_ara sos_18_rep_ceg 
     0.9999978      1.0011318      1.0000111      1.0013835      0.9999975      1.0014605      1.0000070 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0007363      1.0013704      1.0010173      1.0000381      0.9999974      0.9999957      0.9999254 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
     1.0003447      1.0012976      0.9999940      1.0004781      1.0004698      1.0011042      1.0009030 
         pbias           egap 
     1.0004456      1.0014816 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,248 (85.0%)     12.6%        0.83 3,178 (101%)      7 
Split 2     4,615 (92.3%)     13.5%        0.47 3,057 ( 97%)      5 
Split 3     4,665 (93.3%)      7.3%        0.48 2,892 ( 92%)      3 
Resample    3,681 (73.6%)       NA%        0.48 2,941 ( 93%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,256 (85.1%)     10.7%        0.82 3,143 ( 99%)      8 
Split 2     4,617 (92.3%)     13.4%        0.47 3,037 ( 96%)      5 
Split 3     4,672 (93.4%)      7.3%        0.48 2,902 ( 92%)      3 
Resample    3,696 (73.9%)       NA%        0.48 2,916 ( 92%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the master branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny (sorry if you weren't the one who volunteered, I couldn't actually tell who was speaking, haha)