### PR TITLE
2010 New Mexico Congressional Districts

### DIFF
--- a/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("NM", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("NM"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     nm_shp <- left_join(nm_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -59,17 +59,17 @@ if (!file.exists(here(shp_path))) {
     nm_shp <- nm_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$OBJECTID)[
             geo_match(nm_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = nm_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
-                                          keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
@@ -1,0 +1,92 @@
+###############################################################################
+# Download and prepare data for `NM_cd_2010` analysis
+# © ALARM Project, December 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NM_cd_2010}")
+
+path_data <- download_redistricting_file("NM", "data-raw/NM", year = 2010)
+
+# download the enacted plan.
+url <- "https://www.nmlegis.gov/Redistricting2011/Documents/cd_court_ordered_shapefile.zip"
+path_enacted <- "data-raw/NM/NM_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NM_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NM/NM_enacted/cd_court_ordered.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NM_2010/shp_vtd.rds"
+perim_path <- "data-out/NM_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NM} shapefile")
+    # read in redistricting data
+    nm_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$NM)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NM", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("NM"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("NM", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("NM"), vtd),
+                  cd_2000 = as.integer(cd))
+    nm_shp <- left_join(nm_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    cd_shp <- st_transform(cd_shp, st_crs(nm_shp))
+    nm_shp <- nm_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(nm_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nm_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nm_shp <- rmapshaper::ms_simplify(nm_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nm_shp$adj <- redist.adjacency(nm_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    nm_shp <- nm_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nm_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nm_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NM} shapefile")
+}

--- a/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/01_prep_NM_cd_2010.R
@@ -20,12 +20,12 @@ cli_process_start("Downloading files for {.pkg NM_cd_2010}")
 path_data <- download_redistricting_file("NM", "data-raw/NM", year = 2010)
 
 # download the enacted plan.
-url <- "https://www.nmlegis.gov/Redistricting2011/Documents/cd_court_ordered_shapefile.zip"
+url <- "https://redistricting.lls.edu/wp-content/uploads/nm_2010_congress_2011-12-29_2021-12-31.zip"
 path_enacted <- "data-raw/NM/NM_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NM_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/NM/NM_enacted/cd_court_ordered.shp" # TODO use actual SHP
+path_enacted <- "data-raw/NM/NM_enacted/CD_187963_2_Egolf_Executive.shp"
 
 cli_process_done()
 
@@ -57,11 +57,9 @@ if (!file.exists(here(shp_path))) {
     cd_shp <- st_read(here(path_enacted))
     cd_shp <- st_transform(cd_shp, st_crs(nm_shp))
     nm_shp <- nm_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+        mutate(cd_2010 = as.integer(cd_shp$OBJECTID)[
             geo_match(nm_shp, cd_shp, method = "area")],
             .after = cd_2000)
-
-    # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = nm_shp,
@@ -69,17 +67,14 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
-        nm_shp <- rmapshaper::ms_simplify(nm_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+        al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
+                                          keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
     # create adjacency graph
     nm_shp$adj <- redist.adjacency(nm_shp)
-
-    # TODO any custom adjacency graph edits here
 
     nm_shp <- nm_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/NM_cd_2010/02_setup_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/02_setup_NM_cd_2010.R
@@ -4,20 +4,16 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg NM_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
+# Define map
 map <- redist_map(nm_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = nm_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
+# Set up cores objects
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+    mutate(cores = make_cores(boundary = 2))
+
+# merge by both cores and county to preserve county contiguity
+map_cores <- merge_by(map, cores, county)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NM_2010"

--- a/analyses/NM_cd_2010/02_setup_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/02_setup_NM_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NM_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NM_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(nm_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = nm_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NM_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NM_2010/NM_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
@@ -13,10 +13,10 @@ constr <- redist_constr(map_cores) %>%
 
 set.seed(2010)
 plans <- redist_smc(map_cores,
-                    nsims = 2500,
-                    runs = 2L,
-                    counties = county,
-                    constr = constr) %>%
+    nsims = 2500,
+    runs = 2L,
+    counties = county,
+    constr = constr) %>%
     pullback(map)
 plans <- match_numbers(plans, "cd_2010")
 

--- a/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `NM_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NM_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NM_2010/NM_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NM_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NM_2010/NM_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
+++ b/analyses/NM_cd_2010/03_sim_NM_cd_2010.R
@@ -6,27 +6,22 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NM_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
+constr <- redist_constr(map_cores) %>%
+    add_constr_grp_hinge(25, vap - vap_white, vap, 0.52) %>%
+    add_constr_grp_hinge(-25, vap - vap_white, vap, 0.47) %>%
+    add_constr_grp_inv_hinge(20, vap - vap_white, vap, 0.57)
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map_cores,
+                    nsims = 2500,
+                    runs = 2L,
+                    counties = county,
+                    constr = constr) %>%
+    pullback(map)
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NM_2010/NM_cd_2010_plans.rds"), compress = "xz")
@@ -41,11 +36,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/NM_2010/NM_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/NM_cd_2010/doc_NM_cd_2010.md
+++ b/analyses/NM_cd_2010/doc_NM_cd_2010.md
@@ -15,7 +15,7 @@ In New Mexico, according to the [New Mexico Legislative Council Guidelines](http
 We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
-Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 New Mexico enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/new-mexico/?cycle=2010&level=Congress&startdate=2011-12-29).
 
 ## Pre-processing Notes
 To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2000 plan.

--- a/analyses/NM_cd_2010/doc_NM_cd_2010.md
+++ b/analyses/NM_cd_2010/doc_NM_cd_2010.md
@@ -1,0 +1,25 @@
+# 2010 New Mexico Congressional Districts
+
+## Redistricting requirements
+In New Mexico, according to the [New Mexico Legislative Council Guidelines](https://www.nmlegis.gov/Redistricting/Documents/187014.pdf), districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of interest
+6. preserve the core of existing districts
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2000 plan.
+
+## Simulation Notes
+We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.

--- a/analyses/NM_cd_2010/doc_NM_cd_2010.md
+++ b/analyses/NM_cd_2010/doc_NM_cd_2010.md
@@ -12,7 +12,7 @@ In New Mexico, according to the [New Mexico Legislative Council Guidelines](http
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
 
 ## Data Sources
 Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 New Mexico enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/new-mexico/?cycle=2010&level=Congress&startdate=2011-12-29).


### PR DESCRIPTION
## Redistricting requirements
In New Mexico, according to the [New Mexico Legislative Council Guidelines](https://www.nmlegis.gov/Redistricting/Documents/187014.pdf), districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve communities of interest
6. preserve the core of existing districts


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.

## Data Sources
Data for New Mexico comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 New Mexico enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/new-mexico/?cycle=2010&level=Congress&startdate=2011-12-29).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border under the 2000 plan.

## Simulation Notes
We sample 5,000 districting plans for New Mexico across two independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

![validation_20221217_1944](https://user-images.githubusercontent.com/55368740/208271843-ceaa3380-cb93-42ad-a1ce-4fdf0feea7d3.png)

```
SMC: 5,000 sampled plans of 3 districts on 1,448 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.18 to 0.51

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
     1.0012804      0.9998424      0.9999730      1.0029989      1.0002152      1.0003091      1.0002312 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
     1.0003233      1.0001935      1.0002644      1.0000568      1.0003827      1.0003439      1.0001395 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0001620      0.9998905      1.0000895      1.0001015      1.0002450      1.0002742      1.0003503 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_18_dem_hei uss_18_rep_ric uss_20_dem_luj 
     0.9998202      1.0004816      0.9998269      1.0001452      0.9998456      1.0003610      0.9998388 
uss_20_rep_ron gov_18_dem_luj gov_18_rep_pea atg_18_dem_bal atg_18_rep_hen sos_16_dem_oli sos_16_rep_esp 
     1.0002078      0.9999613      1.0002115      0.9999101      1.0001633      0.9998014      1.0004577 
sos_18_dem_tou sos_18_rep_cla         adv_16         adv_18         adv_20         arv_16         arv_18 
     0.9998031      1.0002771      0.9998143      0.9998903      0.9998311      1.0004027      1.0002958 
        arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0002606      0.9998038      1.0022875      0.9998335      1.0005793      0.9998990      0.9998947 
         e_dem          pbias           egap 
     1.0015263      0.9998328      1.0038788 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,246 (89.9%)      5.0%        0.27 1,581 (100%)      8 
Split 2     2,287 (91.5%)      3.0%        0.33 1,440 ( 91%)      5 
Resample    1,781 (71.2%)       NA%        0.73 1,948 (123%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,242 (89.7%)      5.6%        0.28 1,590 (101%)      7 
Split 2     2,302 (92.1%)      3.7%        0.33 1,459 ( 92%)      4 
Resample    1,826 (73.0%)       NA%        0.69 1,993 (126%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
