### PR TITLE
2010 Arizona Congressional Districts

### DIFF
--- a/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
@@ -1,0 +1,88 @@
+###############################################################################
+# Download and prepare data for `AZ_cd_2010` analysis
+# © ALARM Project, December 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AZ_cd_2010}")
+
+path_data <- download_redistricting_file("AZ", "data-raw/AZ", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/az_2010_congress_2012-04-09_2021-12-31.zip"
+path_enacted <- "data-raw/AZ/AZ_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AZ_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/AZ/AZ_enacted/Final_Congressional_Districts-shp.shp"
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AZ_2010/shp_vtd.rds"
+perim_path <- "data-out/AZ_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AZ} shapefile")
+    # read in redistricting data
+    az_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$AZ)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AZ", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("AZ"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("AZ", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("AZ"), vtd),
+                  cd_2000 = as.integer(cd))
+    az_shp <- left_join(az_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("AZ", from = read_baf_cd113("AZ"), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0("04", GEOID))
+    az_shp <- az_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = az_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        az_shp <- rmapshaper::ms_simplify(az_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    az_shp$adj <- redist.adjacency(az_shp)
+
+    az_shp <- az_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(az_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    az_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AZ} shapefile")
+}

--- a/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
@@ -11,6 +11,7 @@ suppressMessages({
     library(geomander)
     library(cli)
     library(here)
+    library(Rfast) # used in this set of simulations
     devtools::load_all() # load utilities
 })
 

--- a/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/01_prep_AZ_cd_2010.R
@@ -27,9 +27,6 @@ unzip(here(path_enacted), exdir = here(dirname(path_enacted), "AZ_enacted"))
 file.remove(path_enacted)
 path_enacted <- "data-raw/AZ/AZ_enacted/Final_Congressional_Districts-shp.shp"
 
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
-
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -50,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("AZ", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("AZ"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     az_shp <- left_join(az_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -64,13 +61,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = az_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         az_shp <- rmapshaper::ms_simplify(az_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/AZ_cd_2010/02_setup_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/02_setup_AZ_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(az_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "AZ_2010"

--- a/analyses/AZ_cd_2010/02_setup_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/02_setup_AZ_cd_2010.R
@@ -1,0 +1,21 @@
+###############################################################################
+# Set up redistricting simulation for `AZ_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AZ_cd_2010}")
+
+map <- redist_map(az_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = az_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "AZ_2010"
+map$state <- "AZ"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/AZ_2010/AZ_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
@@ -102,13 +102,13 @@ if (interactive()) {
     plans_no <- redist_smc(map, nsims = 1e3, counties = pseudo_county) %>%
         add_summary_stats(map)
     p1 <- plot(plans, ndshare, geom = "boxplot") +
-        ggplot2::geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
-        ggplot2::scale_y_continuous("Democratic share", labels = scales::percent) +
-        ggplot2::labs(title = "With competitiveness")
+        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        scale_y_continuous("Democratic share", labels = scales::percent) +
+        labs(title = "With competitiveness")
     p2 <- plot(plans_no, ndshare, geom = "boxplot") +
-        ggplot2::geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
-        ggplot2::scale_y_continuous("Democratic share", labels = scales::percent) +
-        ggplot2::labs(title = "Without competitiveness")
+        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        scale_y_continuous("Democratic share", labels = scales::percent) +
+        labs(title = "Without competitiveness")
     p1 + p2 + patchwork::plot_layout(guides = "collect")
 
     # VRA
@@ -116,13 +116,13 @@ if (interactive()) {
         mutate(min = vap_hisp/total_vap) %>%
         number_by(min) %>%
         redist.plot.distr_qtys(ndshare, sort = "none", geom = "boxplot") +
-        ggplot2::labs(x = "Districts, ordered by HVAP", y = "Average Democratic share")
+        labs(x = "Districts, ordered by HVAP", y = "Average Democratic share")
 
     redist.plot.distr_qtys(plans, vap_hisp/total_vap,
         color_thresh = NULL,
         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
         size = 0.1) +
-        ggplot2::scale_y_continuous("Percent Hispanic by VAP") +
-        ggplot2::labs(title = "Approximate Performance") +
-        ggplot2::scale_color_manual(values = c(cd_2010_prop = "black"))
+        scale_y_continuous("Percent Hispanic by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2010_prop = "black"))
 }

--- a/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
@@ -25,8 +25,8 @@ border_idxs <- as_tibble(map) %>%
 constr <- redist_constr(map_nomaricopa) %>%
     add_constr_compet(15, ndv, nrv) %>%
     add_constr_grp_hinge(20, vap_hisp, vap, 0.5) %>%
-    add_constr_grp_hinge(-30, vap_hisp, vap, 0.25) %>%
-    add_constr_grp_inv_hinge(-10, vap_hisp, vap, 0.55) %>%
+    add_constr_grp_hinge(-20, vap_hisp, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(5, vap_hisp, vap, 0.55) %>%
     add_constr_custom(100, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     }) %>%
@@ -35,7 +35,7 @@ constr <- redist_constr(map_nomaricopa) %>%
 set.seed(2010)
 plans_nomaricopa <- redist_smc(map_nomaricopa, nsims = 1500, runs = 8L, n_steps = 3,
     counties = county_muni, constraints = constr,
-    pop_temper = 0.03, seq_alpha = 0.99, verbose = TRUE)
+    pop_temper = 0.05, verbose = TRUE)
 
 # diagnostic check on HVAP
 if (FALSE) {
@@ -56,16 +56,16 @@ init_m[match(map_nomaricopa$GEOID, map$GEOID), ] <- as.matrix(plans_nomaricopa)[
 ## Finish simulations ------
 constr <- redist_constr(map) %>%
     add_constr_compet(15, ndv, nrv) %>%
-    add_constr_grp_hinge(40, vap_hisp, vap, 0.5) %>%
-    add_constr_grp_hinge(-40, vap_hisp, vap, 0.3) %>%
-    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.55) %>%
+    add_constr_grp_hinge(20, vap_hisp, vap, 0.5) %>%
+    add_constr_grp_hinge(-20, vap_hisp, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(5, vap_hisp, vap, 0.55) %>%
     suppressWarnings()
 
 set.seed(2010)
 
 plans <- redist_smc(map, nsims = 8e3, runs = 4L, counties = pseudo_county,
-    constraints = constr, init_particles = init_m, pop_temper = 0.03,
-    seq_alpha = 0.99, verbose = TRUE) %>%
+    constraints = constr, init_particles = init_m, pop_temper = 0.05,
+    verbose = TRUE) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
     ungroup()

--- a/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
@@ -24,9 +24,9 @@ border_idxs <- as_tibble(map) %>%
 
 constr <- redist_constr(map_nomaricopa) %>%
     add_constr_compet(15, ndv, nrv) %>%
-    add_constr_grp_hinge(30, vap_hisp, vap, 0.53) %>%
-    add_constr_grp_hinge(-30, vap_hisp, vap, 0.28) %>%
-    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.58) %>%
+    add_constr_grp_hinge(20, vap_hisp, vap, 0.5) %>%
+    add_constr_grp_hinge(-30, vap_hisp, vap, 0.25) %>%
+    add_constr_grp_inv_hinge(-10, vap_hisp, vap, 0.55) %>%
     add_constr_custom(100, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     }) %>%
@@ -34,8 +34,18 @@ constr <- redist_constr(map_nomaricopa) %>%
 
 set.seed(2010)
 plans_nomaricopa <- redist_smc(map_nomaricopa, nsims = 1500, runs = 8L, n_steps = 3,
-                               counties = county_muni, constraints = constr,
-                               pop_temper = 0.02, seq_alpha = 0.99, verbose = TRUE)
+    counties = county_muni, constraints = constr,
+    pop_temper = 0.03, seq_alpha = 0.99, verbose = TRUE)
+
+# diagnostic check on HVAP
+if (FALSE) {
+    plot(constr)
+    plans_nomaricopa %>%
+        mutate(hisp = group_frac(map_nomaricopa, vap_hisp, vap),
+            min = 1 - group_frac(map_nomaricopa, vap_white, vap)) %>%
+        filter(district > 0) %>%
+        plot(hisp, geom = "boxplot")
+}
 
 # subsample 8k to init next stage
 init_m <- matrix(0, nrow = nrow(map), ncol = Nsim_final)
@@ -46,16 +56,16 @@ init_m[match(map_nomaricopa$GEOID, map$GEOID), ] <- as.matrix(plans_nomaricopa)[
 ## Finish simulations ------
 constr <- redist_constr(map) %>%
     add_constr_compet(15, ndv, nrv) %>%
-    add_constr_grp_hinge(20, vap_hisp, vap, 0.53) %>%
-    add_constr_grp_hinge(-22, vap_hisp, vap, 0.35) %>%
-    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.58) %>%
+    add_constr_grp_hinge(40, vap_hisp, vap, 0.5) %>%
+    add_constr_grp_hinge(-40, vap_hisp, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.55) %>%
     suppressWarnings()
 
 set.seed(2010)
 
 plans <- redist_smc(map, nsims = 8e3, runs = 4L, counties = pseudo_county,
-                    constraints = constr, init_particles = init_m, pop_temper = 0.03,
-                    seq_alpha = 0.9, verbose = TRUE) %>%
+    constraints = constr, init_particles = init_m, pop_temper = 0.03,
+    seq_alpha = 0.99, verbose = TRUE) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
     ungroup()
@@ -92,27 +102,27 @@ if (interactive()) {
     plans_no <- redist_smc(map, nsims = 1e3, counties = pseudo_county) %>%
         add_summary_stats(map)
     p1 <- plot(plans, ndshare, geom = "boxplot") +
-        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
-        scale_y_continuous("Democratic share", labels = scales::percent) +
-        labs(title = "With competitiveness")
+        ggplot2::geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        ggplot2::scale_y_continuous("Democratic share", labels = scales::percent) +
+        ggplot2::labs(title = "With competitiveness")
     p2 <- plot(plans_no, ndshare, geom = "boxplot") +
-        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
-        scale_y_continuous("Democratic share", labels = scales::percent) +
-        labs(title = "Without competitiveness")
-    p1 + p2 + plot_layout(guides = "collect")
+        ggplot2::geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        ggplot2::scale_y_continuous("Democratic share", labels = scales::percent) +
+        ggplot2::labs(title = "Without competitiveness")
+    p1 + p2 + patchwork::plot_layout(guides = "collect")
 
     # VRA
     plans %>%
         mutate(min = vap_hisp/total_vap) %>%
         number_by(min) %>%
         redist.plot.distr_qtys(ndshare, sort = "none", geom = "boxplot") +
-        labs(x = "Districts, ordered by HVAP", y = "Average Democratic share")
+        ggplot2::labs(x = "Districts, ordered by HVAP", y = "Average Democratic share")
 
     redist.plot.distr_qtys(plans, vap_hisp/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.1) +
-        scale_y_continuous("Percent Hispanic by VAP") +
-        labs(title = "Approximate Performance") +
-        scale_color_manual(values = c(cd_2020_prop = "black"))
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.1) +
+        ggplot2::scale_y_continuous("Percent Hispanic by VAP") +
+        ggplot2::labs(title = "Approximate Performance") +
+        ggplot2::scale_color_manual(values = c(cd_2010_prop = "black"))
 }

--- a/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
+++ b/analyses/AZ_cd_2010/03_sim_AZ_cd_2010.R
@@ -1,0 +1,118 @@
+###############################################################################
+# Simulate plans for `AZ_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AZ_cd_2010}")
+
+Nsim_final <- 8e3 # sims per run in the final map
+
+## Get 1 HVAP outside Maricopa ------
+map_nomaricopa <- filter(map, county != "Maricopa County")
+attr(map_nomaricopa, "pop_bounds") <- attr(map, "pop_bounds")
+
+# ID precincts on the border of Maricopa
+border_idxs <- as_tibble(map) %>%
+    mutate(cluster_edge = ifelse(GEOID %in% map_nomaricopa$GEOID, 0, 1)) %>%
+    geomander::seam_geom(.$adj, ., admin = "cluster_edge", seam = c(0, 1)) %>%
+    suppressWarnings() %>%
+    filter(cluster_edge == 1) %>%
+    pull(GEOID) %>%
+    match(., map_nomaricopa$GEOID)
+
+
+constr <- redist_constr(map_nomaricopa) %>%
+    add_constr_compet(15, ndv, nrv) %>%
+    add_constr_grp_hinge(30, vap_hisp, vap, 0.53) %>%
+    add_constr_grp_hinge(-30, vap_hisp, vap, 0.28) %>%
+    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.58) %>%
+    add_constr_custom(100, function(plan, distr) {
+        ifelse(any(plan[border_idxs] == 0), 0, 1)
+    }) %>%
+    suppressWarnings()
+
+set.seed(2010)
+plans_nomaricopa <- redist_smc(map_nomaricopa, nsims = 1500, runs = 8L, n_steps = 3,
+                               counties = county_muni, constraints = constr,
+                               pop_temper = 0.02, seq_alpha = 0.99, verbose = TRUE)
+
+# subsample 8k to init next stage
+init_m <- matrix(0, nrow = nrow(map), ncol = Nsim_final)
+idxs <- sample(ncol(as.matrix(plans_nomaricopa)), Nsim_final, replace = F)
+init_m[match(map_nomaricopa$GEOID, map$GEOID), ] <- as.matrix(plans_nomaricopa)[, idxs]
+
+
+## Finish simulations ------
+constr <- redist_constr(map) %>%
+    add_constr_compet(15, ndv, nrv) %>%
+    add_constr_grp_hinge(20, vap_hisp, vap, 0.53) %>%
+    add_constr_grp_hinge(-22, vap_hisp, vap, 0.35) %>%
+    add_constr_grp_inv_hinge(10, vap_hisp, vap, 0.58) %>%
+    suppressWarnings()
+
+set.seed(2010)
+
+plans <- redist_smc(map, nsims = 8e3, runs = 4L, counties = pseudo_county,
+                    constraints = constr, init_particles = init_m, pop_temper = 0.03,
+                    seq_alpha = 0.9, verbose = TRUE) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AZ_2010/AZ_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AZ_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AZ_2010/AZ_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    plot(constr)
+
+    # competitiveness
+    constr <- redist_constr(map) %>%
+        add_constr_grp_pow(1e3, vap_hisp, vap, 0.51, 0.15, pow = 1.4)
+    plans_no <- redist_smc(map, nsims = 1e3, counties = pseudo_county) %>%
+        add_summary_stats(map)
+    p1 <- plot(plans, ndshare, geom = "boxplot") +
+        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        scale_y_continuous("Democratic share", labels = scales::percent) +
+        labs(title = "With competitiveness")
+    p2 <- plot(plans_no, ndshare, geom = "boxplot") +
+        geom_hline(yintercept = 0.5, lty = "dashed", color = "red") +
+        scale_y_continuous("Democratic share", labels = scales::percent) +
+        labs(title = "Without competitiveness")
+    p1 + p2 + plot_layout(guides = "collect")
+
+    # VRA
+    plans %>%
+        mutate(min = vap_hisp/total_vap) %>%
+        number_by(min) %>%
+        redist.plot.distr_qtys(ndshare, sort = "none", geom = "boxplot") +
+        labs(x = "Districts, ordered by HVAP", y = "Average Democratic share")
+
+    redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.1) +
+        scale_y_continuous("Percent Hispanic by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020_prop = "black"))
+}

--- a/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
+++ b/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
@@ -13,8 +13,7 @@ In Arizona, districts must:
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
 We add a county/municipality constraint, as described below.
-We add a VRA constraint targeting two majority-HVAP districts which are also substantially majority-minority.
-Not every plans is guaranteed to have two majority-HVAP districts, however.
+We add a hinge Gibbs constraint targeting two majority-HVAP districts, one within Maricopa County and one outside of it (as exist in the enacted plan.) However, not all plans are guaranteed to have two majority-HVAP districts.
 
 ## Data Sources
 Data for Arizona comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -27,14 +26,10 @@ We sample 32,000 districting plans for Arizona across four independent runs of t
 To satisfy the Voting Rights Act constraint, we run the simulation in two steps.
 
 #### 1. Simulate three districts outside of Maricopa County
-We target a Hispanic-majority district outside of Maricopa county (HVAP 53-58%).
-However, most realized districts, while electing Democratic candidates, have a lower HVAP.
-We avoid splitting municipalities in this region.
-
+We target a Hispanic-majority district outside of Maricopa County (HVAP 50-55%). We avoid splitting municipalities in this region.
 
 #### 2. Simulate six more districts in the remainder of the map
-We target 1 Hispanic-majority district in Maricopa county (HVAP 53-58%).
-We are able to realize this target values.
+We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%).
 
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties outside Maricopa County and Pima County, which are larger than a congressional district in population.

--- a/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
+++ b/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
@@ -28,7 +28,7 @@ To satisfy the Voting Rights Act constraint, we run the simulation in two steps.
 We target a Hispanic-majority district outside of Maricopa County (HVAP 50-55%). We avoid splitting municipalities in this region.
 
 #### 2. Simulate six more districts in the remainder of the map
-We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%), and only accept plans where the district with the second-highest HVAP exceeds 30%.
+We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%), and only keep plans where the district with the second-highest HVAP exceeds 30% (including the districts outside Maricopa County).
 
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties outside Maricopa County and Pima County, which are larger than a congressional district in population.

--- a/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
+++ b/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
@@ -9,7 +9,6 @@ In Arizona, districts must:
 1. preserve county and municipality boundaries as much as possible
 1. favor competitive districts to the extent practicable
 
-
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
 We add a county/municipality constraint, as described below.
@@ -29,7 +28,7 @@ To satisfy the Voting Rights Act constraint, we run the simulation in two steps.
 We target a Hispanic-majority district outside of Maricopa County (HVAP 50-55%). We avoid splitting municipalities in this region.
 
 #### 2. Simulate six more districts in the remainder of the map
-We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%).
+We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%), and only accept plans where the district with the second-highest HVAP exceeds 30%.
 
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.
 These are counties outside Maricopa County and Pima County, which are larger than a congressional district in population.

--- a/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
+++ b/analyses/AZ_cd_2010/doc_AZ_cd_2010.md
@@ -1,0 +1,42 @@
+# 2010 Arizona Congressional Districts
+
+## Redistricting requirements
+In Arizona, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. favor competitive districts to the extent practicable
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+We add a county/municipality constraint, as described below.
+We add a VRA constraint targeting two majority-HVAP districts which are also substantially majority-minority.
+Not every plans is guaranteed to have two majority-HVAP districts, however.
+
+## Data Sources
+Data for Arizona comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 32,000 districting plans for Arizona across four independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.
+To satisfy the Voting Rights Act constraint, we run the simulation in two steps.
+
+#### 1. Simulate three districts outside of Maricopa County
+We target a Hispanic-majority district outside of Maricopa county (HVAP 53-58%).
+However, most realized districts, while electing Democratic candidates, have a lower HVAP.
+We avoid splitting municipalities in this region.
+
+
+#### 2. Simulate six more districts in the remainder of the map
+We target 1 Hispanic-majority district in Maricopa county (HVAP 53-58%).
+We are able to realize this target values.
+
+To balance county and municipality splits, we create pseudocounties for use in the county constraint.
+These are counties outside Maricopa County and Pima County, which are larger than a congressional district in population.
+Within Maricopa County and Pima County, municipalities are each their own pseudocounty as well.
+Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.


### PR DESCRIPTION
## Redistricting requirements
In Arizona, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. favor competitive districts to the extent practicable

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We add a county/municipality constraint, as described below.
We add a hinge Gibbs constraint targeting two majority-HVAP districts, one within Maricopa County and one outside of it (as exist in the enacted plan.) However, not all plans are guaranteed to have two majority-HVAP districts.

## Data Sources
Data for Arizona comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 32,000 districting plans for Arizona across four independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans.
To satisfy the Voting Rights Act constraint, we run the simulation in two steps.

#### 1. Simulate three districts outside of Maricopa County
We target a Hispanic-majority district outside of Maricopa County (HVAP 50-55%). We avoid splitting municipalities in this region.

#### 2. Simulate six more districts in the remainder of the map
We target 1 Hispanic-majority district in Maricopa County (HVAP 50-55%).

To balance county and municipality splits, we create pseudocounties for use in the county constraint.
These are counties outside Maricopa County and Pima County, which are larger than a congressional district in population.
Within Maricopa County and Pima County, municipalities are each their own pseudocounty as well.
Overall, this approach leads to much fewer county and municipality splits than using either a county or county/municipality constraint.

## Validation

![validation_20221227_1452](https://user-images.githubusercontent.com/46555283/209733067-0c12e091-3e42-4519-a5da-515c173bf424.png)

```
SMC: 5,000 sampled plans of 9 districts on 2,224 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0.05

Plan diversity 80% range: 0.55 to 0.84

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
      1.007131       1.011104       1.006465       1.004757       1.019307       1.019665 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other 
      1.039325       1.021981       1.021785       1.027378       1.034513       1.035271 
       pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.015950       1.031346       1.038971       1.023286       1.021316       1.028698 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli pre_20_dem_bid 
      1.032422       1.033549       1.006353       1.028330       1.008934       1.017614 
pre_20_rep_tru uss_16_rep_mcc uss_16_dem_kir uss_18_rep_mcs uss_18_dem_sin uss_20_dem_kel 
      1.010727       1.032049       1.009605       1.022904       1.008203       1.017983 
uss_20_rep_mcs gov_18_rep_duc gov_18_dem_gar atg_18_rep_brn atg_18_dem_con sos_18_rep_gay 
      1.011414       1.014537       1.003847       1.015785       1.006302       1.026719 
sos_18_dem_hob         adv_16         adv_18         adv_20         arv_16         arv_18 
      1.007230       1.003324       1.006924       1.017580       1.021364       1.021690 
        arv_20  county_splits    muni_splits            ndv            nrv        ndshare 
      1.010465       1.001663       1.014508       1.010047       1.021033       1.012117 
         e_dvs         pr_dem          e_dem          pbias           egap 
      1.016499       1.006711       1.007349       1.006813       1.011905 

Sampling diagnostics for SMC run 1 of 4 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,914 (61.4%)     10.2%        0.45 3,916 ( 77%)      4 
Split 2     4,303 (53.8%)     19.6%        0.88 4,088 ( 81%)      3 
Split 3     3,904 (48.8%)     23.8%        0.99 3,871 ( 77%)      2 
Split 4     4,190 (52.4%)     18.2%        1.01 3,710 ( 73%)      2 
Split 5     3,432 (42.9%)      6.7%        0.94 3,308 ( 65%)      2 
Resample    1,109 (13.9%)       NA%        2.82 3,152 ( 62%)     NA 

Sampling diagnostics for SMC run 2 of 4 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,930 (61.6%)      5.8%        0.45 3,892 ( 77%)      7 
Split 2     4,341 (54.3%)     15.1%        0.90 4,123 ( 82%)      4 
Split 3     4,255 (53.2%)     13.3%        0.98 3,875 ( 77%)      4 
Split 4     4,446 (55.6%)     13.2%        0.96 3,701 ( 73%)      3 
Split 5     3,785 (47.3%)      7.2%        0.94 3,334 ( 66%)      2 
Resample    1,310 (16.4%)       NA%        2.75 3,290 ( 65%)     NA 

Sampling diagnostics for SMC run 3 of 4 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,938 (61.7%)     13.0%        0.45 3,932 ( 78%)      3 
Split 2     4,347 (54.3%)     14.6%        0.87 4,087 ( 81%)      4 
Split 3     4,196 (52.5%)     17.5%        1.01 3,897 ( 77%)      3 
Split 4     4,453 (55.7%)     18.8%        0.97 3,723 ( 74%)      2 
Split 5     3,832 (47.9%)      6.8%        0.91 3,431 ( 68%)      2 
Resample    1,277 (16.0%)       NA%        2.89 3,357 ( 66%)     NA 

Sampling diagnostics for SMC run 4 of 4 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,964 (62.1%)     13.0%        0.44 3,945 ( 78%)      3 
Split 2     4,291 (53.6%)     15.0%        0.89 4,166 ( 82%)      4 
Split 3     3,984 (49.8%)     17.3%        1.01 3,918 ( 77%)      3 
Split 4     4,229 (52.9%)     18.4%        0.95 3,713 ( 73%)      2 
Split 5     3,556 (44.5%)      6.7%        0.91 3,378 ( 67%)      2 
Resample    1,194 (14.9%)       NA%        3.00 3,090 ( 61%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of
the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
