### PR TITLE
2010 Pennsylvania Congressional Districts

### DIFF
--- a/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("PA", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("PA"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     pa_shp <- left_join(pa_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -58,18 +58,18 @@ if (!file.exists(here(shp_path))) {
     pa_shp <- pa_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$District_1)[
             geo_match(pa_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = pa_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         pa_shp <- rmapshaper::ms_simplify(pa_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `PA_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg PA_cd_2010}")
+
+path_data <- download_redistricting_file("PA", "data-raw/PA", year = 2010)
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/pennsylvania/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/pa_2010_congress_2011-12-22_2018-02-19.zip"
+path_enacted <- "data-raw/PA/PA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "PA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/PA/PA_enacted/BlockLevelFinalCongressionalPlan21Dec2011.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/PA_2010/shp_vtd.rds"
+perim_path <- "data-out/PA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong PA} shapefile")
+    # read in redistricting data
+    pa_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$PA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("PA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("PA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("PA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("PA"), vtd),
+                  cd_2000 = as.integer(cd))
+    pa_shp <- left_join(pa_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    pa_shp <- pa_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District_1)[
+            geo_match(pa_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = pa_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        pa_shp <- rmapshaper::ms_simplify(pa_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    pa_shp$adj <- redist.adjacency(pa_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    pa_shp <- pa_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(pa_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    pa_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong PA} shapefile")
+}

--- a/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/01_prep_PA_cd_2010.R
@@ -20,16 +20,12 @@ cli_process_start("Downloading files for {.pkg PA_cd_2010}")
 path_data <- download_redistricting_file("PA", "data-raw/PA", year = 2010)
 
 # download the enacted plan.
-# TODO try to find a download URL at <https://redistricting.lls.edu/state/pennsylvania/>
 url <- "https://redistricting.lls.edu/wp-content/uploads/pa_2010_congress_2011-12-22_2018-02-19.zip"
 path_enacted <- "data-raw/PA/PA_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "PA_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/PA/PA_enacted/BlockLevelFinalCongressionalPlan21Dec2011.shp" # TODO use actual SHP
-
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
+path_enacted <- "data-raw/PA/PA_enacted/BlockLevelFinalCongressionalPlan21Dec2011.shp"
 
 cli_process_done()
 
@@ -64,7 +60,6 @@ if (!file.exists(here(shp_path))) {
             geo_match(pa_shp, cd_shp, method = "area")],
             .after = cd_2000)
 
-    # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = pa_shp,
@@ -72,7 +67,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         pa_shp <- rmapshaper::ms_simplify(pa_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -81,8 +75,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     pa_shp$adj <- redist.adjacency(pa_shp)
-
-    # TODO any custom adjacency graph edits here
 
     pa_shp <- pa_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
@@ -4,20 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg PA_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(pa_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = pa_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "PA_2010"

--- a/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
@@ -1,0 +1,29 @@
+###############################################################################
+# Set up redistricting simulation for `PA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg PA_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(pa_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = pa_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "PA_2010"
+
+map$state <- "PA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/PA_2010/PA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/02_setup_PA_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(pa_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "PA_2010"

--- a/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
@@ -6,19 +6,17 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg PA_cd_2010}")
 
-
-constr <- redist_constr(map) %>%
-    add_constr_splits(0.25, coalesce(map$county_muni, "<bg>"))
-
 set.seed(2010)
 plans <- redist_smc(map,
                     nsims = 1e4, runs = 2L,
                     counties = pseudo_county,
-                    verbose = TRUE, ncores = 16) %>%
+                    ncores = 16) %>%
     match_numbers("cd_2010")
 
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
@@ -1,0 +1,44 @@
+###############################################################################
+# Simulate plans for `PA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg PA_cd_2010}")
+
+
+constr <- redist_constr(map) %>%
+    add_constr_splits(0.25, coalesce(map$county_muni, "<bg>"))
+
+set.seed(2010)
+plans <- redist_smc(map,
+                    nsims = 1e4, runs = 2L,
+                    counties = pseudo_county,
+                    verbose = TRUE, ncores = 16) %>%
+    match_numbers("cd_2010")
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/PA_2010/PA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg PA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/PA_2010/PA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+}

--- a/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
@@ -8,9 +8,9 @@ cli_process_start("Running simulations for {.pkg PA_cd_2010}")
 
 set.seed(2010)
 plans <- redist_smc(map,
-                    nsims = 1e4, runs = 2L,
-                    counties = pseudo_county,
-                    ncores = 16) %>%
+    nsims = 1e4, runs = 2L,
+    counties = pseudo_county,
+    ncores = 16) %>%
     match_numbers("cd_2010")
 
 plans <- plans %>%

--- a/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
+++ b/analyses/PA_cd_2010/03_sim_PA_cd_2010.R
@@ -34,9 +34,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/PA_2010/PA_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-}

--- a/analyses/PA_cd_2010/doc_PA_cd_2010.md
+++ b/analyses/PA_cd_2010/doc_PA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Pennsylvania Congressional Districts
+
+## Redistricting requirements
+In Pennsylvania, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Pennsylvania comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Pennsylvania.
+No special techniques were needed to produce the sample.

--- a/analyses/PA_cd_2010/doc_PA_cd_2010.md
+++ b/analyses/PA_cd_2010/doc_PA_cd_2010.md
@@ -1,23 +1,25 @@
 # 2010 Pennsylvania Congressional Districts
 
 ## Redistricting requirements
-In Pennsylvania, districts must:
+In Pennsylvania, districts must generally:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
 
+We use a (pseudo-)county constraint to preserve boundaries as much as possible.
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
-Data for Pennsylvania comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Pennsylvania comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Pennsylvania.
+We sample 10,000 districting plans for Pennsylvania over two independent runs of the SMC algorithm, and thin the total 20,000 plans down to 5,000. Pseudo-counties for the county constraint are generated for Allegheny, Montgomery, and Philadelphia counties, as they have more residents than a district's population.
+
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Pennsylvania, districts must generally:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible

We use a (pseudo-)county constraint to preserve boundaries as much as possible.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Pennsylvania comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Pennsylvania over two independent runs of the SMC algorithm, and thin the total 20,000 plans down to 5,000. Pseudo-counties for the county constraint are generated for Allegheny, Montgomery, and Philadelphia counties, as they have more residents than a district's population.

No special techniques were needed to produce the sample.

## Validation (20,000 plans)

<img width="534" alt="image" src="https://user-images.githubusercontent.com/5815717/201176987-f8fadfef-e5ab-49f3-9242-7c6bff922a16.png">

```
SMC: 20,000 sampled plans of 18 districts on 9,256 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.66 to 0.84

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.021009       1.017837       1.013367       1.021607       1.001710       1.016175       1.015101 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.007263       1.015778       1.017111       1.011203       1.028106       1.016832       1.006714 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.014541       1.007130       1.023924       1.020345       1.012188       1.018049       1.019070 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_mcg uss_16_rep_too uss_18_dem_cas 
      1.033125       1.032476       1.014061       1.034240       1.033965       1.029695       1.021461 
uss_18_rep_bar gov_18_dem_wol gov_18_rep_wag atg_16_dem_sha atg_16_rep_raf atg_20_dem_sha atg_20_rep_hei 
      1.029627       1.020546       1.031483       1.035131       1.030263       1.022408       1.033408 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
      1.034455       1.021596       1.017767       1.034523       1.030536       1.031698       1.003324 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
      1.005742       1.025171       1.033710       1.032816       1.032815       0.999958       1.010924 
         pbias           egap 
      1.001807       1.013579 

Sampling diagnostics for SMC run 1 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     9,652 (96.5%)     15.9%        0.38 6,378 (101%)     15 
Split 2     9,562 (95.6%)     20.3%        0.42 6,282 ( 99%)     11 
Split 3     9,541 (95.4%)     29.3%        0.47 6,194 ( 98%)      7 
Split 4     9,459 (94.6%)     31.6%        0.50 6,177 ( 98%)      6 
Split 5     9,375 (93.7%)     34.4%        0.52 6,264 ( 99%)      5 
Split 6     9,303 (93.0%)     32.1%        0.56 6,186 ( 98%)      5 
Split 7     9,227 (92.3%)     35.6%        0.58 6,187 ( 98%)      4 
Split 8     9,177 (91.8%)     28.0%        0.61 6,117 ( 97%)      5 
Split 9     9,111 (91.1%)     26.1%        0.62 6,119 ( 97%)      5 
Split 10    9,108 (91.1%)     15.3%        0.63 6,092 ( 96%)      8 
Split 11    9,094 (90.9%)     21.9%        0.62 6,040 ( 96%)      5 
Split 12    9,007 (90.1%)     30.1%        0.63 6,090 ( 96%)      3 
Split 13    9,046 (90.5%)     21.9%        0.61 6,018 ( 95%)      4 
Split 14    8,792 (87.9%)     24.4%        0.61 5,900 ( 93%)      3 
Split 15    8,731 (87.3%)     16.4%        0.65 5,776 ( 91%)      4 
Split 16    8,717 (87.2%)     15.9%        0.68 5,613 ( 89%)      3 
Split 17    8,840 (88.4%)      4.4%        0.66 5,161 ( 82%)      4 
Resample    5,926 (59.3%)       NA%        0.68 5,526 ( 87%)     NA 

Sampling diagnostics for SMC run 2 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     9,655 (96.6%)     23.5%        0.38 6,307 (100%)     10 
Split 2     9,561 (95.6%)     31.0%        0.42 6,282 ( 99%)      7 
Split 3     9,548 (95.5%)     37.8%        0.46 6,174 ( 98%)      5 
Split 4     9,475 (94.7%)     50.1%        0.49 6,275 ( 99%)      3 
Split 5     9,395 (94.0%)     56.0%        0.52 6,191 ( 98%)      2 
Split 6     9,299 (93.0%)     37.4%        0.56 6,158 ( 97%)      4 
Split 7     9,240 (92.4%)     22.6%        0.58 6,168 ( 98%)      7 
Split 8     9,149 (91.5%)     28.3%        0.61 6,149 ( 97%)      5 
Split 9     9,077 (90.8%)     37.3%        0.63 6,172 ( 98%)      3 
Split 10    9,031 (90.3%)     34.3%        0.65 6,059 ( 96%)      3 
Split 11    9,049 (90.5%)     39.7%        0.65 6,130 ( 97%)      2 
Split 12    9,076 (90.8%)     19.5%        0.62 6,006 ( 95%)      5 
Split 13    9,034 (90.3%)     26.9%        0.61 6,001 ( 95%)      3 
Split 14    8,827 (88.3%)     24.9%        0.60 5,919 ( 94%)      3 
Split 15    8,768 (87.7%)     20.9%        0.63 5,759 ( 91%)      3 
Split 16    8,707 (87.1%)     10.3%        0.68 5,572 ( 88%)      5 
Split 17    8,869 (88.7%)      4.5%        0.65 5,042 ( 80%)      4 
Resample    5,699 (57.0%)       NA%        0.66 5,498 ( 87%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
```
## Validation (thinned 5,000 plans)

<img width="534" alt="image" src="https://user-images.githubusercontent.com/5815717/201177095-58690565-2712-4255-8931-6c0d4cf4f496.png">

```
SMC: 5,000 sampled plans of 18 districts on 9,256 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.67 to 0.84

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.020579       1.018028       1.011372       1.024139       1.000993       1.009577       1.008770 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.009923       1.009268       1.011630       1.012681       1.031385       1.016923       1.004650 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.009540       1.009878       1.020659       1.015338       1.015914       1.019375       1.019407 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_mcg uss_16_rep_too uss_18_dem_cas 
      1.031994       1.029202       1.014978       1.030866       1.032122       1.025392       1.016049 
uss_18_rep_bar gov_18_dem_wol gov_18_rep_wag atg_16_dem_sha atg_16_rep_raf atg_20_dem_sha atg_20_rep_hei 
      1.024714       1.017056       1.025985       1.033365       1.026334       1.022958       1.026299 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
      1.033128       1.016565       1.020580       1.030643       1.025319       1.027984       1.004561 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
      1.002368       1.024267       1.029059       1.024440       1.025581       1.000088       1.013872 
         pbias           egap 
      1.002418       1.015699 

Sampling diagnostics for SMC run 1 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     9,652 (96.5%)     15.9%        0.38 6,378 (101%)     15 
Split 2     9,562 (95.6%)     20.3%        0.42 6,282 ( 99%)     11 
Split 3     9,541 (95.4%)     29.3%        0.47 6,194 ( 98%)      7 
Split 4     9,459 (94.6%)     31.6%        0.50 6,177 ( 98%)      6 
Split 5     9,375 (93.7%)     34.4%        0.52 6,264 ( 99%)      5 
Split 6     9,303 (93.0%)     32.1%        0.56 6,186 ( 98%)      5 
Split 7     9,227 (92.3%)     35.6%        0.58 6,187 ( 98%)      4 
Split 8     9,177 (91.8%)     28.0%        0.61 6,117 ( 97%)      5 
Split 9     9,111 (91.1%)     26.1%        0.62 6,119 ( 97%)      5 
Split 10    9,108 (91.1%)     15.3%        0.63 6,092 ( 96%)      8 
Split 11    9,094 (90.9%)     21.9%        0.62 6,040 ( 96%)      5 
Split 12    9,007 (90.1%)     30.1%        0.63 6,090 ( 96%)      3 
Split 13    9,046 (90.5%)     21.9%        0.61 6,018 ( 95%)      4 
Split 14    8,792 (87.9%)     24.4%        0.61 5,900 ( 93%)      3 
Split 15    8,731 (87.3%)     16.4%        0.65 5,776 ( 91%)      4 
Split 16    8,717 (87.2%)     15.9%        0.68 5,613 ( 89%)      3 
Split 17    8,840 (88.4%)      4.4%        0.66 5,161 ( 82%)      4 
Resample    5,926 (59.3%)       NA%        0.68 5,526 ( 87%)     NA 

Sampling diagnostics for SMC run 2 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     9,655 (96.6%)     23.5%        0.38 6,307 (100%)     10 
Split 2     9,561 (95.6%)     31.0%        0.42 6,282 ( 99%)      7 
Split 3     9,548 (95.5%)     37.8%        0.46 6,174 ( 98%)      5 
Split 4     9,475 (94.7%)     50.1%        0.49 6,275 ( 99%)      3 
Split 5     9,395 (94.0%)     56.0%        0.52 6,191 ( 98%)      2 
Split 6     9,299 (93.0%)     37.4%        0.56 6,158 ( 97%)      4 
Split 7     9,240 (92.4%)     22.6%        0.58 6,168 ( 98%)      7 
Split 8     9,149 (91.5%)     28.3%        0.61 6,149 ( 97%)      5 
Split 9     9,077 (90.8%)     37.3%        0.63 6,172 ( 98%)      3 
Split 10    9,031 (90.3%)     34.3%        0.65 6,059 ( 96%)      3 
Split 11    9,049 (90.5%)     39.7%        0.65 6,130 ( 97%)      2 
Split 12    9,076 (90.8%)     19.5%        0.62 6,006 ( 95%)      5 
Split 13    9,034 (90.3%)     26.9%        0.61 6,001 ( 95%)      3 
Split 14    8,827 (88.3%)     24.9%        0.60 5,919 ( 94%)      3 
Split 15    8,768 (87.7%)     20.9%        0.63 5,759 ( 91%)      3 
Split 16    8,707 (87.1%)     10.3%        0.68 5,572 ( 88%)      5 
Split 17    8,869 (88.7%)      4.5%        0.65 5,042 ( 80%)      4 
Resample    5,699 (57.0%)       NA%        0.66 5,498 ( 87%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the master branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny 