### PR TITLE
# 2010 Minnesota Congressional Districts

### DIFF
--- a/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
@@ -41,6 +41,9 @@ if (!file.exists(here(shp_path))) {
         st_transform(EPSG$MN)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
+    # Fix labeling
+    mn_shp$state <- "MN"
+
     # add municipalities
     d_muni <- make_from_baf("MN", "INCPLACE_CDP", "VTD", year = 2010)  %>%
         mutate(GEOID = paste0(censable::match_fips("MN"), vtd)) %>%

--- a/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
@@ -66,7 +66,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
             keep_shapes = TRUE) %>%

--- a/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/01_prep_MN_cd_2010.R
@@ -1,0 +1,94 @@
+###############################################################################
+# Download and prepare data for `MN_cd_2010` analysis
+# © ALARM Project, September 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MN_cd_2010}")
+
+path_data <- download_redistricting_file("MN", "data-raw/MN", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/mn_2010_congress_2012-02-21_2021-12-31.zip"
+path_enacted <- "data-raw/MN/MN_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "MN_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/MN/MN_enacted/C2012.shp"
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MN_2010/shp_vtd.rds"
+perim_path <- "data-out/MN_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MN} shapefile")
+    # read in redistricting data
+    mn_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$MN)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MN", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("MN"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MN", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("MN"), vtd),
+                  cd_2000 = as.integer(cd))
+    mn_shp <- left_join(mn_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    mn_shp <- mn_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(mn_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redist.prep.polsbypopper(shp = mn_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mn_shp$adj <- redist.adjacency(mn_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    mn_shp <- mn_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(mn_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mn_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MN} shapefile")
+}

--- a/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
@@ -9,7 +9,7 @@ map <- redist_map(mn_shp, pop_tol = 0.005,
 
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = 0.6*get_target(map)))
+        pop_muni = 0.6*get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MN_2010"

--- a/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
@@ -14,9 +14,6 @@ map <- map %>%
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MN_2010"
 
-# Fix labeling
-map$state <- "MN"
-
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/MN_2010/MN_cd_2010_map.rds", compress = "xz")
 cli_process_done()

--- a/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/02_setup_MN_cd_2010.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `MN_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MN_cd_2010}")
+
+map <- redist_map(mn_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = mn_shp$adj)
+
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = 0.6*get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MN_2010"
+
+# Fix labeling
+map$state <- "MN"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MN_2010/MN_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MN_cd_2010/03_sim_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/03_sim_MN_cd_2010.R
@@ -1,0 +1,31 @@
+###############################################################################
+# Simulate plans for `MN_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MN_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MN_2010/MN_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MN_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MN_2010/MN_cd_2010_stats.csv")
+
+cli_process_done()
+
+validate_analysis(plans, map)
+

--- a/analyses/MN_cd_2010/03_sim_MN_cd_2010.R
+++ b/analyses/MN_cd_2010/03_sim_MN_cd_2010.R
@@ -28,4 +28,3 @@ save_summary_stats(plans, "data-out/MN_2010/MN_cd_2010_stats.csv")
 cli_process_done()
 
 validate_analysis(plans, map)
-

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -25,6 +25,4 @@ Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Minnesota across two independent runs of the SMC algorithm. We use a pseudo-county constraint to balance the county and municipality splits, viewing counties with populations larger than 60% of the target population through their municipalties instead of 
-
-Municipality lines used are in , which are all counties with populations larger than 60% the target population for district.
+We sample 5,000 districting plans for Minnesota across two independent runs of the SMC algorithm. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Dakota County, Hennepin County, Ramsey, which are the counties with populations larger than 60% the target population for districts. Within Allegheny County, Montgomery County, and Philadelphia County, each municipality is its own pseudocounty as well. 

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -4,7 +4,7 @@
 In Minnesota, districts must:
 
 1. be contiguous
-2, have equal populations
+2. have equal populations
 3. comply with VRA section 2
 4. be geographically compact
 5. preserve political subdivisions and communities of interest as possible 
@@ -25,4 +25,6 @@ Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans  for Minnesota across two independent runs of the SMC algorithm.  We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines used are in , which are all counties with populations larger than 60% the target population for district.
+We sample 5,000 districting plans for Minnesota across two independent runs of the SMC algorithm. We use a pseudo-county constraint to balance the county and municipality splits, viewing counties with populations larger than 60% of the target population through their municipalties instead of 
+
+Municipality lines used are in , which are all counties with populations larger than 60% the target population for district.

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -7,9 +7,10 @@ In Minnesota, districts must:
 2, have equal populations
 3. comply with VRA section 2
 4. be geographically compact
-5. preserve political subdivisions and communities of interest as possible avoid pairing incumbents but also cannot give unfair advantage to incumbents (least important criteria)
+5. preserve political subdivisions and communities of interest as possible 
+6. avoid pairing incumbents but also cannot give unfair advantage to incumbents (least important criteria)
 
-https://www.ncsl.org/Portals/1/Documents/Redistricting/DistrictingPrinciplesFor2010andBeyond-9.pdf
+https://www.mncourts.gov/mncourtsgov/media/CIOMediaLibrary/2011Redistricting/A110152Order11-4-11.pdf
 
 ### Interpretation of requirements
 We do not adhere to all criteria in the guidelines. We include the following constraints:

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -25,4 +25,6 @@ Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Minnesota across two independent runs of the SMC algorithm. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Dakota County, Hennepin County, Ramsey, which are the counties with populations larger than 60% the target population for districts. Within Allegheny County, Montgomery County, and Philadelphia County, each municipality is its own pseudocounty as well. 
+We sample 5,000 districting plans for Minnesota across two independent runs of the SMC algorithm.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint.
+These are counties, outside of Dakota, Hennepin, and Ramsey counties, which are the counties with populations larger than 60% the target population for districts. Within Dakota, Hennepin, and Ramsey counties, each municipality is its own pseudocounty as well.

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -1,0 +1,25 @@
+# 2010 Minnesota Congressional Districts
+
+## Redistricting requirements
+In Minnesota, districts must:
+
+1. be contiguous
+2, have equal populations
+3. comply with VRA section 2
+4. be geographically compact
+5. preserve political subdivisions and communities of interest as possible avoid pairing incumbents but also cannot give unfair advantage to incumbents (least important criteria)
+
+### Interpretation of requirements
+We do not adhere to all criteria in the guidelines. We include the following constraints:
+
+1. We enforce a maximum population deviation of 0.5%. 
+2. We use a pseudo-county constraint to help preseve county, city, and township boundaries.
+
+## Data Sources
+Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans  for Minnesota across two independent runs of the SMC algorithm. Municipailtiy 

--- a/analyses/MN_cd_2010/doc_MN_cd_2010.md
+++ b/analyses/MN_cd_2010/doc_MN_cd_2010.md
@@ -9,11 +9,13 @@ In Minnesota, districts must:
 4. be geographically compact
 5. preserve political subdivisions and communities of interest as possible avoid pairing incumbents but also cannot give unfair advantage to incumbents (least important criteria)
 
+https://www.ncsl.org/Portals/1/Documents/Redistricting/DistrictingPrinciplesFor2010andBeyond-9.pdf
+
 ### Interpretation of requirements
 We do not adhere to all criteria in the guidelines. We include the following constraints:
 
 1. We enforce a maximum population deviation of 0.5%. 
-2. We use a pseudo-county constraint to help preseve county, city, and township boundaries.
+2. We use a pseudo-county constraint to help preserve county and municipality boundaries.
 
 ## Data Sources
 Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -22,4 +24,4 @@ Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans  for Minnesota across two independent runs of the SMC algorithm. Municipailtiy 
+We sample 5,000 districting plans  for Minnesota across two independent runs of the SMC algorithm.  We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines used are in , which are all counties with populations larger than 60% the target population for district.

--- a/analyses/SC_cd_2010/03_sim_SC_cd_2010.R
+++ b/analyses/SC_cd_2010/03_sim_SC_cd_2010.R
@@ -92,4 +92,14 @@ if (interactive()) {
         group_by(draw) %>%
         summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
         count(n_black_perf)
+
+    redist.plot.hist(plans = plans_5k, qty = e_dem) +
+        # scale_x_continuous(name = 'Expected Number of Democratic Districts') +
+        theme_bw()
+
+    redist.plot.plans(plans, draw = 100, shp = map, qty = ndv/(ndv + nrv), ) +
+        # scale_fill_party_c() +
+        # theme_map() +
+        theme(legend.position = "right") +
+        labs(title = "")
 }


### PR DESCRIPTION
## Redistricting requirements
In Minnesota, districts must:

1. be contiguous
2, have equal populations
3. comply with VRA section 2
4. be geographically compact
5. preserve political subdivisions and communities of interest as possible 
6. avoid pairing incumbents but also cannot give unfair advantage to incumbents (least important criteria)

https://www.mncourts.gov/mncourtsgov/media/CIOMediaLibrary/2011Redistricting/A110152Order11-4-11.pdf

### Interpretation of requirements
We do not adhere to all criteria in the guidelines. We include the following constraints:

1. We enforce a maximum population deviation of 0.5%. 
2. We use a pseudo-county constraint to help preserve county and municipality boundaries.

## Data Sources
Data for Minnesota comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans  for Minnesota across two independent runs of the SMC algorithm.  We use a pseudo-county constraint to limit the county and municipality splits. Municipality lines used are in , which are all counties with populations larger than 60% the target population for district.

## Validation

![validation_20220923_0027](https://user-images.githubusercontent.com/66656384/191894568-e1f72f5e-6820-42ea-a93e-43458d115cd2.png)

```
SMC: 5,000 sampled plans of 8 districts on 4,139 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.75 to 0.96

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge 
     1.0005790      1.0056396      1.0056415      1.0049476 
   comp_polsby      pop_white      pop_black       pop_hisp 
     1.0046960      1.0108363      0.9998412      1.0063150 
      pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0104688      1.0001160      1.0035693      1.0027999 
       pop_two      vap_white      vap_black       vap_hisp 
     1.0010168      0.9999362      1.0004351      1.0057413 
      vap_aian      vap_asian       vap_nhpi      vap_other 
     1.0150546      1.0003509      1.0088918      1.0038647 
       vap_two pre_16_rep_tru pre_16_dem_cli pre_20_dem_bid 
     1.0030227      1.0056811      1.0035710      1.0015246 
pre_20_rep_tru uss_18_rep_new uss_18_dem_klo uss_20_dem_smi 
     1.0078803      1.0127675      1.0037961      1.0019473 
uss_20_rep_lew gov_18_rep_joh gov_18_dem_wal atg_18_rep_war 
     1.0245385      1.0107032      1.0064958      1.0110698 
atg_18_dem_ell sos_18_rep_how sos_18_dem_sim         adv_16 
     1.0057198      1.0118992      1.0041557      1.0035710 
        adv_18         adv_20         arv_16         arv_18 
     1.0051309      1.0012599      1.0056811      1.0117627 
        arv_20  county_splits    muni_splits            ndv 
     1.0109896      1.0090998      1.0011957      1.0032745 
           nrv        ndshare          e_dvs         pr_dem 
     1.0271921      1.0006879      1.0005442      1.0011941 
         e_dem          pbias           egap 
     0.9999207      1.0017316      1.0002931 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique
Split 1     2,458 (98.3%)      9.8%        0.26 1,585 (100%)
Split 2     2,412 (96.5%)     13.8%        0.35 1,567 ( 99%)
Split 3     2,367 (94.7%)     17.6%        0.45 1,574 (100%)
Split 4     2,326 (93.1%)     19.4%        0.52 1,551 ( 98%)
Split 5     2,267 (90.7%)     17.1%        0.58 1,545 ( 98%)
Split 6     2,242 (89.7%)      7.8%        0.59 1,455 ( 92%)
Split 7     2,280 (91.2%)      4.4%        0.55 1,326 ( 84%)
Resample    1,647 (65.9%)       NA%        0.56 1,920 (121%)
         Est. k 
Split 1      13 
Split 2       8 
Split 3       5 
Split 4       4 
Split 5       4 
Split 6       7 
Split 7       4 
Resample     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique
Split 1     2,459 (98.4%)     11.6%        0.26 1,592 (101%)
Split 2     2,417 (96.7%)     15.8%        0.35 1,560 ( 99%)
Split 3     2,393 (95.7%)     18.5%        0.42 1,571 ( 99%)
Split 4     2,305 (92.2%)     20.0%        0.50 1,533 ( 97%)
Split 5     2,290 (91.6%)     16.4%        0.55 1,535 ( 97%)
Split 6     2,300 (92.0%)     17.4%        0.54 1,439 ( 91%)
Split 7     2,285 (91.4%)      4.5%        0.54 1,364 ( 86%)
Resample    1,583 (63.3%)       NA%        0.55 1,907 (121%)
         Est. k 
Split 1      11 
Split 2       7 
Split 3       5 
Split 4       4 
Split 5       4 
Split 6       3 
Split 7       4 
Resample     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny
