### PR TITLE
2010 Massachusetts Congressional Districts

### DIFF
--- a/analyses/MA_cd_2010/01_prep_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/01_prep_MA_cd_2010.R
@@ -1,0 +1,78 @@
+###############################################################################
+# Download and prepare data for `MA_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MA_cd_2010}")
+
+path_data <- download_redistricting_file("MA", "data-raw/MA", year = 2010)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MA_2010/shp_vtd.rds"
+perim_path <- "data-out/MA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MA} shapefile")
+    # read in redistricting data
+    ma_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$MA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("MA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("MA"), vtd),
+                  cd_2000 = as.integer(cd))
+    ma_shp <- left_join(ma_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf('MA', from = read_baf_cd113('MA'), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0('25', GEOID))
+    ma_shp <- ma_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ma_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ma_shp <- rmapshaper::ms_simplify(ma_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ma_shp$adj <- redist.adjacency(ma_shp)
+
+
+    ma_shp <- ma_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ma_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ma_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MA} shapefile")
+}

--- a/analyses/MA_cd_2010/02_setup_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/02_setup_MA_cd_2010.R
@@ -1,0 +1,20 @@
+###############################################################################
+# Set up redistricting simulation for `MA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MA_cd_2010}")
+
+map <- redist_map(ma_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ma_shp$adj)
+
+# Create pseudo counties
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MA_2010/MA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
@@ -1,0 +1,31 @@
+###############################################################################
+# Simulate plans for `MA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MA_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MA_2010/MA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics.
+save_summary_stats(plans, "data-out/MA_2010/MA_cd_2010_stats.csv")
+
+cli_process_done()
+

--- a/analyses/MA_cd_2010/doc_MA_cd_2010.md
+++ b/analyses/MA_cd_2010/doc_MA_cd_2010.md
@@ -12,6 +12,7 @@ In Massachusetts, districts must:
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.05%. 
 We use a pseudo-county constraint to help preserve county and municipality boundaries.
+These counties are Dukes, Middlesex, and Worcester--these three counties have populations larger than 60% of the target population for districts. To preserve municipality splits, each municipality is its own pseudocounty.
 
 ## Data Sources
 Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/MA_cd_2010/doc_MA_cd_2010.md
+++ b/analyses/MA_cd_2010/doc_MA_cd_2010.md
@@ -1,0 +1,24 @@
+# 2010 Massachusetts Congressional Districts
+
+## Redistricting requirements
+In Massachusetts, districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.05%. 
+We use a pseudo-county constraint to help preserve county and municipality boundaries.
+
+## Data Sources
+Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Massachusetts over two runs.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements

In Massachusetts, districts must:

1. Be contiguous
2. Have equal populations
3. Be geographically compact
4. Preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.05%. 
We use a pseudo-county constraint to help preserve county and municipality boundaries.

## Data Sources
Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Massachusetts over two runs.
No special techniques were needed to produce the sample.


## Validation

![ValidatedAnalysisMA_cd_2010GH](https://user-images.githubusercontent.com/57640740/199154973-600052eb-66ec-45d6-9213-4b9055fed78b.png)

```
SMC: 5,000 sampled plans of 9 districts on 2,165 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.48 to 0.76

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby 
     1.0000487      1.0023960      1.0019437      1.0073902      1.0060788 
     pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
     1.0028252      1.0008330      1.0031391      1.0119444      1.0076714 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black 
     1.0047201      1.0005845      1.0007707      1.0006314      1.0011000 
      vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
     1.0021735      1.0117563      1.0024991      1.0055309      1.0004479 
       vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru 
     1.0029299      1.0078367      1.0043473      1.0074794      1.0027101 
uss_18_dem_war uss_18_rep_die uss_20_dem_mar uss_20_rep_oco gov_18_rep_bak 
     1.0050153      1.0036246      1.0068421      1.0031245      1.0027185 
gov_18_dem_gon atg_18_dem_hea atg_18_rep_mcm         adv_16         adv_18 
     1.0030871      1.0086362      1.0048320      1.0078367      1.0059540 
        adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0071927      1.0043473      1.0053729      1.0030743      1.0019480 
   muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0163033      1.0051055      1.0040678      1.0117118      1.0114710 
         e_dem          pbias           egap 
     0.9998162      1.0099548      1.0043140 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,404 (96.1%)     14.8%        0.42 1,589 (101%)      7 
Split 2     2,370 (94.8%)     22.2%        0.44 1,567 ( 99%)      4 
Split 3     2,362 (94.5%)     13.5%        0.46 1,567 ( 99%)      6 
Split 4     2,361 (94.5%)     17.4%        0.48 1,527 ( 97%)      4 
Split 5     2,343 (93.7%)     19.7%        0.49 1,563 ( 99%)      3 
Split 6     2,325 (93.0%)     22.9%        0.51 1,533 ( 97%)      2 
Split 7     2,352 (94.1%)     16.9%        0.47 1,438 ( 91%)      2 
Split 8     2,319 (92.8%)      2.7%        0.51 1,247 ( 79%)      4 
Resample    1,780 (71.2%)       NA%        0.52 1,971 (125%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,400 (96.0%)     16.9%        0.42 1,582 (100%)      6 
Split 2     2,364 (94.6%)     17.8%        0.45 1,559 ( 99%)      5 
Split 3     2,363 (94.5%)     20.1%        0.46 1,547 ( 98%)      4 
Split 4     2,360 (94.4%)     14.3%        0.47 1,530 ( 97%)      5 
Split 5     2,347 (93.9%)     20.6%        0.50 1,542 ( 98%)      3 
Split 6     2,325 (93.0%)     23.7%        0.51 1,498 ( 95%)      2 
Split 7     2,334 (93.4%)      8.8%        0.48 1,467 ( 93%)      4 
Split 8     2,298 (91.9%)      3.7%        0.52 1,217 ( 77%)      3 
Resample    1,663 (66.5%)       NA%        0.54 1,954 (124%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%),
large std. devs. of the log weights (more than 3 or so), and low numbers of unique
plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
