### PR TITLE
2010 Wisconsin Congressional Districts

### DIFF
--- a/analyses/WI_cd_2010/01_prep_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/01_prep_WI_cd_2010.R
@@ -49,9 +49,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("WI", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("WI"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     wi_shp <- left_join(wi_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -60,17 +60,17 @@ if (!file.exists(here(shp_path))) {
     wi_shp <- wi_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$District_N)[
             geo_match(wi_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = wi_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         wi_shp <- rmapshaper::ms_simplify(wi_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/WI_cd_2010/01_prep_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/01_prep_WI_cd_2010.R
@@ -1,0 +1,88 @@
+###############################################################################
+# Download and prepare data for `WI_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WI_cd_2010}")
+
+path_data <- download_redistricting_file("WI", "data-raw/WI", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/wi_2010_congress_2011-08-09_2021-12-31.zip"
+path_enacted <- "data-raw/WI/WI_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "WI_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/WI/WI_enacted/Wisconsin_Congressional_Districts_2011.shp"
+
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WI_2010/shp_vtd.rds"
+perim_path <- "data-out/WI_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WI} shapefile")
+    # read in redistricting data
+    wi_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$WI)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("WI", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("WI"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("WI", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("WI"), vtd),
+                  cd_2000 = as.integer(cd))
+    wi_shp <- left_join(wi_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    wi_shp <- wi_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District_N)[
+            geo_match(wi_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = wi_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wi_shp <- rmapshaper::ms_simplify(wi_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    wi_shp$adj <- redist.adjacency(wi_shp)
+
+    wi_shp <- wi_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(wi_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    wi_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WI} shapefile")
+}

--- a/analyses/WI_cd_2010/02_setup_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/02_setup_WI_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(wi_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/WI_cd_2010/02_setup_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/02_setup_WI_cd_2010.R
@@ -1,0 +1,24 @@
+###############################################################################
+# Set up redistricting simulation for `WI_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WI_cd_2010}")
+
+map <- redist_map(wi_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = wi_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WI_2010"
+
+map$state <- "WI"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WI_2010/WI_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Simulate plans for `WI_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WI_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3,
+                    counties = pseudo_county,
+                    runs = 2L, verbose = TRUE, ncores = 16) %>%
+    match_numbers("cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WI_2010/WI_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WI_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WI_2010/WI_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
@@ -8,8 +8,8 @@ cli_process_start("Running simulations for {.pkg WI_cd_2010}")
 
 set.seed(2010)
 plans <- redist_smc(map, nsims = 5e3,
-                    counties = pseudo_county,
-                    runs = 2L, verbose = TRUE, ncores = 16) %>%
+    counties = pseudo_county,
+    runs = 2L, verbose = TRUE, ncores = 16) %>%
     match_numbers("cd_2010")
 
 cli_process_done()

--- a/analyses/WI_cd_2010/doc_WI_cd_2010.md
+++ b/analyses/WI_cd_2010/doc_WI_cd_2010.md
@@ -6,10 +6,10 @@ In Wisconsin, districts must:
 1. have equal populations
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5% and add a pseudo-county constraint to reduce county and municipality splits. Since Milwaukee County has a greater population than the target district population, we split Milwaukee County by municipality lines.
 
 ## Data Sources
-Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Wisconsin comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.

--- a/analyses/WI_cd_2010/doc_WI_cd_2010.md
+++ b/analyses/WI_cd_2010/doc_WI_cd_2010.md
@@ -15,5 +15,5 @@ Data for Wisconsin comes from the ALARM Project's [2010 Redistricting Data Files
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Wisconsin.
+We sample 10,000 districting plans for Wisconsin over 2 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.

--- a/analyses/WI_cd_2010/doc_WI_cd_2010.md
+++ b/analyses/WI_cd_2010/doc_WI_cd_2010.md
@@ -1,0 +1,19 @@
+# 2010 Wisconsin Congressional Districts
+
+## Redistricting requirements
+In Wisconsin, districts must:
+
+1. have equal populations
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Wisconsin comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Wisconsin.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Wisconsin, districts must:

1. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5% and add a pseudo-county constraint to reduce county and municipality splits. Since Milwaukee County has a greater population than the target district population, we split Milwaukee County by municipality lines.

## Data Sources
Data for Wisconsin comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Wisconsin over 2 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

<img width="532" alt="image" src="https://user-images.githubusercontent.com/5815717/204561717-57985baa-f0c7-4996-b017-774ee19b5136.png">

```
SMC: 10,000 sampled plans of 8 districts on 6,290 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.60 to 0.87

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby 
      1.003023       1.000496       1.006525       1.006056       1.003808 
     pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
      1.002087       1.003262       1.007569       1.000165       1.001255 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black 
      1.002095       1.002484       1.002402       1.002905       1.004289 
      vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
      1.006855       1.000438       1.001002       1.000476       1.002564 
       vap_two pre_16_rep_tru pre_16_dem_cli pre_20_dem_bid pre_20_rep_tru 
      1.001800       1.003794       1.001837       1.002079       1.003212 
uss_16_rep_joh uss_16_dem_fei uss_18_rep_vuk uss_18_dem_bal gov_18_rep_wal 
      1.005168       1.001511       1.005151       1.001903       1.005313 
gov_18_dem_eve atg_18_rep_sch atg_18_dem_kau sos_18_rep_sch sos_18_dem_laf 
      1.000574       1.004340       1.000814       1.004094       1.001847 
        adv_16         adv_18         adv_20         arv_16         arv_18 
      1.001014       1.001186       1.002079       1.004435       1.004681 
        arv_20  county_splits    muni_splits            ndv            nrv 
      1.003212       1.006289       1.015318       1.001142       1.004263 
       ndshare          e_dvs         pr_dem          e_dem          pbias 
      1.003853       1.003965       1.001472       1.002357       1.004259 
          egap 
      1.002601 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,913 (98.3%)     10.6%        0.27 3,149 (100%)     17 
Split 2     4,862 (97.2%)     14.3%        0.34 3,125 ( 99%)     11 
Split 3     4,794 (95.9%)     23.2%        0.44 3,109 ( 98%)      6 
Split 4     4,633 (92.7%)     28.3%        0.50 3,077 ( 97%)      4 
Split 5     4,620 (92.4%)     29.7%        0.52 3,074 ( 97%)      3 
Split 6     4,521 (90.4%)     29.4%        0.56 2,951 ( 93%)      2 
Split 7     4,576 (91.5%)     10.5%        0.55 2,561 ( 81%)      2 
Resample    3,370 (67.4%)       NA%        0.56 2,888 ( 91%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,912 (98.2%)     12.9%        0.27 3,169 (100%)     14 
Split 2     4,859 (97.2%)     17.7%        0.34 3,165 (100%)      9 
Split 3     4,793 (95.9%)     22.8%        0.44 3,140 ( 99%)      6 
Split 4     4,692 (93.8%)     28.3%        0.51 3,078 ( 97%)      4 
Split 5     4,616 (92.3%)     30.0%        0.53 3,052 ( 97%)      3 
Split 6     4,581 (91.6%)     29.1%        0.54 2,926 ( 93%)      2 
Split 7     4,680 (93.6%)     10.2%        0.48 2,619 ( 83%)      2 
Resample    3,760 (75.2%)       NA%        0.49 2,949 ( 93%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than
1%), large std. devs. of the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the master branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko 