### PR TITLE
2010 Iowa Congressional Districts

### DIFF
--- a/analyses/IA_cd_2010/01_prep_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/01_prep_IA_cd_2010.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `IA_cd_2010` analysis
+# © ALARM Project, November 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg IA_cd_2010}")
+
+path_data <- download_redistricting_file("IA", "data-raw/IA", year = 2010)
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/iowa/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+path_enacted <- "data-raw/IA/IA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "IA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/IA/IA_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/IA_2010/shp_vtd.rds"
+perim_path <- "data-out/IA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong IA} shapefile")
+    # read in redistricting data
+    ia_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$IA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("IA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("IA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("IA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("IA"), vtd),
+                  cd_2000 = as.integer(cd))
+    ia_shp <- left_join(ia_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ia_shp <- ia_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ia_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ia_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ia_shp <- rmapshaper::ms_simplify(ia_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ia_shp$adj <- redist.adjacency(ia_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ia_shp <- ia_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ia_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ia_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong IA} shapefile")
+}

--- a/analyses/IA_cd_2010/01_prep_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/01_prep_IA_cd_2010.R
@@ -48,9 +48,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("IA", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("IA"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     ia_shp <- left_join(ia_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -59,24 +59,24 @@ if (!file.exists(here(shp_path))) {
     ia_shp <- ia_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(ia_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # group by county to avoid county splits
     ia_shp <- ia_shp %>%
         group_by(state, county) %>%
         summarize(cd_2010 = cd_2010[1],
-                  across(pop:nrv, sum)) %>%
+            across(pop:nrv, sum)) %>%
         ungroup()
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ia_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ia_shp <- rmapshaper::ms_simplify(ia_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
@@ -8,13 +8,13 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg IA_cd_2010}")
 
 # pop tol set lower because of no county split constraints
 map <- redist_map(ia_shp, pop_tol = 0.0001,
-                  existing_plan = cd_2010, adj = ia_shp$adj)
+    existing_plan = cd_2010, adj = ia_shp$adj)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "IA_2010"
 
 # fix state label on map
-map$state <- 'IA'
+map$state <- "IA"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/IA_2010/IA_cd_2010_map.rds", compress = "xz")

--- a/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `IA_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg IA_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ia_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ia_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "IA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/IA_2010/IA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
@@ -4,18 +4,16 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg IA_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
+# DONE any pre-computation (usually not necessary)
+#   Did not do anything
 
-map <- redist_map(ia_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = ia_shp$adj)
+# pop tol set lower because of no county split constraints
+map <- redist_map(ia_shp, pop_tol = 0.0001,
+                  existing_plan = cd_2010, adj = ia_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
+# DONE any filtering, cores, merging, etc.
+#   did not do anything
 
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/02_setup_IA_cd_2010.R
@@ -4,21 +4,17 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg IA_cd_2010}")
 
-# DONE any pre-computation (usually not necessary)
-#   Did not do anything
+#   Did not do any pre-computation
 
 # pop tol set lower because of no county split constraints
 map <- redist_map(ia_shp, pop_tol = 0.0001,
                   existing_plan = cd_2010, adj = ia_shp$adj)
 
-# DONE any filtering, cores, merging, etc.
-#   did not do anything
-
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "IA_2010"
+
+# fix state label on map
+map$state <- 'IA'
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/IA_2010/IA_cd_2010_map.rds", compress = "xz")

--- a/analyses/IA_cd_2010/03_sim_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/03_sim_IA_cd_2010.R
@@ -45,7 +45,6 @@ save_summary_stats(plans, "data-out/IA_2010/IA_cd_2010_stats.csv")
 
 cli_process_done()
 
-map$state <- 'IA'
 
 # Extra validation plots for custom constraints -----
 if (interactive()) {

--- a/analyses/IA_cd_2010/03_sim_IA_cd_2010.R
+++ b/analyses/IA_cd_2010/03_sim_IA_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `IA_cd_2010`
+# © ALARM Project, November 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg IA_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/IA_2010/IA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg IA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/IA_2010/IA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/IA_cd_2010/doc_IA_cd_2010.md
+++ b/analyses/IA_cd_2010/doc_IA_cd_2010.md
@@ -14,7 +14,7 @@ In Iowa, districts must:
 We enforce a maximum population deviation of 0.01%.
 
 ## Data Sources
-Data for Iowa comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Iowa comes from https://redistricting.lls.edu/wp-content/uploads/ia_2010_congress_2011-04-19_2021-12-31.zip
 
 ## Pre-processing Notes
 Shape file was grouped by county to prevent county splits.

--- a/analyses/IA_cd_2010/doc_IA_cd_2010.md
+++ b/analyses/IA_cd_2010/doc_IA_cd_2010.md
@@ -4,19 +4,20 @@
 In Iowa, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact with compactness defined as length-width compactness and perimeter compactness
+4. not split counties
+5. preserve municipality boundaries as much as possible
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.01%.
 
 ## Data Sources
-Data for Iowa comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Iowa comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+Shape file was grouped by county to prevent county splits.
 
 ## Simulation Notes
 We sample 5,000 districting plans for Iowa.

--- a/analyses/IA_cd_2010/doc_IA_cd_2010.md
+++ b/analyses/IA_cd_2010/doc_IA_cd_2010.md
@@ -4,21 +4,24 @@
 In Iowa, districts must:
 
 1. be contiguous
-2. have equal populations
-3. be geographically compact with compactness defined as length-width compactness and perimeter compactness
-4. not split counties
-5. preserve municipality boundaries as much as possible
+1. have equal populations
+1. be constructed only from counties
+1. be geographically compact, as defined by two compactness measures:
+    1. length-width compactness, which measures the total absolute difference between the length and width of a district, across all districts
+    1. perimeter compactness, which measures the total perimeter of all districts
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.01%.
+We enforce a maximum population deviation of 0.01%, given strict historical deviation standards.
+We also merge VTDs into counties and run the simulation at the county level.
+For compactness, we increase the `compactness` parameter to 1.1, which does not create too much inefficiency.
 
 ## Data Sources
-Data for Iowa comes from https://redistricting.lls.edu/wp-content/uploads/ia_2010_congress_2011-04-19_2021-12-31.zip
+Data for Iowa comes from [All About Redistricting](https://redistricting.lls.edu/wp-content/uploads/ia_2010_congress_2011-04-19_2021-12-31.zip)
 
 ## Pre-processing Notes
-Shape file was grouped by county to prevent county splits.
+No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Iowa.
-No special techniques were needed to produce the sample.
+We sample 8,000 districting plans for Iowa across four independent runs of the SMC algorithm and randomly select 1,250 of the plans from each of the four runs.
+As noted above, we set `compactness=1.1`.

--- a/analyses/IA_cd_2010/doc_IA_cd_2010.md
+++ b/analyses/IA_cd_2010/doc_IA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Iowa Congressional Districts
+
+## Redistricting requirements
+In Iowa, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Iowa comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Iowa.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Iowa, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact with compactness defined as length-width compactness and perimeter compactness
4. not split counties
5. preserve municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.01%.

## Data Sources
Data for Iowa comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Shape file was grouped by county to prevent county splits.

## Simulation Notes
We sample 5,000 districting plans for Iowa.
No special techniques were needed to produce the sample.

## Validation
![validation_20230116_1731](https://user-images.githubusercontent.com/97004864/212848435-e2429393-5d92-4ce2-9d1d-58d65d436c54.png)

![validation_comp](https://user-images.githubusercontent.com/97004864/212848462-0be14872-2add-465e-9fdd-9262f835c3fd.png)


```
SMC: 5,000 sampled plans of 4 districts on 99 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.9
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.00 to 0.79

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian 
      1.031659       1.032497       1.046306       1.019521       1.014219       1.067511       1.010439       1.038040       1.049245 
     pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.068630       1.065857       1.047719       1.022109       1.034628       1.009227       1.041492       1.048448       1.071513 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_gra uss_16_dem_jud 
      1.063447       1.049689       1.060552       1.025999       1.012453       1.047613       1.012420       1.013083       1.010033 
uss_20_rep_ern uss_20_dem_gre gov_18_rep_rey gov_18_dem_hub atg_18_dem_mil sos_18_rep_pat sos_18_dem_dej         adv_16         adv_18 
      1.050681       1.010924       1.020413       1.035063       1.016983       1.015582       1.019597       1.011215       1.012726 
        adv_20         arv_16         arv_18         arv_20            ndv            nrv        ndshare        comp_lw           area 
      1.011222       1.013956       1.019411       1.049174       1.011783       1.025499       1.029347       1.038156       1.017200 
    comp_perim          e_dvs         pr_dem          e_dem          pbias           egap 
      1.008834       1.024968       1.014725       1.020896       1.006218       1.016010 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 4 (4,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,120 (53.0%)      0.3%        1.41 2,547 (101%)      1 
Split 2       866 (21.6%)      0.2%        0.86 1,830 ( 72%)      1 
Split 3       619 (15.5%)      0.0%        0.94   769 ( 30%)      1 
Resample      444 (11.1%)       NA%        0.90 1,943 ( 77%)     NA 

Sampling diagnostics for SMC run 2 of 4 (4,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,112 (52.8%)      0.1%        1.42 2,541 (100%)      3 
Split 2       934 (23.4%)      0.1%        0.81 1,781 ( 70%)      2 
Split 3     2,034 (50.8%)      0.0%        0.59   621 ( 25%)      2 
Resample    1,629 (40.7%)       NA%        0.57 3,017 (119%)     NA 

Sampling diagnostics for SMC run 3 of 4 (4,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,145 (53.6%)      0.1%        1.42 2,515 ( 99%)      3 
Split 2     1,070 (26.7%)      0.1%        0.79 1,831 ( 72%)      2 
Split 3     2,147 (53.7%)      0.0%        0.77   893 ( 35%)      2 
Resample    1,839 (46.0%)       NA%        0.75 2,678 (106%)     NA 

Sampling diagnostics for SMC run 4 of 4 (4,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,173 (54.3%)      0.1%        1.44 2,508 ( 99%)      3 
Split 2       838 (20.9%)      0.1%        0.90 1,789 ( 71%)      2 
Split 3     2,002 (50.0%)      0.0%        0.62   906 ( 36%)      2 
Resample    1,509 (37.7%)       NA%        0.59 3,060 (121%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and
low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
