### PR TITLE
2010 Alabama Congressional Districts

### DIFF
--- a/analyses/AL_cd_2010/01_prep_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/01_prep_AL_cd_2010.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Download and prepare data for `AL_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AL_cd_2010}")
+
+path_data <- download_redistricting_file("AL", "data-raw/AL", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/al_2010_congress_2011-11-21_2021-12-31.zip"
+path_enacted <- "data-raw/AL/AL_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AL_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/AL/AL_enacted/68b815c2-a1f7-4b05-b530-84c1f624fe6b202048-1-ihxzzh.0q5k.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AL_2010/shp_vtd.rds"
+perim_path <- "data-out/AL_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AL} shapefile")
+    # read in redistricting data
+    al_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$AL)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AL", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("AL"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("AL", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
+                  cd_2000 = as.integer(cd))
+    al_shp <- left_join(al_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    al_shp <- al_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTNAME %>% substr(1,1))[
+            geo_match(al_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = al_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    al_shp$adj <- redist.adjacency(al_shp)
+
+    al_shp <- al_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(al_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    al_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AL} shapefile")
+}

--- a/analyses/AL_cd_2010/01_prep_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/01_prep_AL_cd_2010.R
@@ -25,7 +25,7 @@ path_enacted <- "data-raw/AL/AL_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AL_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/AL/AL_enacted/68b815c2-a1f7-4b05-b530-84c1f624fe6b202048-1-ihxzzh.0q5k.shp" # TODO use actual SHP
+path_enacted <- "data-raw/AL/AL_enacted/68b815c2-a1f7-4b05-b530-84c1f624fe6b202048-1-ihxzzh.0q5k.shp"
 
 cli_process_done()
 
@@ -47,28 +47,28 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("AL", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     al_shp <- left_join(al_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
     al_shp <- al_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$DISTNAME %>% substr(1,1))[
+        mutate(cd_2010 = as.integer(cd_shp$DISTNAME %>% substr(1, 1))[
             geo_match(al_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = al_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/AL_cd_2010/02_setup_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/02_setup_AL_cd_2010.R
@@ -1,0 +1,22 @@
+###############################################################################
+# Set up redistricting simulation for `AL_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AL_cd_2010}")
+
+map <- redist_map(al_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = al_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "AL_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/AL_2010/AL_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AL_cd_2010/02_setup_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/02_setup_AL_cd_2010.R
@@ -7,13 +7,6 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg AL_cd_2010}")
 map <- redist_map(al_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = al_shp$adj)
 
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "AL_2010"
 

--- a/analyses/AL_cd_2010/03_sim_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/03_sim_AL_cd_2010.R
@@ -7,47 +7,56 @@
 cli_process_start("Running simulations for {.pkg AL_cd_2010}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(35, vap_black, vap, 0.41) %>%
-    add_constr_grp_hinge(-20, vap_black, vap, 0.38) %>%
-    add_constr_grp_inv_hinge(15, vap_black, vap, 0.43)
+    add_constr_grp_hinge(30, vap_black, vap, 0.40) %>%
+    add_constr_grp_hinge(-30, vap_black, vap, 0.33)
 
 set.seed(2010)
 plans <- redist_smc(map, nsims = 10e3, runs = 2L,
-                    counties = county, constr = constr, pop_temper = 0.05)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+    counties = county, constr = constr, pop_temper = 0.05)
 plans <- match_numbers(plans, "cd_2010")
+
+# Subset plans that are not performing
+n_perf <- plans %>%
+    mutate(bvap = group_frac(map, vap_black, vap),
+        ndshare = group_frac(map, ndv, nrv + ndv)) %>%
+    group_by(draw) %>%
+    summarize(n_blk_perf = sum(bvap > 0.3 & ndshare > 0.5))
+
+plans_5k <- plans %>%
+    # subset non-performing plan
+    anti_join(filter(n_perf, n_blk_perf == 0), by = "draw") %>%
+    # thin to 5000 draws
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/AL_2010/AL_cd_2010_plans.rds"), compress = "xz")
+write_rds(plans_5k, here("data-out/AL_2010/AL_cd_2010_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg AL_cd_2010}")
 
-plans <- add_summary_stats(plans, map)
+plans_5k <- add_summary_stats(plans_5k, map)
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/AL_2010/AL_cd_2010_stats.csv")
+save_summary_stats(plans_5k, "data-out/AL_2010/AL_cd_2010_stats.csv")
 
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
     # Black VAP Performance Plot
-    redist.plot.distr_qtys(plans, vap_black/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
+    redist.plot.distr_qtys(plans_5k, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans_5k)$ndv > subset_sampled(plans_5k)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
         labs(title = "Alabama Proposed Plan versus Simulations") +
         scale_color_manual(values = c(cd_2020_prop = "black")) +
@@ -55,16 +64,16 @@ if (interactive()) {
 
     # Minority VAP Performance Plot
     redist.plot.distr_qtys(plans_5k, (total_vap - vap_white)/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans_5k)$ndv > subset_sampled(plans_5k)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans_5k)$ndv > subset_sampled(plans_5k)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
         scale_y_continuous("Minority Percentage by VAP") +
         labs(title = "Alabama Proposed Plan versus Simulations") +
         scale_color_manual(values = c(cd_2020_prop = "black")) +
         theme_bw()
 
     # Dem seats by BVAP rank -- numeric
-    plans_5k %>%
+    plans %>%
         group_by(draw) %>%
         mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
         subset_sampled() %>%
@@ -75,6 +84,13 @@ if (interactive()) {
 
     # Total Black districts that are performing
     plans %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
+
+    # Total Black districts that are performing from subset
+    plans_5k %>%
         subset_sampled() %>%
         group_by(draw) %>%
         summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%

--- a/analyses/AL_cd_2010/03_sim_AL_cd_2010.R
+++ b/analyses/AL_cd_2010/03_sim_AL_cd_2010.R
@@ -1,0 +1,83 @@
+###############################################################################
+# Simulate plans for `AL_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AL_cd_2010}")
+
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(35, vap_black, vap, 0.41) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, 0.38) %>%
+    add_constr_grp_inv_hinge(15, vap_black, vap, 0.43)
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 10e3, runs = 2L,
+                    counties = county, constr = constr, pop_temper = 0.05)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AL_2010/AL_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AL_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AL_2010/AL_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    # Black VAP Performance Plot
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Alabama Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
+
+    # Minority VAP Performance Plot
+    redist.plot.distr_qtys(plans_5k, (total_vap - vap_white)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans_5k)$ndv > subset_sampled(plans_5k)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Minority Percentage by VAP") +
+        labs(title = "Alabama Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
+
+    # Dem seats by BVAP rank -- numeric
+    plans_5k %>%
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
+
+}

--- a/analyses/AL_cd_2010/doc_AL_cd_2010.md
+++ b/analyses/AL_cd_2010/doc_AL_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Alabama Congressional Districts
+
+## Redistricting requirements
+In Alabama, districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of interest as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 Alabama enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/alabama/?cycle=2020&level=Congress&startdate=2021-11-04).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Alabama across two independent runs of the SMC algorithm. We then thin the sample to down to 5,000 plans.

--- a/analyses/AL_cd_2010/doc_AL_cd_2010.md
+++ b/analyses/AL_cd_2010/doc_AL_cd_2010.md
@@ -11,7 +11,7 @@ In Alabama, districts must:
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan.
 
 ## Data Sources
 Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 Alabama enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/alabama/?cycle=2020&level=Congress&startdate=2021-11-04).
@@ -20,4 +20,4 @@ Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Alabama across two independent runs of the SMC algorithm. We then thin the sample to down to 5,000 plans.
+We sample 20,000 districting plans for Alabama across two independent runs of the SMC algorithm. We set population temperance at 0.05 to avoid bottlenecks. We remove all plans that do not have any district that has BVAP of over 30% and a majority Democratic average vote share, in order to maintain similar standards as the enacted plan. Such plans comprise less than 2% of the original simulation sample. We then thin the sample to down to 5,000 plans.


### PR DESCRIPTION
## Redistricting requirements
In Alabama, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve communities of interest as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan.

## Data Sources
Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 Alabama enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/alabama/?cycle=2020&level=Congress&startdate=2021-11-04).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for Alabama across two independent runs of the SMC algorithm. We set population temperance at 0.05 to avoid bottlenecks. We remove all plans that do not have any district that has BVAP of over 30% and a majority Democratic average vote share, in order to maintain similar standards as the enacted plan. Such plans comprise less than 2% of the original simulation sample. We then thin the sample to down to 5,000 plans.

## Validation

![image](https://user-images.githubusercontent.com/55368740/209241628-009850d3-ce7f-4445-8b98-c6f47adb7283.png)

```
SMC: 20,000 sampled plans of 7 districts on 1,993 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0.05

Plan diversity 80% range: 0.39 to 0.74

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
     1.0090493      1.0079287      1.0025388      1.0028105      1.0185280      1.0018146 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0098524      1.0066917      1.0012538      1.0128121      1.0038723      1.0132122 
       pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
     1.0022996      1.0019645      1.0097171      1.0035227      1.0020420      1.0025400 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru 
     1.0044955      1.0047742      1.0014709      1.0020655      1.0016617      1.0017172 
pre_20_dem_bid uss_16_rep_she uss_16_dem_cru uss_20_rep_tub uss_20_dem_jon gov_18_rep_ive 
     1.0023175      1.0014257      1.0020564      1.0015831      1.0015981      1.0007880 
gov_18_dem_mad atg_18_rep_mar atg_18_dem_sie sos_18_rep_mer sos_18_dem_mil         adv_16 
     1.0015941      1.0081825      1.0013214      1.0020202      1.0016929      1.0019523 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0018108      1.0019732      1.0017725      1.0019241      1.0017053      1.0079579 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
     1.0044418      1.0023181      1.0018123      1.0003515      1.0003196      1.0002214 
         e_dem          pbias           egap 
     1.0004276      0.9999511      0.9999864 

Sampling diagnostics for SMC run 1 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,307 (83.1%)      9.2%        0.34 6,334 (100%)     15 
Split 2     7,499 (75.0%)     12.6%        0.58 5,804 ( 92%)      9 
Split 3     6,914 (69.1%)     13.6%        0.72 5,648 ( 89%)      7 
Split 4     6,016 (60.2%)     15.2%        0.81 5,462 ( 86%)      5 
Split 5     5,574 (55.7%)     18.0%        0.96 5,115 ( 81%)      3 
Split 6     3,750 (37.5%)      8.3%        0.92 4,519 ( 71%)      2 
Resample       697 (7.0%)       NA%        2.65 2,684 ( 42%)     NA 

Sampling diagnostics for SMC run 2 of 2 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     8,385 (83.8%)     10.7%        0.34 6,357 (101%)     13 
Split 2     7,504 (75.0%)     16.1%        0.58 5,889 ( 93%)      7 
Split 3     6,746 (67.5%)     13.7%        0.75 5,644 ( 89%)      7 
Split 4     5,928 (59.3%)     15.2%        0.86 5,430 ( 86%)      5 
Split 5     5,804 (58.0%)      8.7%        0.97 5,081 ( 80%)      7 
Split 6     3,789 (37.9%)      4.8%        0.90 4,626 ( 73%)      4 
Resample       574 (5.7%)       NA%        2.55 2,812 ( 44%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
BVAP performance plot:
![image](https://user-images.githubusercontent.com/55368740/209241799-1662d7ef-497c-4d00-8914-0dee554f77fa.png)

Total Black performant districts:
```
  n_black_perf    n
1            1 2665
2            2 2333
3            3    2
```

@tylersimko
