### PR TITLE
2010 Ohio Congressional Districts

### DIFF
--- a/analyses/OH_cd_2010/01_prep_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/01_prep_OH_cd_2010.R
@@ -70,8 +70,6 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     oh_shp$adj <- redist.adjacency(oh_shp)
 
-    # TODO any custom adjacency graph edits here
-
     oh_shp <- oh_shp %>%
         fix_geo_assignment(muni)
 

--- a/analyses/OH_cd_2010/01_prep_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/01_prep_OH_cd_2010.R
@@ -1,0 +1,83 @@
+###############################################################################
+# Download and prepare data for `OH_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OH_cd_2010}")
+
+path_data <- download_redistricting_file("OH", "data-raw/OH", year = 2010)
+
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OH_2010/shp_vtd.rds"
+perim_path <- "data-out/OH_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong OH} shapefile")
+    # read in redistricting data
+    oh_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$OH)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    d_cd <- make_from_baf("OH", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("OH"), vtd),
+                  cd_2000 = as.integer(cd))
+
+    # add municipalities
+
+    geom_muni <- tigris::county_subdivisions(state="OH", year=2011)
+    oh_shp$muni <- geom_muni$NAME[geomander::geo_match(oh_shp, geom_muni, method="area")] %>%
+        na_if("County subdivisions not defined")
+
+    oh_shp <- left_join(oh_shp, d_cd, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf('OH', from = read_baf_cd113('OH'), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0('39', GEOID))
+    oh_shp <- oh_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = oh_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        oh_shp <- rmapshaper::ms_simplify(oh_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    oh_shp$adj <- redist.adjacency(oh_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    oh_shp <- oh_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(oh_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    oh_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong OH} shapefile")
+}

--- a/analyses/OH_cd_2010/02_setup_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/02_setup_OH_cd_2010.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `OH_cd_2020`
+# © ALARM Project, December 2021
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OH_cd_2020}")
+
+map <- redist_map(oh_shp, pop_tol = 0.005,
+                  existing_plan = cd_2010, adj = oh_shp$adj)
+
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OH_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OH_2010/OH_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
@@ -1,0 +1,56 @@
+###############################################################################
+# Simulate plans for `OH_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OH_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 6500, runs = 2L, counties = pseudo_county) %>%
+    pullback(map) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OH_2010/OH_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OH_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OH_2010/OH_cd_2010_stats.csv")
+
+cli_process_done()
+
++# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
@@ -6,17 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OH_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
 plans <- redist_smc(map, nsims = 6500, runs = 2L, counties = pseudo_county) %>%
     pullback(map) %>%
@@ -24,14 +13,10 @@ plans <- redist_smc(map, nsims = 6500, runs = 2L, counties = pseudo_county) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/OH_2010/OH_cd_2010_plans.rds"), compress = "xz")
@@ -47,10 +32,4 @@ save_summary_stats(plans, "data-out/OH_2010/OH_cd_2010_stats.csv")
 
 cli_process_done()
 
-+# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}
++# Extra validation plots for custom constraints

--- a/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
+++ b/analyses/OH_cd_2010/03_sim_OH_cd_2010.R
@@ -31,5 +31,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/OH_2010/OH_cd_2010_stats.csv")
 
 cli_process_done()
-
-+# Extra validation plots for custom constraints

--- a/analyses/OH_cd_2010/doc_OH_cd_2010.md
+++ b/analyses/OH_cd_2010/doc_OH_cd_2010.md
@@ -4,10 +4,9 @@
 In Ohio, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
+2. have equal populations
+3. be geographically compact
+4. preserve political subdivisions
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.05%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.

--- a/analyses/OH_cd_2010/doc_OH_cd_2010.md
+++ b/analyses/OH_cd_2010/doc_OH_cd_2010.md
@@ -1,0 +1,22 @@
+# 2010 Ohio Congressional Districts
+
+## Redistricting requirements
+In Ohio, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.05%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.
+
+## Data Sources
+Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 13,000 districting plans for Massachusetts over two runs. We then thinned the number of samples to 5,000. No special techniques were needed to produce the sample.

--- a/analyses/OH_cd_2010/doc_OH_cd_2010.md
+++ b/analyses/OH_cd_2010/doc_OH_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Ohio Congressional Districts
 
 ## Redistricting requirements
-In Ohio, districts must:
+In Ohio, districts must, Under HB 319 https://legiscan.com/OH/text/HB319/2011:
 
 1. be contiguous
 2. have equal populations
@@ -9,7 +9,7 @@ In Ohio, districts must:
 4. preserve political subdivisions
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.05%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.
 
 ## Data Sources
 Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -18,4 +18,5 @@ Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](htt
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 13,000 districting plans for Massachusetts over two runs. We then thinned the number of samples to 5,000. No special techniques were needed to produce the sample.
+We sample 13,000 districting plans for Ohio  over two runs. We then thinned the number of samples to 5,000. 
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Cuyahoga County, Franklin County, and Hamilton Counrt must be split due to their large population, although within the county, we avoid splitting any municipality.

--- a/analyses/OH_cd_2010/doc_OH_cd_2010.md
+++ b/analyses/OH_cd_2010/doc_OH_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Ohio Congressional Districts
 
 ## Redistricting requirements
-In Ohio, districts must, Under HB 319 https://legiscan.com/OH/text/HB319/2011:
+In Ohio, districts must, under [HB 319](https://legiscan.com/OH/text/HB319/2011):
 
 1. be contiguous
 2. have equal populations
@@ -9,7 +9,7 @@ In Ohio, districts must, Under HB 319 https://legiscan.com/OH/text/HB319/2011:
 4. preserve political subdivisions
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries.
 
 ## Data Sources
 Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).


### PR DESCRIPTION
# 2010 Ohio Congressional Districts

## Redistricting requirements
In Ohio, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve political subdivisions

### Algorithmic Constraints
We enforce a maximum population deviation of 0.05%. We use a pseudo-county constraint to help preserve county and municipality boundaries. See '02_setup_OH_cd_2010.R' file.

## Data Sources
Data for Ohio comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 13,000 districting plans for Massachusetts over two runs. We then thinned the number of samples to 5,000. No special techniques were needed to produce the sample.

## Validation
![OH Validated Analysis](https://user-images.githubusercontent.com/57640740/215931500-44114b9b-f1b1-45d1-9487-84ac85de9bc1.png)


```
SMC: 5,000 sampled plans of 16 districts on 11,029 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.65 to 0.87

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
      1.001379       1.008771       1.014835       1.000004       1.000919       1.003336       1.007803       1.012579       1.005398       1.010660 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
      1.017784       1.014322       1.014949       1.006788       1.006979       1.013255       1.005950       1.012366       1.011200       1.002364 
       vap_two pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_por uss_16_dem_str uss_18_rep_ren uss_18_dem_bro gov_18_rep_dew 
      1.016253       1.010566       1.026014       1.013723       1.028245       1.012145       1.022183       1.006936       1.029258       1.009850 
gov_18_dem_cor atg_18_rep_yos atg_18_dem_det sos_18_rep_lar sos_18_dem_cly         adv_16         adv_18         adv_20         arv_16         arv_18 
      1.028204       1.010713       1.027422       1.007567       1.026609       1.026538       1.027984       1.028245       1.006625       1.009878 
        arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
      1.013723       1.008425       1.002648       1.026133       1.004794       1.021536       1.019545       1.002001       1.007826       1.011973 
          egap 
      1.011142 

Sampling diagnostics for SMC run 1 of 2 (6,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     6,246 (96.1%)     18.0%        0.37 4,109 (100%)     17 
Split 2     6,182 (95.1%)     27.3%        0.42 4,066 ( 99%)     10 
Split 3     6,159 (94.7%)     38.7%        0.47 4,027 ( 98%)      6 
Split 4     6,120 (94.2%)     33.3%        0.51 4,075 ( 99%)      7 
Split 5     6,083 (93.6%)     29.9%        0.54 4,010 ( 98%)      7 
Split 6     6,023 (92.7%)     28.3%        0.56 3,994 ( 97%)      7 
Split 7     5,960 (91.7%)     22.8%        0.58 3,969 ( 97%)      8 
Split 8     5,900 (90.8%)     31.3%        0.61 3,937 ( 96%)      5 
Split 9     5,891 (90.6%)     21.6%        0.63 3,942 ( 96%)      7 
Split 10    5,833 (89.7%)     22.7%        0.64 3,911 ( 95%)      6 
Split 11    5,773 (88.8%)     28.5%        0.65 3,977 ( 97%)      4 
Split 12    5,673 (87.3%)     20.8%        0.68 3,859 ( 94%)      5 
Split 13    5,716 (87.9%)     17.1%        0.67 3,807 ( 93%)      5 
Split 14    5,450 (83.8%)     20.4%        0.71 3,656 ( 89%)      3 
Split 15    5,662 (87.1%)      9.1%        0.70 3,148 ( 77%)      2 
Resample    3,650 (56.1%)       NA%        0.73 4,648 (113%)     NA 

Sampling diagnostics for SMC run 2 of 2 (6,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     6,232 (95.9%)     21.6%        0.38 4,093 (100%)     14 
Split 2     6,177 (95.0%)     23.3%        0.42 3,985 ( 97%)     12 
Split 3     6,165 (94.9%)     35.8%        0.46 4,074 ( 99%)      7 
Split 4     6,110 (94.0%)     42.0%        0.51 4,063 ( 99%)      5 
Split 5     6,053 (93.1%)     39.5%        0.54 4,003 ( 97%)      5 
Split 6     6,019 (92.6%)     49.1%        0.56 4,002 ( 97%)      3 
Split 7     5,938 (91.3%)     39.3%        0.60 3,994 ( 97%)      4 
Split 8     5,850 (90.0%)     31.4%        0.64 3,950 ( 96%)      5 
Split 9     5,892 (90.6%)     39.9%        0.63 3,996 ( 97%)      3 
Split 10    5,797 (89.2%)     43.3%        0.65 3,974 ( 97%)      2 
Split 11    5,753 (88.5%)     40.2%        0.67 3,916 ( 95%)      2 
Split 12    5,748 (88.4%)     29.3%        0.67 3,868 ( 94%)      3 
Split 13    5,713 (87.9%)     12.6%        0.67 3,856 ( 94%)      7 
Split 14    5,492 (84.5%)     16.9%        0.69 3,666 ( 89%)      4 
Split 15    5,769 (88.8%)      7.3%        0.64 3,291 ( 80%)      3 
Resample    4,017 (61.8%)       NA%        0.69 4,746 (116%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
