### PR TITLE
2010 Virginia Congressional Districts

### DIFF
--- a/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("VA", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("VA"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     va_shp <- left_join(va_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -58,17 +58,17 @@ if (!file.exists(here(shp_path))) {
     va_shp <- va_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(va_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = va_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         va_shp <- rmapshaper::ms_simplify(va_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
@@ -40,7 +40,7 @@ perim_path <- "data-out/VA_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong VA} shapefile")
     # read in redistricting data
-    va_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    va_shp <- read_csv(here(path_data)) %>%
         join_vtd_shapefile(year = 2010) %>%
         st_transform(EPSG$VA)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
@@ -60,7 +60,7 @@ if (!file.exists(here(shp_path))) {
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
     va_shp <- va_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+        mutate(cd_2010 = as.integer(cd_shp$District)[
             geo_match(va_shp, cd_shp, method = "area")],
             .after = cd_2000)
 

--- a/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
@@ -21,12 +21,12 @@ path_data <- download_redistricting_file("VA", "data-raw/VA", year = 2010)
 
 # download the enacted plan.
 # TODO try to find a download URL at <https://redistricting.lls.edu/state/virginia/>
-url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+url <- "https://redistricting.lls.edu/wp-content/uploads/va_2010_congress_2016-01-07_2021-12-31.zip"
 path_enacted <- "data-raw/VA/VA_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "VA_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/VA/VA_enacted/XXXXXXX.shp" # TODO use actual SHP
+path_enacted <- "data-raw/VA/VA_enacted/Mod_16_shpfile.shp" # TODO use actual SHP
 
 # TODO other files here (as necessary). All paths should start with `path_`
 # If large, consider checking to see if these files exist before downloading
@@ -40,7 +40,7 @@ perim_path <- "data-out/VA_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong VA} shapefile")
     # read in redistricting data
-    va_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+    va_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
         join_vtd_shapefile(year = 2010) %>%
         st_transform(EPSG$VA)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))

--- a/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
@@ -20,16 +20,12 @@ cli_process_start("Downloading files for {.pkg VA_cd_2010}")
 path_data <- download_redistricting_file("VA", "data-raw/VA", year = 2010)
 
 # download the enacted plan.
-# TODO try to find a download URL at <https://redistricting.lls.edu/state/virginia/>
-url <- "https://redistricting.lls.edu/wp-content/uploads/va_2010_congress_2016-01-07_2021-12-31.zip"
+url <- "https://redistricting.lls.edu/wp-content/uploads/va_2010_congress_2012-03-14_2016-01-07.zip"
 path_enacted <- "data-raw/VA/VA_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "VA_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/VA/VA_enacted/Mod_16_shpfile.shp" # TODO use actual SHP
-
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
+path_enacted <- "data-raw/VA/VA_enacted/HB251_Bell.shp" # TODO use actual SHP
 
 cli_process_done()
 
@@ -60,11 +56,9 @@ if (!file.exists(here(shp_path))) {
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
     va_shp <- va_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$District)[
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(va_shp, cd_shp, method = "area")],
             .after = cd_2000)
-
-    # TODO any additional columns or data you want to add should go here
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = va_shp,
@@ -72,7 +66,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         va_shp <- rmapshaper::ms_simplify(va_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -81,8 +74,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     va_shp$adj <- redist.adjacency(va_shp)
-
-    # TODO any custom adjacency graph edits here
 
     va_shp <- va_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/01_prep_VA_cd_2010.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `VA_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg VA_cd_2010}")
+
+path_data <- download_redistricting_file("VA", "data-raw/VA", year = 2010)
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/virginia/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+path_enacted <- "data-raw/VA/VA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "VA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/VA/VA_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/VA_2010/shp_vtd.rds"
+perim_path <- "data-out/VA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong VA} shapefile")
+    # read in redistricting data
+    va_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$VA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("VA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("VA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("VA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("VA"), vtd),
+                  cd_2000 = as.integer(cd))
+    va_shp <- left_join(va_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    va_shp <- va_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(va_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = va_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        va_shp <- rmapshaper::ms_simplify(va_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    va_shp$adj <- redist.adjacency(va_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    va_shp <- va_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(va_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    va_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong VA} shapefile")
+}

--- a/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(va_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
@@ -4,14 +4,9 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg VA_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(va_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = va_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/02_setup_VA_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `VA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg VA_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(va_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = va_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "VA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/VA_2010/VA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `VA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg VA_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/VA_2010/VA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg VA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/VA_2010/VA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
@@ -6,19 +6,12 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg VA_cd_2010}")
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
+
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 5e3, runs = 2L, counties = pseudo_county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()

--- a/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
@@ -6,8 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg VA_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
 # TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
 #  `pop_temper=0.01` and nudging upward from there. Monitor the output for

--- a/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
+++ b/analyses/VA_cd_2010/03_sim_VA_cd_2010.R
@@ -17,8 +17,6 @@ plans <- match_numbers(plans, "cd_2010")
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/VA_2010/VA_cd_2010_plans.rds"), compress = "xz")
 cli_process_done()
@@ -32,11 +30,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/VA_2010/VA_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/VA_cd_2010/doc_VA_cd_2010.md
+++ b/analyses/VA_cd_2010/doc_VA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Virginia Congressional Districts
+
+## Redistricting requirements
+In Virginia, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Virginia.
+No special techniques were needed to produce the sample.

--- a/analyses/VA_cd_2010/doc_VA_cd_2010.md
+++ b/analyses/VA_cd_2010/doc_VA_cd_2010.md
@@ -1,16 +1,17 @@
 # 2010 Virginia Congressional Districts
 
 ## Redistricting requirements
-In Virginia, districts must:
+In Virginia, districts must, under the 2001 Commitee Resolution No. 1 of the Senate and House Committees on Privileges and Elections:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of interest as defined by criteria that "may include, among others, economic factors, social factors, cultural factors, geographic features, governmental jurisdictions and service delivery areas, political beliefs, voting trends, and incumbency considerations"
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,5 +20,5 @@ Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Virginia.
-No special techniques were needed to produce the sample.
+We sample 10,000 districting plans for Virginia across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Fairfax County must be split due to its large population, although within the county, we avoid splitting any municipality.

--- a/analyses/VA_cd_2010/doc_VA_cd_2010.md
+++ b/analyses/VA_cd_2010/doc_VA_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Virginia Congressional Districts
 
 ## Redistricting requirements
-In Virginia, districts must, under Commitee Resolution No. 1 adopted by the Senate and House Committees on Privileges and Elections in 2001:
+In Virginia, districts must, under [Commitee Resolution No. 1](https://www.virginiaredistricting.org/2010/data/publications/2011Draw1.pdf) adopted by the Senate and House Committees on Privileges and Elections in 2001:
 
 1. be contiguous
 2. have equal populations

--- a/analyses/VA_cd_2010/doc_VA_cd_2010.md
+++ b/analyses/VA_cd_2010/doc_VA_cd_2010.md
@@ -1,17 +1,16 @@
 # 2010 Virginia Congressional Districts
 
 ## Redistricting requirements
-In Virginia, districts must, under the 2001 Commitee Resolution No. 1 of the Senate and House Committees on Privileges and Elections:
+In Virginia, districts must, under Commitee Resolution No. 1 adopted by the Senate and House Committees on Privileges and Elections in 2001:
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. preserve communities of interest as defined by criteria that "may include, among others, economic factors, social factors, cultural factors, geographic features, governmental jurisdictions and service delivery areas, political beliefs, voting trends, and incumbency considerations"
-
+5. preserve communities of interest, as defined by criteria that "may include, among others, economic factors, social factors, cultural factors, geographic features, governmental jurisdictions and service delivery areas, political beliefs, voting trends, and incumbency considerations"
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Virginia of generally preserving county, city, and township boundaries.
 
 ## Data Sources
 Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).


### PR DESCRIPTION
## Redistricting requirements
In Virginia, districts must, under [Commitee Resolution No. 1](https://www.virginiaredistricting.org/2010/data/publications/2011Draw1.pdf) adopted by the Senate and House Committees on Privileges and Elections in 2001:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve communities of interest, as defined by criteria that "may include, among others, economic factors, social factors, cultural factors, geographic features, governmental jurisdictions and service delivery areas, political beliefs, voting trends, and incumbency considerations"

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Virginia of generally preserving county, city, and township boundaries.

## Data Sources
Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Virginia across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Fairfax County must be split due to its large population, although within the county, we avoid splitting any municipality.

## Validation

![validation_20230106_1819](https://user-images.githubusercontent.com/26680063/211118250-9a203e55-8540-406d-962d-679fee3dcc55.png)

```
SMC: 5,000 sampled plans of 11 districts on 2,373 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0  
ℹ Running simulations for VA_cd_2010
Plan diversity 80% range: 0.61 to 0.85
ℹ Running simulations for VA_cd_2010
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.003868       1.000114       1.005894       1.003689       1.001729       1.002286       1.001260 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.000052       1.003187       1.000871       1.004234       1.000297       1.007810       1.001300 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.000727       1.000004       1.002956       1.002090       1.002937       1.002055       1.002543 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_18_dem_kai uss_18_rep_ste uss_20_dem_war 
      1.003154       1.005587       1.005808       1.004005       1.005674       1.005871       1.004615 
uss_20_rep_gad         adv_16         adv_18         adv_20         arv_16         arv_18         arv_20 
      1.003080       1.003154       1.005674       1.005205       1.005587       1.005871       1.003531 
 county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
      1.000645       1.004895       1.004043       1.004709       1.005044       1.004990       1.006348 
         e_dem          pbias           egap 
      1.012382       1.000935       1.010968 

Sampling diagnostics for SMC run 1 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    4,854 (194.2%)     15.0%        0.35 3,156 (200%)      7 
Split 2    4,776 (191.0%)     19.8%        0.43 3,151 (199%)      5 
Split 3    4,652 (186.1%)     22.6%        0.52 3,061 (194%)      4 
Split 4    4,570 (182.8%)     26.9%        0.57 3,076 (195%)      3 
Split 5    4,467 (178.7%)     12.8%        0.62 3,080 (195%)      6 
Split 6    4,458 (178.3%)     14.0%        0.62 2,994 (189%)      5 
Split 7    4,459 (178.4%)     20.1%        0.61 3,005 (190%)      3 
Split 8    4,451 (178.0%)     13.2%        0.61 2,970 (188%)      4 
Split 9    4,397 (175.9%)     13.2%        0.65 2,826 (179%)      3 
Split 10   4,472 (178.9%)      6.4%        0.62 2,570 (163%)      2 
Resample   3,033 (121.3%)       NA%        0.62 2,844 (180%)     NA 

Sampling diagnostics for SMC run 2 of 2
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    4,857 (194.3%)     11.5%        0.35 3,144 (199%)      9 
Split 2    4,757 (190.3%)     16.7%        0.44 3,082 (195%)      6 
Split 3    4,581 (183.2%)     22.3%        0.54 3,116 (197%)      4 
Split 4    4,535 (181.4%)     26.9%        0.59 3,088 (195%)      3 
Split 5    4,504 (180.1%)     24.3%        0.62 3,059 (194%)      3 
Split 6    4,484 (179.4%)     30.2%        0.60 3,042 (192%)      2 
Split 7    4,497 (179.9%)     27.0%        0.58 3,003 (190%)      2 
Split 8    4,472 (178.9%)     16.9%        0.60 2,975 (188%)      3 
Split 9    4,462 (178.5%)     19.4%        0.62 2,850 (180%)      2 
Split 10   4,546 (181.8%)      6.5%        0.59 2,594 (164%)      2 
Resample   3,330 (133.2%)       NA%        0.59 2,855 (181%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
ℹ Running simulations for VA_cd_2010
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
