### PR TITLE
2010 Massachusetts Congressional Districts

### DIFF
--- a/analyses/MA_cd_2010/02_setup_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/02_setup_MA_cd_2010.R
@@ -7,11 +7,6 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg MA_cd_2010}")
 map <- redist_map(ma_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ma_shp$adj)
 
-# Create pseudo counties
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MA_2010"
 

--- a/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
@@ -7,8 +7,10 @@
 cli_process_start("Running simulations for {.pkg MA_cd_2010}")
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 3500, runs = 2L, counties = county_muni) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+plans <- redist_smc(map, nsims = 3500, runs = 2L, counties = county_muni) %>%
+    match_numbers("cd_2010") %>% group_by(chain) %>%
+    # thin samples
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>%
     ungroup()
 
 plans <- match_numbers(plans, "cd_2010")

--- a/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
+++ b/analyses/MA_cd_2010/03_sim_MA_cd_2010.R
@@ -7,7 +7,9 @@
 cli_process_start("Running simulations for {.pkg MA_cd_2010}")
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = pseudo_county)
+plans <- redist_smc(map, nsims = 3500, runs = 2L, counties = county_muni) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 
 plans <- match_numbers(plans, "cd_2010")
 

--- a/analyses/MA_cd_2010/doc_MA_cd_2010.md
+++ b/analyses/MA_cd_2010/doc_MA_cd_2010.md
@@ -22,4 +22,5 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 7,500 districting plans for Massachusetts over two runs.
+We then thinned the number of samples to 5,000.
 No special techniques were needed to produce the sample.

--- a/analyses/MA_cd_2010/doc_MA_cd_2010.md
+++ b/analyses/MA_cd_2010/doc_MA_cd_2010.md
@@ -21,5 +21,5 @@ Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data F
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Massachusetts over two runs.
+We sample 7,500 districting plans for Massachusetts over two runs.
 No special techniques were needed to produce the sample.

--- a/analyses/MA_cd_2010/doc_MA_cd_2010.md
+++ b/analyses/MA_cd_2010/doc_MA_cd_2010.md
@@ -21,6 +21,6 @@ Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data F
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 7,500 districting plans for Massachusetts over two runs.
+We sample 7,000 districting plans for Massachusetts over two runs.
 We then thinned the number of samples to 5,000.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2010 Massachusetts Congressional Districts

## Redistricting requirements
In Massachusetts, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.05%. 
We use a pseudo-county constraint to help preserve county and municipality boundaries.
These counties are Dukes, Middlesex, and Worcester--these three counties have populations larger than 60% of the target population for districts. To preserve municipality splits, each municipality is its own pseudocounty.

## Data Sources
Data for Massachusetts comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 7,500 districting plans for Massachusetts over two runs.
No special techniques were needed to produce the sample.


## Validation

![MA 2010 Analysis](https://user-images.githubusercontent.com/57640740/214466001-53b9b4e5-447e-44f0-89a5-0cc772eac08b.png)

```
SMC: 7,000 sampled plans of 9 districts on 2,165 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.7 to 0.9

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
     1.0019569      1.0060361      1.0051570      1.0063435      1.0027901      1.0191425      1.0054869      1.0013889      1.0026305      1.0297700 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
     0.9999906      1.0281259      1.0158481      1.0078179      1.0083280      1.0020198      1.0040321      1.0148851      1.0048442      1.0278418 
       vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_18_dem_war uss_18_rep_die uss_20_dem_mar uss_20_rep_oco gov_18_rep_bak 
     1.0161448      1.0118460      1.0141748      1.0066600      1.0140936      1.0110774      1.0151628      1.0067000      1.0145590      1.0160401 
gov_18_dem_gon atg_18_dem_hea atg_18_rep_mcm         adv_16         adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0119384      1.0098197      1.0146609      1.0118460      1.0114351      1.0067367      1.0141748      1.0159360      1.0143757      1.0158210 
   muni_splits            ndv            nrv        ndshare          e_dvs          e_dem          pbias           egap 
     1.0161969      1.0108484      1.0151332      1.0130056      1.0130334      1.0008851      1.0249832      1.0025164 

Sampling diagnostics for SMC run 1 of 2 (3,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,295 (94.2%)     12.0%        0.49 2,200 ( 99%)      8 
Split 2     3,284 (93.8%)     18.1%        0.47 2,158 ( 98%)      5 
Split 3     3,268 (93.4%)     26.0%        0.49 2,145 ( 97%)      3 
Split 4     3,245 (92.7%)     31.9%        0.52 2,164 ( 98%)      2 
Split 5     3,194 (91.3%)     16.7%        0.55 2,172 ( 98%)      4 
Split 6     3,180 (90.8%)     14.7%        0.57 2,130 ( 96%)      4 
Split 7     3,094 (88.4%)     15.4%        0.61 2,037 ( 92%)      3 
Split 8     2,877 (82.2%)      7.6%        0.67 1,832 ( 83%)      2 
Resample      809 (23.1%)       NA%        0.69 2,353 (106%)     NA 

Sampling diagnostics for SMC run 2 of 2 (3,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,299 (94.3%)     12.8%        0.48 2,254 (102%)      8 
Split 2     3,258 (93.1%)     18.1%        0.50 2,177 ( 98%)      5 
Split 3     3,270 (93.4%)     20.3%        0.49 2,158 ( 98%)      4 
Split 4     3,218 (91.9%)     23.5%        0.53 2,190 ( 99%)      3 
Split 5     3,134 (89.5%)     29.1%        0.58 2,116 ( 96%)      2 
Split 6     3,153 (90.1%)     11.2%        0.59 2,079 ( 94%)      5 
Split 7     3,081 (88.0%)     15.7%        0.62 2,054 ( 93%)      3 
Split 8     3,174 (90.7%)      7.5%        0.57 1,820 ( 82%)      2 
Resample    2,275 (65.0%)       NA%        0.59 2,642 (119%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@CoryMcCartan
