### PR TITLE
2010 Missouri Congressional Districts

### DIFF
--- a/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
@@ -1,0 +1,85 @@
+###############################################################################
+# Download and prepare data for `MO_cd_2010` analysis
+# © ALARM Project, December 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MO_cd_2010}")
+
+path_data <- download_redistricting_file("MO", "data-raw/MO", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/mo_2010_congress_2011-05-04_2021-12-31.zip"
+path_enacted <- "data-raw/MO/MO_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "MO_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/MO/MO_enacted/MO_2011_US_Congressional_Districts_(SHP).shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MO_2010/shp_vtd.rds"
+perim_path <- "data-out/MO_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MO} shapefile")
+    # read in redistricting data
+    mo_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$MO)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MO", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("MO"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MO", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("MO"), vtd),
+                  cd_2000 = as.integer(cd))
+    mo_shp <- left_join(mo_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("MO", from = read_baf_cd113("MO"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("29", GEOID))
+    mo_shp <- mo_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mo_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mo_shp <- rmapshaper::ms_simplify(mo_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mo_shp$adj <- redist.adjacency(mo_shp)
+
+    mo_shp <- mo_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(mo_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mo_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MO} shapefile")
+}

--- a/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("MO", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("MO"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     mo_shp <- left_join(mo_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -61,13 +61,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = mo_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         mo_shp <- rmapshaper::ms_simplify(mo_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/01_prep_MO_cd_2010.R
@@ -25,7 +25,7 @@ path_enacted <- "data-raw/MO/MO_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "MO_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/MO/MO_enacted/MO_2011_US_Congressional_Districts_(SHP).shp" # TODO use actual SHP
+path_enacted <- "data-raw/MO/MO_enacted/MO_2011_US_Congressional_Districts_(SHP).shp"
 
 cli_process_done()
 

--- a/analyses/MO_cd_2010/02_setup_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/02_setup_MO_cd_2010.R
@@ -1,0 +1,16 @@
+###############################################################################
+# Set up redistricting simulation for `MO_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MO_cd_2010}")
+
+map <- redist_map(mo_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = mo_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MO_2010"
+map$state <- "MO"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MO_2010/MO_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MO_cd_2010/03_sim_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/03_sim_MO_cd_2010.R
@@ -14,7 +14,7 @@ constr <- redist_constr(map) %>%
 set.seed(2010)
 
 plans <- redist_smc(map, nsims = 5e3, runs = 2L, ncores = 8, seq_alpha = 0.95,
-                    counties = county, constraints = constr)
+    counties = county, constraints = constr)
 
 plans <- plans %>%
     mutate(vap_black = group_frac(map, vap_black, vap)) %>%
@@ -53,9 +53,9 @@ if (interactive()) {
     library(patchwork)
 
     redist.plot.distr_qtys(plans, vap_black/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
         scale_y_continuous("Percent Black by VAP") +
         labs(title = "Approximate Performance") +
         scale_color_manual(values = c(cd_2020 = "black")) +

--- a/analyses/MO_cd_2010/03_sim_MO_cd_2010.R
+++ b/analyses/MO_cd_2010/03_sim_MO_cd_2010.R
@@ -1,0 +1,63 @@
+###############################################################################
+# Simulate plans for `MO_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MO_cd_2010}")
+
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(6, vap_black, vap, 0.4) %>%
+    add_constr_grp_hinge(-3, vap_black, vap, 0.25) %>%
+    add_constr_grp_hinge(-3, vap_black, vap, 0.08)
+
+set.seed(2010)
+
+plans <- redist_smc(map, nsims = 5e3, runs = 2L, ncores = 8, seq_alpha = 0.95,
+                    counties = county, constraints = constr)
+
+plans <- plans %>%
+    mutate(vap_black = group_frac(map, vap_black, vap)) %>%
+    group_by(draw) %>%
+    mutate(vap_black = max(vap_black)) %>%
+    ungroup() %>%
+    filter(vap_black > 0.3 | draw == "cd_2010")
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(droplevels(draw)) < min(as.integer(droplevels(draw))) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MO_2010/MO_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MO_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MO_2010/MO_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        theme_bw()
+}

--- a/analyses/MO_cd_2010/doc_MO_cd_2010.md
+++ b/analyses/MO_cd_2010/doc_MO_cd_2010.md
@@ -1,0 +1,19 @@
+# 2010 Missouri Congressional Districts
+
+## Redistricting requirements
+In Missouri, according to [Mo. Const. art. III, § 2](https://redistricting.lls.edu/wp-content/uploads/MO-2000-constitution.pdf#page=26), districts must:
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We use a standard algorithmic county constraint. We add a hinge Gibbs constraint targeting one majority-minority district to comply with VRA requirements and match the number in the enacted plan.
+
+## Data Sources
+Data for Missouri comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Missouri across two independent runs of the SMC algorithm.


### PR DESCRIPTION
## Redistricting requirements
In Missouri, according to [Mo. Const. art. III, § 2](https://redistricting.lls.edu/wp-content/uploads/MO-2000-constitution.pdf#page=26), districts must:
1. be contiguous
1. have equal populations
1. be geographically compact

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a standard algorithmic county constraint. We add a hinge Gibbs constraint targeting one majority-minority district to comply with VRA requirements and match the number in the enacted plan.

## Data Sources
Data for Missouri comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Missouri across two independent runs of the SMC algorithm.

## Validation
![validation_20221224_1219](https://user-images.githubusercontent.com/46555283/209450346-d0e785a6-7f7c-482f-871d-2c2836f67372.png)

```
SMC: 5,000 sampled plans of 8 districts on 4,813 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.50 to 0.77

R-hat values for summary statistics:
     vap_black    pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
     1.0019362      1.0001980      1.0057206      1.0114052      1.0002806      1.0040337      1.0029391 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two 
     1.0021549      1.0017776      1.0078128      1.0162107      1.0040745      0.9999582      1.0016358 
     vap_white       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
     1.0059124      1.0017963      1.0036996      1.0160445      1.0015127      1.0008652      1.0018242 
pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_blu uss_16_dem_kan uss_18_rep_haw 
     1.0007565      1.0026979      1.0002460      1.0025551      1.0004420      1.0011973      1.0003595 
uss_18_dem_mcc gov_16_rep_gre gov_16_dem_kos gov_20_rep_par gov_20_dem_gal atg_16_rep_haw atg_16_dem_hen 
     1.0019069      1.0003949      1.0009932      1.0001194      1.0018208      1.0001550      1.0018807 
atg_20_rep_sch atg_20_dem_fin sos_16_rep_ash sos_16_dem_smi sos_20_rep_ash sos_20_dem_fal         adv_16 
     1.0000752      1.0027933      1.0002822      1.0024667      1.0001090      1.0029881      1.0020217 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits    muni_splits 
     1.0019069      1.0027655      1.0002214      1.0003595      1.0000291      1.0010467      1.0032203 
           ndv            nrv        ndshare          e_dvs          e_dem          pbias           egap 
     1.0017142      1.0001595      1.0003798      1.0003734      0.9998732      1.0014939      0.9999342 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,026 (60.5%)     12.2%        0.41 3,173 (100%)     13 
Split 2     3,029 (60.6%)     18.0%        0.47 2,733 ( 86%)      8 
Split 3     2,814 (56.3%)      9.7%        0.51 2,783 ( 88%)     13 
Split 4     2,975 (59.5%)     14.1%        0.54 2,766 ( 88%)      8 
Split 5     3,124 (62.5%)     16.1%        0.52 2,819 ( 89%)      6 
Split 6     3,225 (64.5%)     17.7%        0.56 2,751 ( 87%)      4 
Split 7     2,720 (54.4%)      6.1%        0.56 2,498 ( 79%)      4 
Resample    2,466 (49.3%)       NA%        0.66 3,706 (117%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,019 (60.4%)     13.5%        0.42 3,152 (100%)     12 
Split 2     2,961 (59.2%)     20.7%        0.46 2,728 ( 86%)      7 
Split 3     2,851 (57.0%)     20.5%        0.52 2,808 ( 89%)      6 
Split 4     2,998 (60.0%)     25.0%        0.53 2,774 ( 88%)      4 
Split 5     3,050 (61.0%)     27.5%        0.53 2,759 ( 87%)      3 
Split 6     3,437 (68.7%)     26.0%        0.54 2,696 ( 85%)      2 
Split 7     3,088 (61.8%)      9.7%        0.55 2,468 ( 78%)      2 
Resample    2,898 (58.0%)       NA%        0.63 3,734 (118%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan