### PR TITLE
2010 Connecticut Congressional Districts

### DIFF
--- a/analyses/CT_cd_2010/01_prep_CT_cd_2010.R
+++ b/analyses/CT_cd_2010/01_prep_CT_cd_2010.R
@@ -1,0 +1,90 @@
+###############################################################################
+# Download and prepare data for `CT_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CT_cd_2010}")
+
+path_data <- download_redistricting_file("CT", "data-raw/CT", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ct_2010_congress_2012-02-10_2021-12-31.zip"
+path_enacted <- "data-raw/CT/CT_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "CT_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/CT/CT_enacted/Special Master Draft Plan.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CT_2010/shp_vtd.rds"
+perim_path <- "data-out/CT_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CT} shapefile")
+    # read in redistricting data
+    ct_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$CT)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("CT", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("CT"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("CT", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("CT"), vtd),
+            cd_2000 = as.integer(cd))
+    ct_shp <- left_join(ct_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("CT", from = read_baf_cd113("CT"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("09", GEOID))
+    ct_shp <- ct_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Four VTDs in the south which encompass mostly-to-only water are not assigned to a district in the final plan.
+    # According to the Report and Plan of the Special Master (2012, page 13), these "water blocks" were left
+    # "largely as they are under the current plan." These VTDs have population zero, so we are removing them.
+    ct_shp <- ct_shp[!is.na(ct_shp$cd_2010), ]
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ct_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ct_shp <- rmapshaper::ms_simplify(ct_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ct_shp$adj <- redist.adjacency(ct_shp)
+
+    ct_shp <- ct_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ct_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ct_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CT} shapefile")
+}

--- a/analyses/CT_cd_2010/02_setup_CT_cd_2010.R
+++ b/analyses/CT_cd_2010/02_setup_CT_cd_2010.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `CT_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CT_cd_2010}")
+
+map <- redist_map(ct_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ct_shp$adj)
+
+# make pseudo counties with 40% of target size
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = 0.4*get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CT_2010"
+
+map$state <- "CT"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CT_2010/CT_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CT_cd_2010/03_sim_CT_cd_2010.R
+++ b/analyses/CT_cd_2010/03_sim_CT_cd_2010.R
@@ -1,0 +1,28 @@
+###############################################################################
+# Simulate plans for `CT_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CT_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CT_2010/CT_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CT_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CT_2010/CT_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/CT_cd_2010/doc_CT_cd_2010.md
+++ b/analyses/CT_cd_2010/doc_CT_cd_2010.md
@@ -1,0 +1,27 @@
+# 2010 Connecticut Congressional Districts
+
+## Redistricting requirements
+In Connecticut, there are no state law requirements for congressional districts. 
+The Supreme Court of Connecticut set out the [following guidelines](https://www.cga.ct.gov/red2011/documents/special_master/Merged%20Draft%20Report%20with%20Exhibits.pdf) in the order appointing a special master.
+1. Districts shall be as equal in population as is practicable. 
+1. Districts shall be made of contiguous territory. 
+1. Districts shall comply with 42 U.S.C. § 1973(b) and with other applicable provisions of the Voting Rights Act and federal law. 
+1. Districts shall not be substantially less compact than the existing congressional districts.
+1. Districts shall not substantially violate town lines more than the existing congressional districts. 
+1. Districts shall not consider either the residency of incumbents or potential candidates or other political data, such as party registration statistics or election returns.
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 congressional district plan.
+We use a pseudo-county constraint described below which attempts to mimic the norms in Connecticut of generally preserving county and municipal boundaries.
+
+## Data Sources
+Data for Connecticut comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Connecticut across two independent runs of the SMC algorithm.
+We use a pseudo-county constraint to limit county and municipality splits.
+Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all counties with populations larger than 40% the target population for a district.
+No special techniques were needed to produce the sample.

--- a/analyses/ME_cd_2020/doc_ME_cd_2020.md
+++ b/analyses/ME_cd_2020/doc_ME_cd_2020.md
@@ -21,4 +21,4 @@ Islands tracts were connected to the nearest tract within the same district.
 ## Simulation Notes
 We sample 5,000 districting plans for Maine across 4 independent runs of the SMC algorithm.
 We use the standard county constraint.
-We weaken the compactness parameter to 0.9 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.
+We weaken the compactness parameter to 0.8 due to the relatively small state size and total number of tracts to encourage more diversity in the sample.


### PR DESCRIPTION
## Redistricting requirements
In Connecticut, there are no state law requirements for congressional districts. 
The Supreme Court of Connecticut set out the [following guidelines](https://www.cga.ct.gov/red2011/documents/special_master/Merged%20Draft%20Report%20with%20Exhibits.pdf) in the order appointing a special master.
1. Districts shall be as equal in population as is practicable. 
1. Districts shall be made of contiguous territory. 
1. Districts shall comply with 42 U.S.C. § 1973(b) and with other applicable provisions of the Voting Rights Act and federal law. 
1. Districts shall not be substantially less compact than the existing congressional districts.
1. Districts shall not substantially violate town lines more than the existing congressional districts. 
1. Districts shall not consider either the residency of incumbents or potential candidates or other political data, such as party registration statistics or election returns.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low population deviation observed in the 2000 congressional district plan.
We use a pseudo-county constraint described below which attempts to mimic the norms in Connecticut of generally preserving county and municipal boundaries.

## Data Sources
Data for Connecticut comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Connecticut across two independent runs of the SMC algorithm.
We use a pseudo-county constraint to limit county and municipality splits.
Municipality lines are used in Fairfield County, Hartford County, and New Haven County, which are all counties with populations larger than 40% the target population for a district.
No special techniques were needed to produce the sample.

## Validation
![validation_20221103_1549](https://user-images.githubusercontent.com/46555283/199820423-eedfb769-2c9c-449a-9214-0ea8782fdd29.png)

```
SMC: 5,000 sampled plans of 5 districts on 770 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing CT shapefile
Plan diversity 80% range: 0.48 to 0.84
ℹ Preparing CT shapefile
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.008475       1.003795       1.000568       1.008529       1.015606       1.005969       1.003846 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.003611       1.001044       1.024221       1.006114       1.011754       1.010572       1.006281 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.004182       1.003960       1.000248       1.019696       1.007332       1.011386       1.018464 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_blu uss_16_rep_car uss_18_dem_mur 
      1.005625       1.013105       1.004683       1.012419       1.007100       1.010565       1.008109 
uss_18_rep_cor gov_18_dem_lam gov_18_rep_ste atg_18_dem_ton atg_18_rep_hat sos_18_dem_mer sos_18_rep_cha 
      1.013457       1.011316       1.013450       1.009557       1.014482       1.008501       1.014044 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
      1.005647       1.007237       1.004683       1.012676       1.013380       1.012419       1.010670 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
      1.001646       1.009415       1.013244       1.008367       1.008485       1.000501       1.011296 
         pbias           egap 
      1.005829       1.013071 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,437 (97.5%)     10.1%        0.33 1,584 (100%)      5 
Split 2     2,367 (94.7%)     11.3%        0.39 1,524 ( 96%)      3 
Split 3     2,325 (93.0%)     10.9%        0.49 1,465 ( 93%)      2 
Split 4     2,238 (89.5%)      3.3%        0.59 1,234 ( 78%)      2 
Resample    1,489 (59.6%)       NA%        0.59 1,844 (117%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,439 (97.6%)     10.2%        0.32 1,615 (102%)      5 
Split 2     2,376 (95.1%)      8.2%        0.37 1,527 ( 97%)      4 
Split 3     2,344 (93.8%)      7.3%        0.46 1,461 ( 92%)      3 
Split 4     2,335 (93.4%)      3.2%        0.50 1,298 ( 82%)      2 
Resample    1,839 (73.6%)       NA%        0.49 1,985 (126%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

Note: Minor correction to Maine 2020 documentation bundled in.

@CoryMcCartan