### PR TITLE
2010 Arkansas Congressional Districts

### DIFF
--- a/analyses/AR_cd_2010/01_prep_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/01_prep_AR_cd_2010.R
@@ -72,7 +72,7 @@ if (!file.exists(here(shp_path))) {
     }
 
     # create adjacency graph
-    ar_shp$adj <- redist.adjacency(ar_shp)
+    ar_shp$adj <- redist.adjacency(st_make_valid(ar_shp))
 
     ar_shp <- ar_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/AR_cd_2010/01_prep_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/01_prep_AR_cd_2010.R
@@ -1,0 +1,85 @@
+###############################################################################
+# Download and prepare data for `AR_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AR_cd_2010}")
+
+path_data <- download_redistricting_file("AR", "data-raw/AR", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ar_2010_congress_2011-04-14_2021-12-31.zip"
+path_enacted <- "data-raw/AR/AR_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AR_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/AR/AR_enacted/ADMIN_CONGRESSIONAL_DISTRICTS_polygon.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AR_2010/shp_vtd.rds"
+perim_path <- "data-out/AR_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AR} shapefile")
+    # read in redistricting data
+    ar_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$AR)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AR", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("AR"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("AR", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("AR"), vtd),
+            cd_2000 = as.integer(cd))
+    ar_shp <- left_join(ar_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("AR", from = read_baf_cd113("AR"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("05", GEOID))
+    ar_shp <- ar_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ar_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ar_shp <- rmapshaper::ms_simplify(ar_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ar_shp$adj <- redist.adjacency(ar_shp)
+
+    ar_shp <- ar_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ar_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ar_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AR} shapefile")
+}

--- a/analyses/AR_cd_2010/02_setup_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/02_setup_AR_cd_2010.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `AR_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AR_cd_2010}")
+
+map <- redist_map(ar_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ar_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "AR_2010"
+
+map$state <- "AR"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/AR_2010/AR_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
@@ -28,9 +28,3 @@ save_summary_stats(plans, "data-out/AR_2010/AR_cd_2010_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
@@ -1,0 +1,36 @@
+###############################################################################
+# Simulate plans for `AR_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AR_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AR_2010/AR_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AR_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AR_2010/AR_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
+++ b/analyses/AR_cd_2010/03_sim_AR_cd_2010.R
@@ -26,5 +26,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/AR_2010/AR_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----

--- a/analyses/AR_cd_2010/doc_AR_cd_2010.md
+++ b/analyses/AR_cd_2010/doc_AR_cd_2010.md
@@ -5,7 +5,7 @@ In Arkansas, there are no state law requirements for congressional districts.
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
-We use a standard algorithmic county constraint and limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.
+We apply a county constraint, as described below, which is in line with the small number of county/municipality splits observed in past congressional district maps.
 
 ## Data Sources
 Data for Arkansas comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -15,4 +15,5 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Arkansas across two independent runs of the SMC algorithm.
-No special techniques were needed to produce the sample.
+We use the standard algorithmic county constraint to limit the number of county splits.
+

--- a/analyses/AR_cd_2010/doc_AR_cd_2010.md
+++ b/analyses/AR_cd_2010/doc_AR_cd_2010.md
@@ -5,7 +5,7 @@ In Arkansas, there are no state law requirements for congressional districts.
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
-We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.
+We use a standard algorithmic county constraint and limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.
 
 ## Data Sources
 Data for Arkansas comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/AR_cd_2010/doc_AR_cd_2010.md
+++ b/analyses/AR_cd_2010/doc_AR_cd_2010.md
@@ -1,0 +1,18 @@
+# 2010 Arkansas Congressional Districts
+
+## Redistricting requirements
+In Arkansas, there are no state law requirements for congressional districts.
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
+We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.
+
+## Data Sources
+Data for Arkansas comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Arkansas across two independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Arkansas, there are no state law requirements for congressional districts.

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%, which is in line with the low deviation seen in past congressional district maps.
We limit the number of county/municipality splits, which is in line with the small number of county/municipality splits observed in past congressional district maps.

## Data Sources
Data for Arkansas comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Arkansas across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

![validation_20221130_2008](https://user-images.githubusercontent.com/46555283/204942035-e38ccf20-d1d9-4853-a66f-f3af97656ac0.png)


```
SMC: 5,000 sampled plans of 4 districts on 2,784 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing WV shapefile
Plan diversity 80% range: 0.34 to 0.78
ℹ Preparing WV shapefile
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0009041      1.0038464      1.0003680      1.0010062      0.9998685      1.0004246      1.0004679 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0005685      1.0001398      1.0004262      1.0008790      1.0014776      0.9999571      1.0003402 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0004733      1.0003640      1.0002997      1.0013274      1.0007875      1.0015609      1.0011423 
pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_boo uss_16_dem_eld uss_20_rep_cot 
     1.0005219      0.9999698      1.0005089      1.0000345      1.0005610      1.0006173      1.0004602 
uss_20_dem_har gov_18_rep_hut gov_18_dem_hen atg_18_rep_rut atg_18_dem_lee sos_18_rep_thu sos_18_dem_inm 
     1.0001425      1.0004244      1.0000224      1.0004619      1.0000548      1.0004431      0.9999958 
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0002214      1.0000226      1.0001541      1.0005459      1.0004531      1.0004793      1.0039716 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem 
     1.0040011      1.0000220      1.0005035      1.0001766      1.0001782      1.0004000      1.0000256 
         pbias           egap 
     0.9999162      1.0005349 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,424 (97.0%)     11.4%        0.35 1,596 (101%)     11 
Split 2     2,405 (96.2%)     14.9%        0.38 1,549 ( 98%)      7 
Split 3     2,373 (94.9%)      8.2%        0.47 1,393 ( 88%)      4 
Resample    1,997 (79.9%)       NA%        0.43 2,031 (129%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,423 (96.9%)      7.1%        0.35 1,564 ( 99%)     18 
Split 2     2,409 (96.4%)     10.4%        0.38 1,580 (100%)     10 
Split 3     2,301 (92.1%)      5.9%        0.53 1,399 ( 89%)      6 
Resample    1,615 (64.6%)       NA%        0.50 1,964 (124%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan