### PR TITLE
2010 New Hampshire Congressional Districts

### DIFF
--- a/analyses/NH_cd_2010/01_prep_NH_cd_2010.R
+++ b/analyses/NH_cd_2010/01_prep_NH_cd_2010.R
@@ -1,0 +1,92 @@
+###############################################################################
+# Download and prepare data for `NH_cd_2010` analysis
+# © ALARM Project, September 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NH_cd_2010}")
+
+path_data <- download_redistricting_file("NH", "data-raw/NH", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/nh_2010_congress_2012-06-22_2021-12-31.zip"
+path_enacted <- "data-raw/NH/NH_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NH_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NH/NH_enacted/NHCongDists2012.shp"
+
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NH_2010/shp_vtd.rds"
+perim_path <- "data-out/NH_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NH} shapefile")
+    # read in redistricting data
+    nh_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$NH)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NH", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("NH"), vtd)) %>%
+        select(-vtd)
+    d_mcd <- make_from_baf("NH", "MCD", "VTD")  %>%
+        mutate(GEOID = paste0(censable::match_fips("NH"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("NH", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("NH"), vtd),
+            cd_2000 = as.integer(cd))
+    nh_shp <- left_join(nh_shp, d_muni, by = "GEOID") %>%
+        left_join(d_mcd, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    nh_shp <- nh_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$CONG2012)[
+            geo_match(nh_shp, cd_shp, method = "area")],
+        .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nh_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nh_shp <- rmapshaper::ms_simplify(nh_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nh_shp$adj <- redist.adjacency(nh_shp)
+
+    nh_shp <- nh_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nh_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nh_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NH} shapefile")
+}

--- a/analyses/NH_cd_2010/02_setup_NH_cd_2010.R
+++ b/analyses/NH_cd_2010/02_setup_NH_cd_2010.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `NH_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NH_cd_2010}")
+
+map <- redist_map(nh_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = nh_shp$adj) %>% mutate(state = "NH")
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NH_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NH_2010/NH_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NH_cd_2010/03_sim_NH_cd_2010.R
+++ b/analyses/NH_cd_2010/03_sim_NH_cd_2010.R
@@ -1,0 +1,35 @@
+###############################################################################
+# Simulate plans for `NH_cd_2010`
+# © ALARM Project, September 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NH_cd_2010}")
+
+# Run simulations, replacing state FIPS with abbreviation (for ease in generating validation graphic)
+## Merging by MCDs
+set.seed(2010)
+plans <- redist_smc(map %>% mutate(state = "NH") %>% merge_by(mcd),
+    nsims = 5e3,
+    runs = 2L,
+    counties = county) %>%
+    pullback() %>%
+    structure(prec_pop = map$pop) %>%
+    match_numbers("cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NH_2010/NH_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NH_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NH_2010/NH_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/NH_cd_2010/doc_NH_cd_2010.md
+++ b/analyses/NH_cd_2010/doc_NH_cd_2010.md
@@ -1,0 +1,20 @@
+# 2010 New Hampshire Congressional Districts
+
+## Redistricting requirements
+In New Hampshire, districts must:
+
+1. be contiguous
+2. have equal populations
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for New Hampshire comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+Since the enacted plan has no minor civil division (MCD) splits, we merge precincts into MCDs prior to simulating districts.
+
+## Simulation Notes
+We sample 5,000 districting plans for New Hampshire in 2 independent runs of the sequential Monte Carlo algorithm.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In New Hampshire, districts must:

1. be contiguous
2. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for New Hampshire comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Since the enacted plan has no minor civil division (MCD) splits, we merge precincts into MCDs prior to simulating districts.

## Simulation Notes
We sample 5,000 districting plans for New Hampshire in 2 independent runs of the sequential Monte Carlo algorithm.
No special techniques were needed to produce the sample.

## Validation

<img width="539" alt="image" src="https://user-images.githubusercontent.com/5815717/193037321-890c2672-05d3-43f0-84e1-dc77fc7758b7.png">

```
SMC: 10,000 sampled plans of 2 districts on 327 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.077 to 0.688

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0003513      1.0001241      1.0001424      1.0001911      1.0001240      0.9999308      0.9999279 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0002353      1.0004657      1.0001745      1.0003403      1.0002216      1.0001565      1.0000949 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     0.9999270      1.0001076      1.0004601      1.0001754      1.0004624      1.0001429      1.0007339 
pre_16_rep_tru pre_16_dem_cli pre_20_dem_bid pre_20_rep_tru uss_16_rep_ayo uss_16_dem_has uss_20_dem_sha 
     1.0004108      1.0000235      1.0000306      1.0003255      1.0004218      1.0000711      1.0000726 
uss_20_rep_mes gov_16_rep_sun gov_16_dem_van gov_18_rep_sun gov_18_dem_kel gov_20_dem_fel gov_20_rep_sun 
     1.0003142      1.0006072      1.0001284      1.0004109      1.0000197      1.0000276      1.0003850 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20            ndv 
     1.0000556      1.0000197      1.0000716      1.0004907      1.0004109      1.0003269      1.0000385 
           nrv        ndshare          e_dvs         pr_dem          e_dem           egap 
     1.0004114      1.0003163      1.0002981      1.0006573      0.9999000      1.0001386 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,944 (98.9%)      3.5%        0.21 3,127 ( 99%)      5 
Resample    4,765 (95.3%)       NA%        0.21 3,115 ( 99%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,945 (98.9%)      3.5%        0.21 3,168 (100%)      5 
Resample    4,768 (95.4%)       NA%        0.21 3,102 ( 98%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the master branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko
