### PR TITLE
2010 Maine Congressional Districts

### DIFF
--- a/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
@@ -47,27 +47,27 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("ME", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("ME"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     me_shp <- left_join(me_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
     # add the enacted plan
-    baf_cd113 <- make_from_baf('ME', from = read_baf_cd113('ME'), year = 2010) %>%
-        rename(GEOID = vtd) %>% mutate(GEOID = paste0('23', GEOID))
+    baf_cd113 <- make_from_baf("ME", from = read_baf_cd113("ME"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("23", GEOID))
     me_shp <- me_shp %>%
         left_join(baf_cd113, by = "GEOID")
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = me_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         me_shp <- rmapshaper::ms_simplify(me_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
@@ -1,0 +1,93 @@
+###############################################################################
+# Download and prepare data for `ME_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg ME_cd_2010}")
+
+path_data <- download_redistricting_file("ME", "data-raw/ME", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/me_2010_congress_2011-09-28_2021-12-31.zip"
+path_enacted <- "data-raw/ME/ME_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "ME_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/ME/ME_enacted/Maine_US_Congressional_Districts_2011_GeoLibrary.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/ME_2010/shp_vtd.rds"
+perim_path <- "data-out/ME_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong ME} shapefile")
+    # read in redistricting data
+    me_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$ME)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("ME", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("ME"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("ME", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("ME"), vtd),
+                  cd_2000 = as.integer(cd))
+    me_shp <- left_join(me_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    me_shp <- me_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(me_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = me_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        me_shp <- rmapshaper::ms_simplify(me_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    me_shp$adj <- redist.adjacency(me_shp)
+
+    # fix disconnected islands, respecting district assumptions
+    adds <- suggest_component_connection(me_shp, me_shp$adj, me_shp$cd_2010)
+    me_shp$adj <- me_shp$adj %>% add_edge(adds$x, adds$y)
+
+    me_shp <- me_shp %>%
+        fix_geo_assignment(muni)
+
+    me_shp$state <- "ME"
+
+    write_rds(me_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    me_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong ME} shapefile")
+}

--- a/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/01_prep_ME_cd_2010.R
@@ -25,7 +25,7 @@ path_enacted <- "data-raw/ME/ME_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "ME_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/ME/ME_enacted/Maine_US_Congressional_Districts_2011_GeoLibrary.shp" # TODO use actual SHP
+path_enacted <- "data-raw/ME/ME_enacted/Maine_US_Congressional_Districts_2011_GeoLibrary.shp"
 
 cli_process_done()
 

--- a/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `ME_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg ME_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(me_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = me_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "ME_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/ME_2010/ME_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
@@ -4,23 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg ME_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(me_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = me_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "ME_2010"
+
+map$state <- 'ME'
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/ME_2010/ME_cd_2010_map.rds", compress = "xz")

--- a/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/02_setup_ME_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(me_shp, pop_tol = 0.005,
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "ME_2010"
 
-map$state <- 'ME'
+map$state <- "ME"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/ME_2010/ME_cd_2010_map.rds", compress = "xz")

--- a/analyses/ME_cd_2010/03_sim_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/03_sim_ME_cd_2010.R
@@ -1,0 +1,53 @@
+###############################################################################
+# Simulate plans for `ME_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg ME_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+
+plans <- redist_smc(
+    map,
+    nsims = 1250, runs = 4L,
+    counties = county, compactness = 0.8
+)
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/ME_2010/ME_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg ME_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/ME_2010/ME_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/ME_cd_2010/03_sim_ME_cd_2010.R
+++ b/analyses/ME_cd_2010/03_sim_ME_cd_2010.R
@@ -6,17 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg ME_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
 
 plans <- redist_smc(
@@ -43,11 +32,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/ME_2010/ME_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/ME_cd_2010/doc_ME_cd_2010.md
+++ b/analyses/ME_cd_2010/doc_ME_cd_2010.md
@@ -16,4 +16,4 @@ Islands tracts were connected to the nearest tract within the same district.
 ## Simulation Notes
 We sample 5,000 districting plans for Maine, across 4 independent runs of the SMC algorithm.
 We use the standard county constraint.
-We weaken the compactness parameter to 0.0 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.
+We weaken the compactness parameter to 0.8 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.

--- a/analyses/ME_cd_2010/doc_ME_cd_2010.md
+++ b/analyses/ME_cd_2010/doc_ME_cd_2010.md
@@ -16,4 +16,4 @@ Islands tracts were connected to the nearest tract within the same district.
 ## Simulation Notes
 We sample 5,000 districting plans for Maine, across 4 independent runs of the SMC algorithm.
 We use the standard county constraint.
-We weaken the compactness parameter to 0.9 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.
+We weaken the compactness parameter to 0.0 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.

--- a/analyses/ME_cd_2010/doc_ME_cd_2010.md
+++ b/analyses/ME_cd_2010/doc_ME_cd_2010.md
@@ -1,0 +1,19 @@
+# 2010 Maine Congressional Districts
+## Redistricting requirements
+[In Maine, following Title 21-A, Chapter 15, Section 1206, districts must](https://legislature.maine.gov/legis/statutes/21-A/title21-Asec1206.html):
+1. be contiguous (1)
+1. have equal populations (1)
+1. be geographically compact (1)
+1. preserve county and municipality boundaries as much as possible (1)
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+We apply the standard algorithmic county constraint.
+## Data Sources
+Data for Maine comes from the [Voting and Election Science Team](https://dataverse.harvard.edu/dataverse/electionscience) for 2016, 2018, and 2020. It is retabulated to 2020 Census tracts, as 2020 Census VTDs do not cover the majority of Maine's geography.
+## Pre-processing Notes
+Islands tracts were connected to the nearest tract within the same district.
+
+## Simulation Notes
+We sample 5,000 districting plans for Maine, across 4 independent runs of the SMC algorithm.
+We use the standard county constraint.
+We weaken the compactness parameter to 0.9 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.


### PR DESCRIPTION
## Redistricting requirements
[In Maine, following Title 21-A, Chapter 15, Section 1206, districts must](https://legislature.maine.gov/legis/statutes/21-A/title21-Asec1206.html):
1. be contiguous (1)
1. have equal populations (1)
1. be geographically compact (1)
1. preserve county and municipality boundaries as much as possible (1)
### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We apply the standard algorithmic county constraint.
## Data Sources
Data for Maine comes from the [Voting and Election Science Team](https://dataverse.harvard.edu/dataverse/electionscience) for 2016, 2018, and 2020. It is retabulated to 2020 Census tracts, as 2020 Census VTDs do not cover the majority of Maine's geography.
## Pre-processing Notes
Islands tracts were connected to the nearest tract within the same district.

## Simulation Notes
We sample 5,000 districting plans for Maine, across 4 independent runs of the SMC algorithm.
We use the standard county constraint.
We weaken the compactness parameter to 0.0 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.

## Validation
![validation_20221102_1520](https://user-images.githubusercontent.com/46555283/199582922-b2defd10-99e9-48d4-a3df-002b1b1d737b.png)

```
SMC: 5,000 sampled plans of 2 districts on 288 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.08 to 0.61
x WARNING: Low plan diversity

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0016304      1.0006552      1.0011907      1.0007446      1.0013620      1.0028100      1.0016165 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0019402      0.9997223      1.0001822      1.0002458      1.0011645      1.0022978      1.0022428 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0012229      1.0014702      0.9997750      0.9999535      1.0007415      1.0017581      1.0010225 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_18_dem_rin uss_18_rep_bra uss_20_dem_gid 
     1.0011891      1.0007762      1.0009348      1.0008138      1.0001335      1.0019796      1.0008980 
uss_20_rep_col gov_18_dem_mil gov_18_rep_moo         adv_16         adv_18         adv_20         arv_16 
     1.0036252      1.0023539      1.0056620      1.0011891      1.0017261      1.0009263      1.0007762 
        arv_18         arv_20    muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0045683      1.0020944      1.0000876      1.0012118      1.0024344      1.0010895      1.0009055 
        pr_dem          e_dem           egap 
     1.0000605      1.0024182      1.0024065 

Sampling diagnostics for SMC run 1 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,160 (92.8%)      7.0%         0.4   801 (101%)      4 
Resample      561 (44.9%)       NA%         0.4 1,005 (127%)     NA 

Sampling diagnostics for SMC run 2 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,180 (94.4%)      5.7%        0.39   775 ( 98%)      5 
Resample      822 (65.8%)       NA%        0.39 1,040 (132%)     NA 

Sampling diagnostics for SMC run 3 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,168 (93.4%)      5.5%        0.39   797 (101%)      5 
Resample      689 (55.1%)       NA%        0.39 1,015 (128%)     NA 

Sampling diagnostics for SMC run 4 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,178 (94.2%)      5.8%        0.38   795 (101%)      5 
Resample      806 (64.5%)       NA%        0.38 1,030 (130%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot
with `hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing constraints, or increasing
the population tolerance. If the accpetance rate drops quickly in the final splits, try increasing
`pop_temper` by 0.01.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

Notes: Low diversity due to having only two districts. Surprised that every plan is splitting one county.

@CoryMcCartan