### PR TITLE
2010 Louisiana Congressional Districts

### DIFF
--- a/analyses/LA_cd_2010/01_prep_LA_cd_2010.R
+++ b/analyses/LA_cd_2010/01_prep_LA_cd_2010.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Download and prepare data for `LA_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg LA_cd_2010}")
+
+path_data <- download_redistricting_file("LA", "data-raw/LA", year = 2010)
+
+# download the enacted plan.
+url <- "https://house.louisiana.gov/h_redistricting2011/ShapfilesAnd2010CensusBlockEquivFiles/Shapefile%20-%20Congress%20-%20Act%202%20(HB6)%20of%20the%202011%20ES.zip"
+path_enacted <- "data-raw/LA/LA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "LA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/LA/LA_enacted/Congress_-_Act_2_(2011).shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/LA_2010/shp_vtd.rds"
+perim_path <- "data-out/LA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong LA} shapefile")
+    # read in redistricting data
+    la_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$LA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("LA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("LA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("LA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("LA"), vtd),
+            cd_2000 = as.integer(cd))
+    la_shp <- left_join(la_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    la_shp <- la_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(la_shp, cd_shp, method = "area")],
+        .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = la_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    la_shp$adj <- redist.adjacency(la_shp)
+
+    la_shp <- la_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(la_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    la_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong LA} shapefile")
+}

--- a/analyses/LA_cd_2010/02_setup_LA_cd_2010.R
+++ b/analyses/LA_cd_2010/02_setup_LA_cd_2010.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `LA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_2010}")
+
+map <- redist_map(la_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = la_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map))) %>%
+    mutate(core_id = redist.identify.cores(adj, cd_2010, boundary = 2))
+map_m <- merge_by(map, core_id)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "LA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/LA_2010/LA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/LA_cd_2010/03_sim_LA_cd_2010.R
+++ b/analyses/LA_cd_2010/03_sim_LA_cd_2010.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Simulate plans for `LA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_cd_2010}")
+
+constr <- redist_constr(map_m) %>%
+    add_constr_grp_hinge(30, vap - vap_white, vap, 0.50) %>%
+    add_constr_grp_hinge(-25, vap - vap_white, vap, 0.41) %>%
+    add_constr_grp_inv_hinge(10, vap - vap_white, vap, 0.55)
+
+set.seed(2010)
+plans <- redist_smc(map_m,
+    runs = 2L,
+    nsims = 8e3,
+    counties = pseudo_county,
+    constraints = constr) %>%
+    pullback(map) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_2010/LA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_2010/LA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    # Black VAP Performance Plot
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Louisiana Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
+
+    # Minority VAP Performance Plot
+    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Minority Percentage by VAP") +
+        labs(title = "Louisiana Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
+
+    # Dem seats by BVAP rank -- numeric
+    plans %>%
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
+
+}

--- a/analyses/LA_cd_2010/03_sim_LA_cd_2010.R
+++ b/analyses/LA_cd_2010/03_sim_LA_cd_2010.R
@@ -53,7 +53,7 @@ if (interactive()) {
         size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
         labs(title = "Louisiana Proposed Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        scale_color_manual(values = c(cd_2010_prop = "black")) +
         theme_bw()
 
     # Minority VAP Performance Plot
@@ -63,7 +63,7 @@ if (interactive()) {
         size = 0.5, alpha = 0.5) +
         scale_y_continuous("Minority Percentage by VAP") +
         labs(title = "Louisiana Proposed Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        scale_color_manual(values = c(cd_2010_prop = "black")) +
         theme_bw()
 
     # Dem seats by BVAP rank -- numeric

--- a/analyses/LA_cd_2010/doc_LA_cd_2010.md
+++ b/analyses/LA_cd_2010/doc_LA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Louisiana Congressional Districts
+
+## Redistricting requirements
+In Louisiana, according to [La. Const. art. III, § 6](https://senate.la.gov/Documents/Constitution/Article3.htm#%C2%A76%20Legislative%20Reapportionment;%20Reapportionment%20by%20Supreme%20Court;%20Procedure), districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve parish and municipality boundaries as much as possible
+5. preserve the cores of traditional district alignments
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
+
+## Data Sources
+Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 enacted plan comes from [State of Louisiana Redistricting](https://redist.legis.la.gov/).
+
+## Pre-processing Notes
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2000 plan.
+
+## Simulation Notes
+We sample 16,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Louisiana, according to [La. Const. art. III, § 6](https://senate.la.gov/Documents/Constitution/Article3.htm#%C2%A76%20Legislative%20Reapportionment;%20Reapportionment%20by%20Supreme%20Court;%20Procedure), districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve parish and municipality boundaries as much as possible
5. preserve the cores of traditional district alignments


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.

## Data Sources
Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 enacted plan comes from [State of Louisiana Redistricting](https://redist.legis.la.gov/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2000 plan.

## Simulation Notes
We sample 16,000 districting plans for Louisiana across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


## Validation

![validation_20221031_1626](https://user-images.githubusercontent.com/55368740/199105785-40c5a899-1590-4816-ac71-7d487700fc2c.png)

```
SMC: 5,000 sampled plans of 6 districts on 3,671 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.35 to 0.63

R-hat values for summary statistics:
    pop_overlap       total_vap        plan_dev       comp_edge     comp_polsby       pop_white       pop_black        pop_hisp 
      1.0030457       1.0047633       1.0025970       1.0067970       1.0031160       1.0001316       1.0008049       1.0023660 
       pop_aian       pop_asian        pop_nhpi       pop_other         pop_two       vap_white       vap_black        vap_hisp 
      1.0046909       1.0061944       1.0132366       1.0051109       1.0019936       1.0006788       1.0007559       1.0020076 
       vap_aian       vap_asian        vap_nhpi       vap_other         vap_two  pre_16_rep_tru  pre_16_dem_cli  pre_20_rep_tru 
      1.0049997       1.0062487       1.0010450       1.0055397       1.0119408       1.0023954       1.0058058       1.0005009 
 pre_20_dem_bid  uss_16_rep_ken  uss_16_rep_bou  uss_16_rep_fle  uss_16_rep_man  uss_16_rep_duk  uss_16_rep_cra  uss_16_rep_cao 
      1.0035275       1.0016199       1.0028609       1.0034384       1.0004598       1.0037585       1.0013934       1.0035052 
 uss_16_rep_mar  uss_16_rep_pat  uss_16_dem_cam  uss_16_dem_fay  uss_16_dem_edw  uss_16_dem_lan  uss_16_dem_pel  uss_16_dem_wil 
      1.0035245       1.0014309       1.0110926       1.0010633       1.0038878       1.0030205       1.0025543       1.0036300 
 uss_16_dem_men uss_r16_rep_ken uss_r16_dem_cam  uss_20_rep_cas  uss_20_rep_mur  uss_20_dem_per  uss_20_dem_edw  uss_20_dem_pie 
      1.0015927       1.0030900       1.0154472       0.9999853       0.9999805       1.0059686       1.0077669       1.0027185 
 uss_20_dem_kni  uss_20_dem_wen  sos_18_rep_ard  sos_18_rep_edm  sos_18_rep_sto  sos_18_rep_ken  sos_18_rep_cro  sos_18_rep_clo 
      1.0049630       1.0018723       1.0033763       1.0085822       1.0038701       1.0052762       1.0048485       1.0041034 
 sos_18_dem_col  sos_18_dem_fre sos_r18_rep_ard sos_r18_dem_col          adv_16          adv_18          adv_20          arv_16 
      1.0049509       1.0048222       1.0037522       1.0006890       1.0094526       1.0086789       1.0038369       1.0003330 
         arv_18          arv_20   county_splits     muni_splits             ndv             nrv         ndshare           e_dvs 
      1.0018229       0.9998994       1.0049064       1.0071205       1.0054118       1.0017583       1.0063723       1.0012305 
         pr_dem           e_dem           pbias            egap 
      1.0000683       1.0004277       1.0003136       1.0023064 

Sampling diagnostics for SMC run 1 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,650 (45.6%)      6.0%        0.27 5,064 (100%)     14 
Split 2     5,203 (65.0%)      8.3%        0.90 4,135 ( 82%)      8 
Split 3     5,854 (73.2%)     12.2%        0.69 4,346 ( 86%)      5 
Split 4     5,654 (70.7%)     17.3%        0.72 4,330 ( 86%)      3 
Split 5     4,744 (59.3%)      7.4%        0.72 3,633 ( 72%)      2 
Resample       662 (8.3%)       NA%        1.34 3,882 ( 77%)     NA 

Sampling diagnostics for SMC run 2 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,620 (45.2%)      8.4%        0.28 5,065 (100%)     10 
Split 2     5,259 (65.7%)     11.2%        0.90 4,098 ( 81%)      6 
Split 3     5,810 (72.6%)      9.0%        0.68 4,366 ( 86%)      7 
Split 4     5,941 (74.3%)     13.8%        0.69 4,295 ( 85%)      4 
Split 5     5,331 (66.6%)      4.7%        0.68 3,749 ( 74%)      4 
Resample    1,020 (12.8%)       NA%        1.30 4,328 ( 86%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Minority VAP performance plot:
![image](https://user-images.githubusercontent.com/55368740/199596973-8f32e2be-4a8a-4599-81b1-c0d098662dbf.png)

BVAP performance plot:
![image](https://user-images.githubusercontent.com/55368740/199596917-d1779a29-79a2-42ea-873a-719bc03445f9.png)

Number of performant districts per plan:
```
  n_black_perf    n
1            1 4708
2            2  292
```

@tylersimko
