### PR TITLE
2010 West Virginia Congressional Districts

### DIFF
--- a/analyses/WV_cd_2010/01_prep_WV_cd_2010.R
+++ b/analyses/WV_cd_2010/01_prep_WV_cd_2010.R
@@ -47,27 +47,27 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("WV", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("WV"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     wv_shp <- left_join(wv_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
     # add the enacted plan
     baf_cd113 <- make_from_baf("WV", from = read_baf_cd113("WV"), year = 2010) %>%
-        rename(GEOID = vtd) %>% mutate(GEOID = paste0("09", GEOID))
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("54", GEOID))
     ct_shp <- ct_shp %>%
         left_join(baf_cd113, by = "GEOID")
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = wv_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         wv_shp <- rmapshaper::ms_simplify(wv_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/WV_cd_2010/01_prep_WV_cd_2010.R
+++ b/analyses/WV_cd_2010/01_prep_WV_cd_2010.R
@@ -1,0 +1,85 @@
+###############################################################################
+# Download and prepare data for `WV_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WV_cd_2010}")
+
+path_data <- download_redistricting_file("WV", "data-raw/WV", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/wv_2010_congress_2011-08-18_2021-12-31.zip"
+path_enacted <- "data-raw/WV/WV_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "WV_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/WV/WV_enacted/2010 Congressional.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WV_2010/shp_vtd.rds"
+perim_path <- "data-out/WV_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WV} shapefile")
+    # read in redistricting data
+    wv_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$WV)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("WV", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("WV"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("WV", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("WV"), vtd),
+                  cd_2000 = as.integer(cd))
+    wv_shp <- left_join(wv_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("WV", from = read_baf_cd113("WV"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("09", GEOID))
+    ct_shp <- ct_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = wv_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wv_shp <- rmapshaper::ms_simplify(wv_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    wv_shp$adj <- redist.adjacency(wv_shp)
+
+    wv_shp <- wv_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(wv_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    wv_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WV} shapefile")
+}

--- a/analyses/WV_cd_2010/02_setup_WV_cd_2010.R
+++ b/analyses/WV_cd_2010/02_setup_WV_cd_2010.R
@@ -9,7 +9,6 @@ map <- redist_map(wv_shp, pop_tol = 0.005,
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "WV_2010"
-
 map$state <- "WV"
 
 # Output the redist_map object. Do not edit this path.

--- a/analyses/WV_cd_2010/02_setup_WV_cd_2010.R
+++ b/analyses/WV_cd_2010/02_setup_WV_cd_2010.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `WV_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WV_cd_2010}")
+
+map <- redist_map(wv_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = wv_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WV_2010"
+
+map$state <- "WV"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WV_2010/WV_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WV_cd_2010/03_sim_WV_cd_2010.R
+++ b/analyses/WV_cd_2010/03_sim_WV_cd_2010.R
@@ -1,0 +1,29 @@
+###############################################################################
+# Simulate plans for `WV_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WV_cd_2010}")
+
+set.seed(2010)
+
+plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = county)
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WV_2010/WV_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WV_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WV_2010/WV_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/WV_cd_2010/doc_WV_cd_2010.md
+++ b/analyses/WV_cd_2010/doc_WV_cd_2010.md
@@ -9,7 +9,6 @@
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
-We also merge VTDs into counties and run the simulation at the county level.
 
 ## Data Sources
 Data for West Virginia comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,4 +18,4 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 5,000 districting plans for West Virginia across 4 independent runs of the SMC algorithm.
-No special techniques were needed to produce the sample.
+We also merge VTDs into counties and run the simulation at the county level.

--- a/analyses/WV_cd_2010/doc_WV_cd_2010.md
+++ b/analyses/WV_cd_2010/doc_WV_cd_2010.md
@@ -1,14 +1,15 @@
 # 2010 West Virginia Congressional Districts
 
 ## Redistricting requirements
-[In West Virginia, under the state constitution, districts must](http://www.wvlegislature.gov/WVCODE/WV_CON.cfm):
-1. be contiguous (I 1-4)
-1. have equal populations (I 1-4)
-1. be geographically compact (I 1-4)
-1. districts must be made of contiguous counties (I 1-4)
+[In West Virginia, according to [W.V. Const. art. I, § 4](https://www.wvlegislature.gov/WVCODE/Code.cfm?chap=01&art=2), districts must:
+
+1. be made of contiguous counties
+1. have equal populations
+1. be geographically compact
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
+We also merge VTDs into counties and run the simulation at the county level.
 
 ## Data Sources
 Data for West Virginia comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/WV_cd_2010/doc_WV_cd_2010.md
+++ b/analyses/WV_cd_2010/doc_WV_cd_2010.md
@@ -1,0 +1,21 @@
+# 2010 West Virginia Congressional Districts
+
+## Redistricting requirements
+[In West Virginia, under the state constitution, districts must](http://www.wvlegislature.gov/WVCODE/WV_CON.cfm):
+1. be contiguous (I 1-4)
+1. have equal populations (I 1-4)
+1. be geographically compact (I 1-4)
+1. districts must be made of contiguous counties (I 1-4)
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for West Virginia comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for West Virginia across 4 independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
[In West Virginia, according to [W.V. Const. art. I, § 4](https://www.wvlegislature.gov/WVCODE/Code.cfm?chap=01&art=2), districts must:

1. be made of contiguous counties
1. have equal populations
1. be geographically compact

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We also merge VTDs into counties and run the simulation at the county level.

## Data Sources
Data for West Virginia comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for West Virginia across 4 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
![validation_20221224_1551](https://user-images.githubusercontent.com/46555283/209453520-4d4a5490-22c7-47e1-997d-c2c2b0b8f157.png)

```
SMC: 5,000 sampled plans of 3 districts on 55 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing WV shapefile
Plan diversity 80% range: 0.35 to 0.79
ℹ Preparing WV shapefile
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.004724       1.000832       1.000995       1.001041       1.000643       1.002544       1.001706 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.002082       1.002052       1.001623       1.001914       1.002869       1.002047       1.001106 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.002101       1.002102       1.002717       1.001718       1.002812       1.001806       1.002128 
pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_18_rep_mor uss_18_dem_man uss_20_rep_cap 
      1.001844       1.001648       1.002676       1.001055       1.001482       1.002323       1.001800 
uss_20_dem_swe gov_16_rep_col gov_16_dem_jus gov_20_rep_jus gov_20_dem_sal atg_16_rep_mor atg_16_dem_rey 
      1.001373       1.002377       1.001429       1.000963       1.001869       1.001814       1.001415 
atg_20_rep_mor atg_20_dem_pet sos_16_rep_war sos_16_dem_ten sos_20_rep_war sos_20_dem_ten         adv_16 
      1.001877       1.002013       1.002063       1.001841       1.001600       1.002364       1.001554 
        adv_18         adv_20         arv_16         arv_18         arv_20            ndv            nrv 
      1.002323       1.001434       1.002321       1.001482       1.002170       1.003138       1.002296 
       ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
      1.002266       1.002608       1.002071       1.000032       1.003598       1.000091 

Sampling diagnostics for SMC run 1 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,224 (97.9%)      2.4%        0.29   787 (100%)      4 
Split 2     1,208 (96.7%)      1.0%        0.35   682 ( 86%)      3 
Resample    1,085 (86.8%)       NA%        0.36 1,068 (135%)     NA 

Sampling diagnostics for SMC run 2 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,223 (97.9%)      2.5%        0.30   777 ( 98%)      4 
Split 2     1,219 (97.5%)      1.0%        0.30   694 ( 88%)      3 
Resample    1,134 (90.7%)       NA%        0.32 1,078 (136%)     NA 

Sampling diagnostics for SMC run 3 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,223 (97.9%)      2.4%        0.30   770 ( 97%)      4 
Split 2     1,214 (97.1%)      1.0%        0.32   684 ( 87%)      3 
Resample    1,116 (89.3%)       NA%        0.34 1,083 (137%)     NA 

Sampling diagnostics for SMC run 4 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,224 (97.9%)      2.4%        0.29   784 ( 99%)      4 
Split 2     1,217 (97.3%)      1.0%        0.30   696 ( 88%)      3 
Resample    1,125 (90.0%)       NA%        0.33 1,077 (136%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan