### PR TITLE
2010 Michigan Congressional Districts

### DIFF
--- a/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
@@ -1,0 +1,88 @@
+###############################################################################
+# Download and prepare data for `MI_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MI_cd_2010}")
+
+path_data <- download_redistricting_file("MI", "data-raw/MI", year = 2010, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MI_2010/shp_vtd.rds"
+perim_path <- "data-out/MI_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MI} shapefile")
+    # read in redistricting data
+    mi_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$MI)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MI", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("MI"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("MI", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("MI"), vtd),
+                  cd_2000 = as.integer(cd))
+    mi_shp <- left_join(mi_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf('MI', from = read_baf_cd113('MI'), year = 2010) %>%
+        rename(GEOID = vtd) %>%
+        mutate(GEOID = paste0('26', GEOID))
+
+    mi_shp <- mi_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mi_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mi_shp <- rmapshaper::ms_simplify(mi_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mi_shp$adj <- redist.adjacency(mi_shp)
+
+    #Rename cd_2010 Column
+    mi_shp <- mi_shp %>%
+        select(-ends_with(".y")) %>%
+        rename(cd_2010 = cd_2010.x)
+
+    mi_shp <- mi_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(mi_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mi_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MI} shapefile")
+}

--- a/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
@@ -77,6 +77,28 @@ if (!file.exists(here(shp_path))) {
         mi_shp$cd_2010[i] <- Mode(mi_shp$cd_2010[mi_shp$adj[[i]] + 1])
     }
 
+    #Check for missing connections
+    if (FALSE) {
+        redist.plot.adj(mi_shp, mi_shp$adj, centroids = F)
+        x <- redist:::contiguity(mi_shp$adj, rep(1, length(mi_shp$adj)))
+        unique(mi_shp$county[x > 1])
+
+        idx <- which(x > 1 & str_detect(mi_shp$county, "055"))
+        bbox <- st_bbox(st_buffer(mi_shp$geometry[idx], 800))
+        lbls <- rep("", nrow(wa_shp))
+        adj_idxs <- c(idx, unlist(adj_nowater[idx]) + 1L)
+        # adj_idxs = c(adj_idxs, unlist(adj_nowater[adj_idxs]) + 1L)
+        lbls[adj_idxs] <- wa_shp$GEOID[adj_idxs]
+        ggplot(wa_shp) +
+            geom_sf(aes(fill = x > 1), size = 0.1) +
+            geom_sf(data = d_water, size = 0.0, fill = "#ffffff55", color = NA) +
+            coord_sf(xlim = bbox[c(1, 3)], ylim = bbox[c(2, 4)]) +
+            geom_sf_text(aes(label = lbls), size = 2.5) +
+            theme_void()
+
+        table(redist:::contiguity(mi_shp$adj, mi_shp$cd_2010))
+    }
+
     mi_shp <- mi_shp %>%
         fix_geo_assignment(muni)
 

--- a/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
@@ -33,6 +33,9 @@ if (!file.exists(here(shp_path))) {
         st_transform(EPSG$MI)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
+    mi_shp <- mi_shp %>%
+        filter(ALAND10 >= AWATER10 | pop > 0)
+
     # add municipalities
     d_muni <- make_from_baf("MI", "INCPLACE_CDP", "VTD", year = 2010)  %>%
         mutate(GEOID = paste0(censable::match_fips("MI"), vtd)) %>%

--- a/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
@@ -64,8 +64,6 @@ if (!file.exists(here(shp_path))) {
                                perim_path = here(perim_path)) %>%
         invisible()
 
-    # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         mi_shp <- rmapshaper::ms_simplify(mi_shp, keep = 0.05,
                                           keep_shapes = TRUE) %>%

--- a/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/01_prep_MI_cd_2010.R
@@ -99,6 +99,16 @@ if (!file.exists(here(shp_path))) {
         table(redist:::contiguity(mi_shp$adj, mi_shp$cd_2010))
     }
 
+    # Connect Charlevoix
+    idx_1 <- which(mi_shp$GEOID == "26029029017")
+    idx_2 <- which(mi_shp$GEOID == "26029029016")
+    mi_shp$adj <- add_edge(mi_shp$adj, idx_1, idx_2)
+
+    # Connect UP
+    idx_1 <- which(mi_shp$GEOID == "26047047022")
+    idx_2 <- which(mi_shp$GEOID == "26097097010")
+    mi_shp$adj <- add_edge(mi_shp$adj, idx_1, idx_2)
+
     mi_shp <- mi_shp %>%
         fix_geo_assignment(muni)
 

--- a/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
@@ -1,0 +1,24 @@
+###############################################################################
+# Set up redistricting simulation for `MI_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MI_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(mi_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = mi_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MI_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MI_2010/MI_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
@@ -7,6 +7,9 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg MI_cd_2010}")
 map <- redist_map(mi_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = mi_shp$adj)
 
+map <- map %>%
+    mutate(state = "MI")
+
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/02_setup_MI_cd_2010.R
@@ -4,8 +4,6 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg MI_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(mi_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = mi_shp$adj)
 
@@ -13,8 +11,6 @@ map <- redist_map(mi_shp, pop_tol = 0.005,
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MI_2010"

--- a/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
@@ -6,37 +6,21 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MI_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-
 constr <- redist_constr(map) %>%
     add_constr_grp_hinge(13, vap - vap_white, vap, 0.52) %>%
     add_constr_grp_hinge(-13, vap - vap_white, vap, 0.3) %>%
     add_constr_grp_inv_hinge(8, vap - vap_white, vap, 0.62)
 
-#  - Ask for help!
 set.seed(2010)
 plans <- redist_smc(map, nsims = 8000, runs = 4, counties = pseudo_county, constraints = constr) %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
     ungroup()
 
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/MI_2010/MI_cd_2010_plans.rds"), compress = "xz")
@@ -52,10 +36,3 @@ save_summary_stats(plans, "data-out/MI_2010/MI_cd_2010_stats.csv")
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
@@ -12,7 +12,7 @@ constr <- redist_constr(map) %>%
     add_constr_grp_inv_hinge(8, vap - vap_white, vap, 0.62)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 8000, runs = 4, counties = pseudo_county, constraints = constr) %>%
+plans <- redist_smc(map, nsims = 8000, runs = 4, ncores = 1, counties = pseudo_county, constraints = constr)%>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
     ungroup()

--- a/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
@@ -16,9 +16,19 @@ cli_process_start("Running simulations for {.pkg MI_cd_2010}")
 #  - Don't change the number of simulations unless you have a good reason
 #  - If the sampler freezes, try turning off the county split constraint to see
 #  if that's the problem.
+
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(13, vap - vap_white, vap, 0.52) %>%
+    add_constr_grp_hinge(-13, vap - vap_white, vap, 0.3) %>%
+    add_constr_grp_inv_hinge(8, vap - vap_white, vap, 0.62)
+
 #  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
+plans <- redist_smc(map, nsims = 8000, runs = 4, counties = pseudo_county, constraints = constr) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
+    ungroup()
+
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 plans <- match_numbers(plans, "cd_2010")

--- a/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
@@ -12,9 +12,9 @@ constr <- redist_constr(map) %>%
     add_constr_grp_inv_hinge(8, vap - vap_white, vap, 0.62)
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 8000, runs = 4, ncores = 1, counties = pseudo_county, constraints = constr)%>%
+plans <- redist_smc(map, nsims = 8000, runs = 2, ncores = 1, counties = pseudo_county, constraints = constr)%>%
     group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 1250) %>% # thin samples
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
 plans <- match_numbers(plans, "cd_2010")

--- a/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
+++ b/analyses/MI_cd_2010/03_sim_MI_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `MI_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MI_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MI_2010/MI_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MI_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MI_2010/MI_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -20,5 +20,5 @@ Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 8,000 districting plans for Michigan across four independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
+We sample 8,000 districting plans for Michigan across two independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Wayne County, Oakland County, and Macomb County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Michigan Congressional Districts
 
 ## Redistricting requirements
-in Michigan, according to (http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6), districts must:
+in Michigan, according to [Article IV, Section 6](http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6) of the state constitution, districts must:
 
 1. be contiguous
 2. have equal populations
@@ -11,7 +11,7 @@ in Michigan, according to (http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We applied a constraint to limit county and municipality splits (see '02_setup_MI_cd_2010.R' file).
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
 
 ## Data Sources
 Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Michigan Congressional Districts
 
 ## Redistricting requirements
-According to http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6, in Michigan, districts must:
+in Michigan, according to (http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6), districts must:
 
 1. be contiguous
 2. have equal populations
@@ -21,5 +21,4 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 8,000 districting plans for Michigan across four independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
-
 To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Wayne County, Oakland County, and Macomb County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -1,17 +1,17 @@
 # 2010 Michigan Congressional Districts
 
 ## Redistricting requirements
-In Michigan, districts must:
+According to http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6, in Michigan, districts must:
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. Cannot favor/disfavor incumbents
+5. cannot favor/disfavor incumbents
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see '02_setup_MI_cd_2010.R' file).
+We enforce a maximum population deviation of 0.5%. We applied a constraint to limit county and municipality splits (see '02_setup_MI_cd_2010.R' file).
 
 ## Data Sources
 Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -21,4 +21,5 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 8,000 districting plans for Michigan across four independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
-No special techniques were needed to produce the sample.
+
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Wayne County, Oakland County, and Macomb County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Michigan Congressional Districts
+
+## Redistricting requirements
+In Michigan, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Michigan.
+No special techniques were needed to produce the sample.

--- a/analyses/MI_cd_2010/doc_MI_cd_2010.md
+++ b/analyses/MI_cd_2010/doc_MI_cd_2010.md
@@ -4,13 +4,14 @@
 In Michigan, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. Cannot favor/disfavor incumbents
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see '02_setup_MI_cd_2010.R' file).
 
 ## Data Sources
 Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,5 +20,5 @@ Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Michigan.
+We sample 8,000 districting plans for Michigan across four independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2010 Michigan Congressional Districts

## Redistricting requirements
in Michigan, according to (http://www.legislature.mi.gov/(S(xxvumgge0jwzkeswmwt0bh4v))/mileg.aspx?page=GetObject&objectname=mcl-Article-IV-6), districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. cannot favor/disfavor incumbents


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We applied a constraint to limit county and municipality splits (see '02_setup_MI_cd_2010.R' file).

## Data Sources
Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 8,000 districting plans for Michigan across two independent runs of the SMC algorithm and then thinned our results to 5,000 simulations.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that Wayne County, Oakland County, and Macomb County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.



## Validation

![Validated Ana MI2010 fixed](https://user-images.githubusercontent.com/57640740/230293743-a4f7e0e2-5d2f-48dc-937b-00afb0074c62.png)


```
SMC: 5,000 sampled plans of 14 districts on 5,104 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.68 to 0.89

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian 
      1.024640       1.013404       1.005539       1.039100       1.015565       1.000029       1.001752       1.003249       1.006874 
     pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.003477       1.031900       1.001011       1.003258       1.009569       1.004801       1.002881       1.004928       1.004899 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_rep_tru pre_20_dem_bid uss_18_rep_jam uss_18_dem_sta 
      1.028900       1.008008       1.008620       1.005105       1.023123       1.001784       1.005069       1.007101       1.006148 
uss_20_rep_jam uss_20_dem_pet gov_18_rep_sch gov_18_dem_whi atg_18_rep_leo atg_18_dem_nes sos_18_rep_lan sos_18_dem_ben         adv_16 
      1.011219       1.004469       1.011308       1.008103       1.007810       1.007374       1.007873       1.006395       1.005105 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits    muni_splits            ndv            nrv 
      1.007813       1.006213       1.023123       1.008030       1.003342       1.000381       1.010967       1.006498       1.010175 
       ndshare          e_dvs          e_dem          pbias           egap 
      1.004891       1.004285       1.013067       1.003928       1.015758 

Sampling diagnostics for SMC run 1 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     6,751 (84.4%)     17.7%        0.47 5,109 (101%)     11 
Split 2     6,617 (82.7%)     24.3%        0.58 4,837 ( 96%)      7 
Split 3     6,491 (81.1%)     29.9%        0.62 4,771 ( 94%)      5 
Split 4     6,332 (79.1%)     27.8%        0.71 4,786 ( 95%)      5 
Split 5     6,093 (76.2%)     18.9%        0.76 4,639 ( 92%)      7 
Split 6     5,999 (75.0%)     20.1%        0.81 4,568 ( 90%)      6 
Split 7     5,885 (73.6%)     18.4%        0.80 4,614 ( 91%)      6 
Split 8     5,901 (73.8%)     24.1%        0.81 4,582 ( 91%)      4 
Split 9     5,835 (72.9%)     27.6%        0.79 4,603 ( 91%)      3 
Split 10    5,797 (72.5%)     31.3%        0.78 4,538 ( 90%)      2 
Split 11    5,856 (73.2%)     27.6%        0.77 4,454 ( 88%)      2 
Split 12    5,934 (74.2%)     21.9%        0.74 4,231 ( 84%)      2 
Split 13    5,009 (62.6%)      7.7%        0.76 3,805 ( 75%)      2 
Resample    2,401 (30.0%)       NA%        1.94 4,144 ( 82%)     NA 

Sampling diagnostics for SMC run 2 of 2 (8,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     6,767 (84.6%)     14.7%        0.47 5,117 (101%)     13 
Split 2     6,601 (82.5%)     21.5%        0.58 4,840 ( 96%)      8 
Split 3     6,327 (79.1%)     29.8%        0.64 4,792 ( 95%)      5 
Split 4     6,216 (77.7%)     32.9%        0.73 4,682 ( 93%)      4 
Split 5     6,054 (75.7%)     25.5%        0.78 4,666 ( 92%)      5 
Split 6     5,967 (74.6%)     35.5%        0.81 4,622 ( 91%)      3 
Split 7     6,001 (75.0%)     21.9%        0.81 4,546 ( 90%)      5 
Split 8     5,974 (74.7%)     29.9%        0.79 4,583 ( 91%)      3 
Split 9     5,706 (71.3%)     22.0%        0.79 4,578 ( 91%)      4 
Split 10    5,775 (72.2%)     24.3%        0.78 4,513 ( 89%)      3 
Split 11    5,897 (73.7%)     21.3%        0.72 4,411 ( 87%)      3 
Split 12    5,937 (74.2%)     22.3%        0.72 4,326 ( 86%)      2 
Split 13    5,225 (65.3%)      4.3%        0.72 3,990 ( 79%)      4 
Resample    2,884 (36.1%)       NA%        1.89 4,265 ( 84%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny