### PR TITLE
2010 Kansas Congressional Districts

### DIFF
--- a/analyses/KS_cd_2010/01_prep_KS_cd_2010.R
+++ b/analyses/KS_cd_2010/01_prep_KS_cd_2010.R
@@ -1,0 +1,82 @@
+###############################################################################
+# Download and prepare data for `KS_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg KS_cd_2010}")
+
+path_data <- download_redistricting_file("KS", "data-raw/KS", year = 2010)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/KS_2010/shp_vtd.rds"
+perim_path <- "data-out/KS_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong KS} shapefile")
+    # read in redistricting data
+    ks_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$KS)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("KS", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("KS"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("KS", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("KS"), vtd),
+            cd_2000 = as.integer(cd))
+    ks_shp <- left_join(ks_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf("KS", from = read_baf_cd113("KS"), year = 2010) %>%
+        rename(GEOID = vtd) %>%
+        mutate(
+            GEOID = paste0("20", GEOID),
+            cd_2010 = as.integer(cd_2010)
+        )
+    ks_shp <- ks_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ks_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ks_shp$adj <- redist.adjacency(ks_shp)
+
+    ks_shp <- ks_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ks_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ks_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong KS} shapefile")
+}

--- a/analyses/KS_cd_2010/02_setup_KS_cd_2010.R
+++ b/analyses/KS_cd_2010/02_setup_KS_cd_2010.R
@@ -8,16 +8,16 @@ map <- redist_map(ks_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ks_shp$adj)
 
 map <- map %>%
-    mutate(core_id = redist.identify.cores(map$adj, map$cd_2000, boundary = 2),
+    mutate(
+        core_id = redist.identify.cores(map$adj, map$cd_2000, boundary = 2),
         core_id_lump = forcats::fct_lump_n(as.character(core_id), max(cd_2000) + 1), # lump all non-core precincts in to "Other"
         core_id = if_else(as.logical(is_county_split(core_id_lump, county)), # break off counties which are split by core border
             str_c(county, "_", core_id),
-            as.character(core_id))) %>%
+            as.character(core_id)),
+        state = "KS"
+    ) %>%
     select(-core_id_lump)
 map_m <- merge_by(map, core_id)
-
-map <- map %>%
-    mutate(state = "KS")
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KS_2010"

--- a/analyses/KS_cd_2010/02_setup_KS_cd_2010.R
+++ b/analyses/KS_cd_2010/02_setup_KS_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `KS_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg KS_cd_2010}")
+
+map <- redist_map(ks_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ks_shp$adj)
+
+map <- map %>%
+    mutate(core_id = redist.identify.cores(map$adj, map$cd_2000, boundary = 2),
+        core_id_lump = forcats::fct_lump_n(as.character(core_id), max(cd_2000) + 1), # lump all non-core precincts in to "Other"
+        core_id = if_else(as.logical(is_county_split(core_id_lump, county)), # break off counties which are split by core border
+            str_c(county, "_", core_id),
+            as.character(core_id))) %>%
+    select(-core_id_lump)
+map_m <- merge_by(map, core_id)
+
+map <- map %>%
+    mutate(state = "KS")
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "KS_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/KS_2010/KS_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/KS_cd_2010/03_sim_KS_cd_2010.R
+++ b/analyses/KS_cd_2010/03_sim_KS_cd_2010.R
@@ -1,0 +1,31 @@
+###############################################################################
+# Simulate plans for `KS_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg KS_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map_m, nsims = 1250, ncores = 4,
+    runs = 4L, counties = county, seq_alpha = 0.7) %>%
+    pullback(map)
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/KS_2010/KS_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg KS_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/KS_2010/KS_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/KS_cd_2010/doc_KS_cd_2010.md
+++ b/analyses/KS_cd_2010/doc_KS_cd_2010.md
@@ -1,0 +1,26 @@
+# 2010 Kansas Congressional Districts
+
+## Redistricting requirements
+In Kansas, under the [Guidelines And Criteria For 2012 Kansas Congressional And Legislative Redistricting](http://www.kslegislature.org/li_2012/b2011_12/committees/misc/ctte_h_redist_1_20120109_01_other.pdf) districts must:
+
+1. be contiguous (5)
+1. have equal populations (2)
+1. be geographically compact (5)
+1. preserve county and municipality boundaries as much as possible (4c)
+1. preserve communities of interest (4a)
+1. preserve cores of existing districts (4b)
+1. be built primarily from counties and VTDs (1)
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.
+
+## Simulation Notes
+We sample 5,000 districting plans for Kansas across four independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Kansas, under the [Guidelines And Criteria For 2012 Kansas Congressional And Legislative Redistricting](http://www.kslegislature.org/li_2012/b2011_12/committees/misc/ctte_h_redist_1_20120109_01_other.pdf) districts must:

1. be contiguous (5)
1. have equal populations (2)
1. be geographically compact (5)
1. preserve county and municipality boundaries as much as possible (4c)
1. preserve communities of interest (4a)
1. preserve cores of existing districts (4b)
1. be built primarily from counties and VTDs (1)


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Kansas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.

## Simulation Notes
We sample 5,000 districting plans for Kansas across four independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation

![validation_20230204_1520](https://user-images.githubusercontent.com/28026893/216788172-57ee1748-93fd-432b-b026-343f13fbf2ba.png)

```
SMC: 5,000 sampled plans of 4 districts on 3,907 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.7
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.29 to 0.70

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
      1.013543       1.006512       1.000904       1.012780       1.021304       1.008013 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other 
      1.002621       1.000982       1.009344       1.010264       1.010760       1.008708 
       pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.012561       1.010236       1.007950       1.000311       1.009257       1.010967 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid 
      1.009118       1.014380       1.013490       1.009830       1.020055       1.010805 
pre_20_rep_tru uss_16_dem_wie uss_16_rep_mor uss_20_dem_bol uss_20_rep_mar gov_18_dem_kel 
      1.008497       1.004944       1.001842       1.011967       1.004842       1.013116 
gov_18_rep_kob atg_18_rep_sch atg_18_dem_swa sos_18_rep_sch sos_18_dem_mcc         adv_16 
      1.006942       1.001122       1.011482       1.005231       1.011130       1.008358 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
      1.013540       1.011396       1.007235       1.003480       1.005554       1.003842 
   muni_splits            ndv            nrv        ndshare          e_dvs          e_dem 
      1.009800       1.013994       1.004894       1.004910       1.004952       1.002131 
         pbias           egap 
      1.002125       1.003052 

Sampling diagnostics for SMC run 1 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,197 (95.7%)      4.6%        0.33   791 (100%)     12 
Split 2     1,068 (85.5%)      6.7%        0.39   785 ( 99%)      7 
Split 3     1,146 (91.7%)      3.3%        0.43   679 ( 86%)      4 
Resample    1,046 (83.6%)       NA%        0.42 1,047 (133%)     NA 

Sampling diagnostics for SMC run 2 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,198 (95.9%)      6.1%        0.33   787 (100%)      9 
Split 2     1,153 (92.3%)      7.7%        0.36   790 (100%)      6 
Split 3     1,130 (90.4%)      3.2%        0.43   656 ( 83%)      4 
Resample    1,016 (81.2%)       NA%        0.45 1,015 (128%)     NA 

Sampling diagnostics for SMC run 3 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,194 (95.5%)      5.4%        0.34   802 (101%)     10 
Split 2     1,077 (86.1%)      7.6%        0.41   776 ( 98%)      6 
Split 3       923 (73.8%)      3.3%        0.54   646 ( 82%)      4 
Resample      521 (41.7%)       NA%        0.54   936 (118%)     NA 

Sampling diagnostics for SMC run 4 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,194 (95.6%)      5.0%        0.34   785 ( 99%)     11 
Split 2     1,148 (91.9%)      6.6%        0.37   775 ( 98%)      7 
Split 3     1,053 (84.2%)      2.5%        0.49   685 ( 87%)      5 
Resample      806 (64.5%)       NA%        0.49   998 (126%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of
the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

## Additional Notes
- Uses 4 runs of 1250 to make diversity happier, given large cores.