### PR TITLE
2010 Utah Congressional Districts

### DIFF
--- a/analyses/UT_cd_2010/01_prep_UT_cd_2010.R
+++ b/analyses/UT_cd_2010/01_prep_UT_cd_2010.R
@@ -1,0 +1,85 @@
+###############################################################################
+# Download and prepare data for `UT_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg UT_cd_2010}")
+
+path_data <- download_redistricting_file("UT", "data-raw/UT", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ut_2010_congress_2011-10-20_2021-12-31.zip"
+path_enacted <- "data-raw/UT/UT_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "UT_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/UT/UT_enacted/SGID93_POLITICAL_USCongressDistricts2012.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/UT_2010/shp_vtd.rds"
+perim_path <- "data-out/UT_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong UT} shapefile")
+    # read in redistricting data
+    ut_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$UT)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("UT", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("UT"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("UT", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("UT"), vtd),
+            cd_2000 = as.integer(cd))
+    ut_shp <- left_join(ut_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("UT", from = read_baf_cd113("UT"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("49", GEOID))
+    ut_shp <- ut_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ut_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ut_shp <- rmapshaper::ms_simplify(ut_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ut_shp$adj <- redist.adjacency(ut_shp)
+
+    ut_shp <- ut_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ut_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ut_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong UT} shapefile")
+}

--- a/analyses/UT_cd_2010/02_setup_UT_cd_2010.R
+++ b/analyses/UT_cd_2010/02_setup_UT_cd_2010.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `UT_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg UT_cd_2010}")
+
+map <- redist_map(ut_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ut_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "UT_2010"
+
+map$state <- "UT"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/UT_2010/UT_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/UT_cd_2010/03_sim_UT_cd_2010.R
+++ b/analyses/UT_cd_2010/03_sim_UT_cd_2010.R
@@ -1,0 +1,28 @@
+###############################################################################
+# Simulate plans for `UT_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg UT_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/UT_2010/UT_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg UT_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/UT_2010/UT_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/UT_cd_2010/doc_UT_cd_2010.md
+++ b/analyses/UT_cd_2010/doc_UT_cd_2010.md
@@ -14,5 +14,5 @@ Data for Utah comes from the ALARM Project's [Redistricting Data Files](https://
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Utah across two independent runs of the SMC algorithm
+We sample 5,000 districting plans for Utah across two independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.

--- a/analyses/UT_cd_2010/doc_UT_cd_2010.md
+++ b/analyses/UT_cd_2010/doc_UT_cd_2010.md
@@ -5,7 +5,7 @@ In Utah, there are no state law requirements for congressional districts.
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
-We limit the number of county/municipality splits
+We limit the number of county/municipality splits.
 
 ## Data Sources
 Data for Utah comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/UT_cd_2010/doc_UT_cd_2010.md
+++ b/analyses/UT_cd_2010/doc_UT_cd_2010.md
@@ -1,0 +1,18 @@
+# 2010 Utah Congressional Districts
+
+## Redistricting requirements
+In Utah, there are no state law requirements for congressional districts.
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+We limit the number of county/municipality splits
+
+## Data Sources
+Data for Utah comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Utah across two independent runs of the SMC algorithm
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Utah, there are no state law requirements for congressional districts.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We limit the number of county/municipality splits.

## Data Sources
Data for Utah comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Utah across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
![validation_20221130_1552](https://user-images.githubusercontent.com/46555283/204906257-bc6cbf95-932d-4271-b05b-30246eec3b6b.png)

```
SMC: 5,000 sampled plans of 4 districts on 2,299 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing AR shapefile
Plan diversity 80% range: 0.54 to 0.86
ℹ Preparing AR shapefile
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0011028      1.0013501      1.0032429      1.0007001      1.0009548      1.0007389      1.0012223 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0023677      1.0011348      1.0015591      1.0008147      1.0025380      1.0020332      1.0001014 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0034864      1.0023662      1.0011476      1.0013099      1.0014830      1.0030006      1.0021348 
pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_lee uss_16_dem_sno uss_18_rep_rom 
     1.0024333      1.0002818      1.0028094      1.0019078      1.0005141      1.0009794      1.0007408 
uss_18_dem_wil gov_16_rep_her gov_16_dem_wei gov_20_rep_cox gov_20_dem_pet atg_16_rep_rey atg_16_dem_har 
     1.0008207      1.0007144      1.0013581      1.0023349      1.0009473      1.0003990      1.0004774 
atg_20_rep_rey atg_20_dem_sko         adv_16         adv_18         adv_20         arv_16         arv_18 
     1.0025387      1.0019075      1.0006316      1.0008207      1.0021107      1.0020189      1.0007408 
        arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0019817      1.0000444      1.0005939      1.0010505      1.0019898      1.0001951      1.0002571 
        pr_dem          e_dem          pbias           egap 
     0.9998962      1.0003556      1.0008593      1.0002706 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,306 (92.2%)     10.3%        0.56 1,593 (101%)      7 
Split 2     2,333 (93.3%)     15.8%        0.45 1,536 ( 97%)      4 
Split 3     2,313 (92.5%)      6.6%        0.51 1,389 ( 88%)      3 
Resample    1,653 (66.1%)       NA%        0.51 1,956 (124%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,308 (92.3%)     10.0%        0.56 1,580 (100%)      7 
Split 2     2,341 (93.7%)     15.6%        0.44 1,531 ( 97%)      4 
Split 3     2,327 (93.1%)      5.1%        0.50 1,381 ( 87%)      4 
Resample    1,826 (73.0%)       NA%        0.50 1,948 (123%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan 
