### PR TITLE
2010 Georgia Congressional Districts

### DIFF
--- a/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `GA_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg GA_cd_2010}")
+
+path_data <- download_redistricting_file("GA", "data-raw/GA", year = 2010)
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/georgia/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+path_enacted <- "data-raw/GA/GA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "GA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/GA/GA_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/GA_2010/shp_vtd.rds"
+perim_path <- "data-out/GA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong GA} shapefile")
+    # read in redistricting data
+    ga_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$GA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("GA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("GA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("GA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("GA"), vtd),
+                  cd_2000 = as.integer(cd))
+    ga_shp <- left_join(ga_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ga_shp <- ga_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ga_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ga_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ga_shp$adj <- redist.adjacency(ga_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ga_shp <- ga_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ga_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ga_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong GA} shapefile")
+}

--- a/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
@@ -36,7 +36,7 @@ perim_path <- "data-out/GA_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong GA} shapefile")
     # read in redistricting data
-    ga_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+    ga_shp <- read_csv(here(path_data)) %>%
         join_vtd_shapefile(year = 2010) %>%
         st_transform(EPSG$GA)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
@@ -63,6 +63,9 @@ if (!file.exists(here(shp_path))) {
     # fix labeling
     ga_shp$state <- "GA"
 
+    # eliminate empty shapes
+    ga_shp <- ga_shp %>% filter(!st_is_empty(geometry))
+
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ga_shp,
                              perim_path = here(perim_path)) %>%
@@ -87,17 +90,3 @@ if (!file.exists(here(shp_path))) {
     ga_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong GA} shapefile")
 }
-
-### troubleshooting disconnected precincts
-discon <- c(1042) #DeKalb County
-
-# empty geometries?
-ga_shp[discon,]$geometry
-
-# this might give you an error
-ga_shp[discon,] %>% plot()
-
-# this should not give you an error
-ga_shp[1:5,] %>% plot()
-
-ga_shp[discon,] %>% View() #missing cd_2010 and vtd

--- a/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/01_prep_GA_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("GA", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("GA"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     ga_shp <- left_join(ga_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -58,7 +58,7 @@ if (!file.exists(here(shp_path))) {
     ga_shp <- ga_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(ga_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # fix labeling
     ga_shp$state <- "GA"
@@ -68,13 +68,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ga_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
@@ -4,20 +4,12 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ga_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ga_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "GA_2010"

--- a/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
@@ -7,10 +7,6 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2010}")
 map <- redist_map(ga_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ga_shp$adj)
 
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = 0.8*get_target(map)))
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "GA_2010"
 

--- a/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
@@ -9,7 +9,7 @@ map <- redist_map(ga_shp, pop_tol = 0.005,
 
 # make pseudo counties with default settings
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = get_target(map)))
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = 0.8 * get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "GA_2010"

--- a/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `GA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ga_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ga_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "GA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/GA_2010/GA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/02_setup_GA_cd_2010.R
@@ -9,7 +9,7 @@ map <- redist_map(ga_shp, pop_tol = 0.005,
 
 # make pseudo counties with default settings
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = 0.8 * get_target(map)))
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni, pop_muni = 0.8*get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "GA_2010"

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `GA_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg GA_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/GA_2010/GA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg GA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/GA_2010/GA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -7,13 +7,13 @@
 cli_process_start("Running simulations for {.pkg GA_cd_2010}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(20, vap_black, vap, 0.43) %>%
-    add_constr_grp_hinge(-20, vap_black, vap, 0.34) %>%
-    add_constr_grp_inv_hinge(10, vap_black, vap, 0.61)
+    add_constr_grp_hinge(18, vap_black, vap, 0.43) %>%
+    add_constr_grp_hinge(-18, vap_black, vap, 0.34) %>%
+    add_constr_grp_inv_hinge(9, vap_black, vap, 0.61)
 
 set.seed(2010)
 plans <- redist_smc(map, nsims = 1.5e4, runs = 2L, counties = county, constraints = constr,
-    pop_temper = 0.05) # %>%
+    pop_temper = 0.01) # %>%
 # group_by(chain) %>%
 # filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
 # ungroup()

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -12,12 +12,11 @@ constr <- redist_constr(map) %>%
     add_constr_grp_inv_hinge(10, vap_black, vap, 0.61)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 1.5e4, runs =2L, counties = county, constraints = constr,
-                    pop_temper = 0.05) #%>%
-    #group_by(chain) %>%
-    #filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
-    #ungroup()
-
+plans <- redist_smc(map, nsims = 1.5e4, runs = 2L, counties = county, constraints = constr,
+    pop_temper = 0.05) # %>%
+# group_by(chain) %>%
+# filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+# ungroup()
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -7,13 +7,13 @@
 cli_process_start("Running simulations for {.pkg GA_cd_2010}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(20, vap_black, vap, 0.45) %>%
-    add_constr_grp_hinge(-20, vap_black, vap, 0.37) %>%
-    add_constr_grp_inv_hinge(12, vap_black, vap, 0.61)
+    add_constr_grp_hinge(20, vap_black, vap, 0.43) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, 0.34) %>%
+    add_constr_grp_inv_hinge(10, vap_black, vap, 0.61)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 1e4, runs =2L, counties = county, constraints = constr,
-                    pop_temper = 0.04) #%>%
+plans <- redist_smc(map, nsims = 1.5e4, runs =2L, counties = county, constraints = constr,
+                    pop_temper = 0.05) #%>%
     #group_by(chain) %>%
     #filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
     #ungroup()

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -12,11 +12,10 @@ constr <- redist_constr(map) %>%
     add_constr_grp_inv_hinge(9, vap_black, vap, 0.61)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 1.5e4, runs = 2L, counties = county, constraints = constr,
-    pop_temper = 0.01) # %>%
-# group_by(chain) %>%
-# filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
-# ungroup()
+plans <- redist_smc(map, nsims = 3e4, runs = 2L, counties = county, constraints = constr) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
+    ungroup()
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()

--- a/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
+++ b/analyses/GA_cd_2010/03_sim_GA_cd_2010.R
@@ -7,12 +7,12 @@
 cli_process_start("Running simulations for {.pkg GA_cd_2010}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(20, vap_black, vap, 0.47) %>%
-    add_constr_grp_hinge(-20, vap_black, vap, 0.38) %>%
+    add_constr_grp_hinge(20, vap_black, vap, 0.45) %>%
+    add_constr_grp_hinge(-20, vap_black, vap, 0.37) %>%
     add_constr_grp_inv_hinge(12, vap_black, vap, 0.61)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 1e4, runs =2L, countries = county, constraints = constr,
+plans <- redist_smc(map, nsims = 1e4, runs =2L, counties = county, constraints = constr,
                     pop_temper = 0.04) #%>%
     #group_by(chain) %>%
     #filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -22,8 +22,8 @@ Data for Georgia comes from the ALARM Project's [2010 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 40,000 districting plans for Georgia across two independent runs of the SMC algorithm. We then thin the sample to exactly 5,000 plans.
+We sample 60,000 districting plans for Georgia across two independent runs of the SMC algorithm. We then thin the sample to exactly 5,000 plans.
 
-We use municipality lines in Fulton county and Gwinnett county because their populations are greater than the target district population. 
+To balance county and municipality splits, we create pseudocounties for use in the county constraint. Within Fulton, Gwinnett, Cobb, and DeKalb County, which are the counties with populations larger than 80% of the target district population, each muncipality is its own pseudocounty. Each other county is its own pseudocounty. 
 
 We impose a hinge constraint on the Black Voting Age Population so that it encourages districts with BVAP above 43%, but districts with BVAP of 34% or less are not penalized as much. In addition, we impose an inverse hinge constraint on the Black Voting Age Population to penalize districts with BVAP above 61% to prevent packing. 

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Georgia Congressional Districts
+
+## Redistricting requirements
+In Georgia, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Georgia.
+No special techniques were needed to produce the sample.

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -6,11 +6,10 @@ In Georgia, under the 2011-12 Guidelines for the House Legislative and Congressi
 1. be contiguous
 2. have equal populations
 3. be geographically compact
-4. comply with VRA section 2
-5. preserve political subdivisions and communities of interest 
-6. avoid pairing incumbents 
+4. preserve political subdivisions and communities of interest 
+5. avoid pairing incumbents 
 
-https://www.dropbox.com/s/i8zqyivtr8iozs8/GeorgiaSenateCommitteeGuidelines2011-12.pdf
+[Guidelines for the House Legislative and Congressional Reapportionment Committee](https://www.dropbox.com/s/i8zqyivtr8iozs8/GeorgiaSenateCommitteeGuidelines2011-12.pdf)
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -24,6 +24,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 60,000 districting plans for Georgia across two independent runs of the SMC algorithm. We then thin the sample to exactly 5,000 plans.
 
-To balance county and municipality splits, we create pseudocounties for use in the county constraint. Within Fulton, Gwinnett, Cobb, and DeKalb County, which are the counties with populations larger than 80% of the target district population, each muncipality is its own pseudocounty. Each other county is its own pseudocounty. 
-
 We impose a hinge constraint on the Black Voting Age Population so that it encourages districts with BVAP above 43%, but districts with BVAP of 34% or less are not penalized as much. In addition, we impose an inverse hinge constraint on the Black Voting Age Population to penalize districts with BVAP above 61% to prevent packing. 

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -4,16 +4,19 @@
 In Georgia, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact
+4. comply with VRA section 2
+5. preserve political subdivisions and communities of interest 
+6. avoid pairing incumbents 
 
+https://www.dropbox.com/s/i8zqyivtr8iozs8/GeorgiaSenateCommitteeGuidelines2011-12.pdf
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
-Data for Georgia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Georgia comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.

--- a/analyses/GA_cd_2010/doc_GA_cd_2010.md
+++ b/analyses/GA_cd_2010/doc_GA_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Georgia Congressional Districts
 
 ## Redistricting requirements
-In Georgia, districts must:
+In Georgia, under the 2011-12 Guidelines for the House Legislative and Congressional Reapportionment Committee: districts must:
 
 1. be contiguous
 2. have equal populations
@@ -22,5 +22,8 @@ Data for Georgia comes from the ALARM Project's [2010 Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Georgia.
-No special techniques were needed to produce the sample.
+We sample 40,000 districting plans for Georgia across two independent runs of the SMC algorithm. We then thin the sample to exactly 5,000 plans.
+
+We use municipality lines in Fulton county and Gwinnett county because their populations are greater than the target district population. 
+
+We impose a hinge constraint on the Black Voting Age Population so that it encourages districts with BVAP above 43%, but districts with BVAP of 34% or less are not penalized as much. In addition, we impose an inverse hinge constraint on the Black Voting Age Population to penalize districts with BVAP above 61% to prevent packing. 

--- a/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
@@ -1,0 +1,94 @@
+###############################################################################
+# Download and prepare data for `NJ_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NJ_cd_2010}")
+
+path_data <- download_redistricting_file("NJ", "data-raw/NJ", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/nj_2010_congress_2011-12-23_2021-12-31.zip"
+path_enacted <- "data-raw/NJ/NJ_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NJ_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NJ/NJ_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NJ_2010/shp_vtd.rds"
+perim_path <- "data-out/NJ_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NJ} shapefile")
+    # read in redistricting data
+    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$NJ)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NJ", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("NJ"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("NJ", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("NJ"), vtd),
+                  cd_2000 = as.integer(cd))
+    nj_shp <- left_join(nj_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    nj_shp <- nj_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(nj_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nj_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nj_shp$adj <- redist.adjacency(nj_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    nj_shp <- nj_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nj_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nj_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NJ} shapefile")
+}

--- a/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NJ_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(nj_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = nj_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NJ_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NJ_2010/NJ_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `NJ_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NJ_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NJ_2010/NJ_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NJ_2010/NJ_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
+++ b/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 New Jersey Congressional Districts
+
+## Redistricting requirements
+In New Jersey, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for New Jersey comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for New Jersey.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Georgia, under the 2011-12 Guidelines for the House Legislative and Congressional Reapportionment Committee: districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve political subdivisions and communities of interest 
5. avoid pairing incumbents 

[Guidelines for the House Legislative and Congressional Reapportionment Committee](https://www.dropbox.com/s/i8zqyivtr8iozs8/GeorgiaSenateCommitteeGuidelines2011-12.pdf)

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Georgia comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 60,000 districting plans for Georgia across two independent runs of the SMC algorithm. We then thin the sample to exactly 5,000 plans.

We impose a hinge constraint on the Black Voting Age Population so that it encourages districts with BVAP above 43%, but districts with BVAP of 34% or less are not penalized as much. In addition, we impose an inverse hinge constraint on the Black Voting Age Population to penalize districts with BVAP above 61% to prevent packing. 

## Validation

![validation_20230120_1500](https://user-images.githubusercontent.com/66656384/213795157-f5f68259-69ac-45b3-b362-80da14d5ac13.png)

```
SMC: 60,000 sampled plans of 14 districts on 2,961 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.63 to 0.82

R-hat values for summary statistics:
    pop_overlap       total_vap        plan_dev       comp_edge     comp_polsby       pop_white 
       1.028433        1.000465        1.006164        1.019184        1.029123        1.014853 
      pop_black        pop_hisp        pop_aian       pop_asian        pop_nhpi       pop_other 
       1.013547        1.009564        1.014845        1.037753        1.023118        1.012276 
        pop_two       vap_white       vap_black        vap_hisp        vap_aian       vap_asian 
       1.011599        1.016606        1.005109        1.009466        1.039454        1.035719 
       vap_nhpi       vap_other         vap_two  pre_16_rep_tru  pre_16_dem_cli  pre_20_rep_tru 
       1.026342        1.005372        1.020378        1.000464        1.022859        1.000818 
 pre_20_dem_bid  uss_16_rep_isa  uss_16_dem_bar  uss_20_rep_per  uss_20_dem_oss  gov_18_rep_kem 
       1.044291        1.000610        1.022661        1.000719        1.039536        1.004839 
 gov_18_dem_abr  atg_18_rep_car  atg_18_dem_bai  sos_18_rep_raf  sos_18_dem_bar sos_r18_rep_raf 
       1.032997        1.003077        1.036278        1.002255        1.008487        1.010313 
sos_r18_dem_bar          adv_16          adv_18          adv_20          arv_16          arv_18 
       1.009812        1.023670        1.016225        1.041143        1.001537        1.001523 
         arv_20   county_splits     muni_splits             ndv             nrv         ndshare 
       1.000756        1.007849        1.002823        1.024799        1.001580        1.000859 
          e_dvs          pr_dem           e_dem           pbias            egap 
       1.001079        1.000464        1.032985        1.039055        1.029460 

Sampling diagnostics for SMC run 1 of 2 (30,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    23,635 (78.8%)     20.2%        0.25 19,004 (100%)      9 
Split 2    23,300 (77.7%)     23.2%        0.55 17,328 ( 91%)      7 
Split 3    22,972 (76.6%)     29.1%        0.63 17,302 ( 91%)      5 
Split 4    22,490 (75.0%)     26.3%        0.67 17,098 ( 90%)      5 
Split 5    21,777 (72.6%)     23.7%        0.71 16,991 ( 90%)      5 
Split 6    20,955 (69.8%)     26.0%        0.75 16,841 ( 89%)      4 
Split 7    20,352 (67.8%)     30.0%        0.79 16,686 ( 88%)      3 
Split 8    19,843 (66.1%)     27.2%        0.80 16,569 ( 87%)      3 
Split 9    19,332 (64.4%)     32.0%        0.82 16,565 ( 87%)      2 
Split 10   18,722 (62.4%)     28.6%        0.83 16,417 ( 87%)      2 
Split 11   19,393 (64.6%)     18.1%        0.84 15,792 ( 83%)      3 
Split 12   19,673 (65.6%)     19.4%        0.82 15,465 ( 82%)      2 
Split 13   15,689 (52.3%)      7.3%        0.86 13,678 ( 72%)      2 
Resample    3,553 (11.8%)       NA%        1.70 12,654 ( 67%)     NA 

Sampling diagnostics for SMC run 2 of 2 (30,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    23,614 (78.7%)     20.3%        0.25 18,977 (100%)      9 
Split 2    23,294 (77.6%)     27.0%        0.55 17,338 ( 91%)      6 
Split 3    23,044 (76.8%)     29.2%        0.63 17,220 ( 91%)      5 
Split 4    22,387 (74.6%)     31.8%        0.67 17,139 ( 90%)      4 
Split 5    21,876 (72.9%)     36.2%        0.71 16,993 ( 90%)      3 
Split 6    21,236 (70.8%)     42.8%        0.75 16,944 ( 89%)      2 
Split 7    20,290 (67.6%)     38.7%        0.78 16,834 ( 89%)      2 
Split 8    19,804 (66.0%)     27.0%        0.81 16,466 ( 87%)      3 
Split 9    19,485 (64.9%)     24.1%        0.81 16,483 ( 87%)      3 
Split 10   19,044 (63.5%)     21.2%        0.81 16,356 ( 86%)      3 
Split 11   19,615 (65.4%)     13.7%        0.83 16,123 ( 85%)      4 
Split 12   19,621 (65.4%)     13.9%        0.81 15,561 ( 82%)      3 
Split 13   14,736 (49.1%)      6.8%        0.78 13,983 ( 74%)      2 
Resample    3,323 (11.1%)       NA%        1.70 11,805 ( 62%)     NA 
```
![image](https://user-images.githubusercontent.com/66656384/213795281-326d11a9-3628-4438-836c-e4436f62db48.png)

```
   bvap_rank       dem
       <dbl>     <dbl>
 1         1 0        
 2         2 0.0000833
 3         3 0.0693   
 4         4 0.426    
 5         5 0.625    
 6         6 0.551    
 7         7 0.128    
 8         8 0.0620   
 9         9 0.0282   
10        10 0.0828   
11        11 0.247    
12        12 0.947    
13        13 1.00     
14        14 1        
```

```
  n_black_perf     n
1            2   778
2            3 40877
3            4 17330
4            5  1005
5            6    10
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
@christopherkenny
