### PR TITLE
2010 New Jersey Congressional Districts

### DIFF
--- a/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("NJ", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("NJ"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     nj_shp <- left_join(nj_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -58,17 +58,20 @@ if (!file.exists(here(shp_path))) {
     nj_shp <- nj_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(nj_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
+
+    # fix labeling
+    nj_shp$state <- "NJ"
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = nj_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/01_prep_NJ_cd_2010.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Download and prepare data for `NJ_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NJ_cd_2010}")
+
+path_data <- download_redistricting_file("NJ", "data-raw/NJ", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/nj_2010_congress_2011-12-23_2021-12-31.zip"
+path_enacted <- "data-raw/NJ/NJ_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "NJ_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/NJ/NJ_enacted/NJCD_2011_PLAN_SHAPE_FILE.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NJ_2010/shp_vtd.rds"
+perim_path <- "data-out/NJ_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NJ} shapefile")
+    # read in redistricting data
+    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$NJ)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NJ", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("NJ"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("NJ", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("NJ"), vtd),
+                  cd_2000 = as.integer(cd))
+    nj_shp <- left_join(nj_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    nj_shp <- nj_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(nj_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nj_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nj_shp$adj <- redist.adjacency(nj_shp)
+
+    nj_shp <- nj_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nj_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nj_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NJ} shapefile")
+}

--- a/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(nj_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = 0.5*get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NJ_2010"

--- a/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/02_setup_NJ_cd_2010.R
@@ -1,0 +1,20 @@
+###############################################################################
+# Set up redistricting simulation for `NJ_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2010}")
+
+map <- redist_map(nj_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = nj_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NJ_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NJ_2010/NJ_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
@@ -6,27 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NJ_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 2.5e3, runs = 2L, counties = pseudo_county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 5e3, runs = 2L, counties = pseudo_county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NJ_2010/NJ_cd_2010_plans.rds"), compress = "xz")
@@ -41,11 +29,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/NJ_2010/NJ_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
@@ -18,7 +18,7 @@ cli_process_start("Running simulations for {.pkg NJ_cd_2010}")
 #  if that's the problem.
 #  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
+plans <- redist_smc(map, nsims = 2.5e3, runs = 2L, counties = pseudo_county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 plans <- match_numbers(plans, "cd_2010")

--- a/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
+++ b/analyses/NJ_cd_2010/03_sim_NJ_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `NJ_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NJ_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NJ_2010/NJ_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NJ_2010/NJ_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
+++ b/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
@@ -16,5 +16,4 @@ Data for New Jersey comes from the ALARM Project's [2010 Redistricting Data File
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for New Jersey.
-No special techniques were needed to produce the sample.
+We sample 10,000 districting plans for New Jersey across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Bergen, Burlington, Camden, Essex, Hudson, Mercer, Middlesex, Monmouth, Morris, Ocean, Passaic, and Union County, which are the counties larger than 50% of the target district population. WithinBergen, Burlington, Camden, Essex, Hudson, Mercer, Middlesex, Monmouth, Morris, Ocean, Passaic, and Union County, which are the counties larger than 50% of the target district population, each municipality is its own pseudocounty as well.

--- a/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
+++ b/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
@@ -3,11 +3,12 @@
 ## Redistricting requirements
 In New Jersey, districts must:
 
-1. have equal populations
-2. comply with section 2 of the voting rights act
+1. be contiguous
+2. have equal populations
 
-### Algorithmic Constraints
+### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%.
+We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
 
 ## Data Sources
 Data for New Jersey comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
+++ b/analyses/NJ_cd_2010/doc_NJ_cd_2010.md
@@ -1,0 +1,20 @@
+# 2010 New Jersey Congressional Districts
+
+## Redistricting requirements
+In New Jersey, districts must:
+
+1. have equal populations
+2. comply with section 2 of the voting rights act
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for New Jersey comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for New Jersey.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In New Jersey, districts must:

1. be contiguous
2. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.

## Data Sources
Data for New Jersey comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for New Jersey across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Bergen, Burlington, Camden, Essex, Hudson, Mercer, Middlesex, Monmouth, Morris, Ocean, Passaic, and Union County, which are the counties larger than 50% of the target district population. WithinBergen, Burlington, Camden, Essex, Hudson, Mercer, Middlesex, Monmouth, Morris, Ocean, Passaic, and Union County, which are the counties larger than 50% of the target district population, each municipality is its own pseudocounty as well.

## Validation

![validation_20230120_2125](https://user-images.githubusercontent.com/66656384/213884853-dbf57245-53b1-4caf-ad2a-6365f133dbda.png)

```
SMC: 10,000 sampled plans of 12 districts on 6,344 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.69 to 0.89

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
      1.028225       1.008622       1.018606       1.001469       1.045092       1.039168 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other 
      1.040636       1.001220       1.044586       1.019275       1.016296       1.008444 
       pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.030445       1.022881       1.031330       1.001028       1.035543       1.016141 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid 
      1.003926       1.005651       1.025073       1.020200       1.035463       1.023895 
pre_20_rep_tru uss_18_dem_men uss_18_rep_hug uss_20_dem_boo uss_20_rep_meh         adv_16 
      1.040345       1.022220       1.012714       1.022041       1.031613       1.020200 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
      1.022220       1.023329       1.035463       1.012714       1.044714       1.010899 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
      1.001378       1.022002       1.031914       1.026862       1.027341       1.007064 
         e_dem          pbias           egap 
      1.019315       1.019660       1.022577 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,907 (98.1%)     11.7%        0.28 3,251 (103%)     15 
Split 2     4,824 (96.5%)     17.6%        0.40 3,103 ( 98%)      9 
Split 3     4,737 (94.7%)     27.3%        0.49 3,092 ( 98%)      5 
Split 4     4,701 (94.0%)     35.1%        0.51 3,088 ( 98%)      3 
Split 5     4,650 (93.0%)     38.4%        0.54 3,088 ( 98%)      2 
Split 6     4,613 (92.3%)     34.8%        0.56 3,058 ( 97%)      2 
Split 7     4,519 (90.4%)     31.9%        0.59 3,055 ( 97%)      2 
Split 8     4,466 (89.3%)     22.4%        0.60 2,985 ( 94%)      3 
Split 9     4,503 (90.1%)     20.1%        0.59 2,900 ( 92%)      3 
Split 10    4,511 (90.2%)     16.7%        0.59 2,779 ( 88%)      3 
Split 11    4,510 (90.2%)      8.2%        0.58 2,444 ( 77%)      2 
Resample    2,916 (58.3%)       NA%        0.59 3,771 (119%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,903 (98.1%)     14.1%        0.29 3,166 (100%)     12 
Split 2     4,817 (96.3%)     19.5%        0.41 3,140 ( 99%)      8 
Split 3     4,743 (94.9%)     27.4%        0.48 3,096 ( 98%)      5 
Split 4     4,652 (93.0%)     35.4%        0.53 3,099 ( 98%)      3 
Split 5     4,621 (92.4%)     31.5%        0.55 3,091 ( 98%)      3 
Split 6     4,589 (91.8%)     23.0%        0.57 3,057 ( 97%)      4 
Split 7     4,541 (90.8%)     25.7%        0.57 3,016 ( 95%)      3 
Split 8     4,546 (90.9%)     17.7%        0.58 2,978 ( 94%)      4 
Split 9     4,523 (90.5%)     19.5%        0.58 2,923 ( 92%)      3 
Split 10    4,593 (91.9%)     18.8%        0.56 2,851 ( 90%)      2 
Split 11    4,568 (91.4%)      6.9%        0.55 2,455 ( 78%)      2 
Resample    3,399 (68.0%)       NA%        0.57 3,788 (120%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@CoryMcCartan
@christopherkenny
