### PR TITLE
2010 Texas Congressional Districts

### DIFF
--- a/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
@@ -49,9 +49,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("TX", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("TX"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     tx_shp <- left_join(tx_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -63,7 +63,7 @@ if (!file.exists(here(shp_path))) {
     tx_shp <- tx_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$District)[
             geo_match(tx_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     state <- "TX"
     path_cvap <- here(paste0("data-raw/", state, "/cvap.rds"))
@@ -74,7 +74,7 @@ if (!file.exists(here(shp_path))) {
         vtd_baf <- get_baf_10(state)$VTD
         cvap <- cvap %>%
             left_join(vtd_baf %>% rename(GEOID = BLOCKID),
-                      by = "GEOID")
+                by = "GEOID")
         cvap <- cvap %>%
             mutate(GEOID = paste0(COUNTYFP, "00", DISTRICT)) %>%
             select(GEOID, starts_with("cvap"))
@@ -94,14 +94,14 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = tx_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         tx_shp <- rmapshaper::ms_simplify(tx_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
@@ -98,7 +98,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         tx_shp <- rmapshaper::ms_simplify(tx_shp, keep = 0.05,
             keep_shapes = TRUE) %>%

--- a/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
@@ -1,0 +1,119 @@
+###############################################################################
+# Download and prepare data for `TX_cd_2010` analysis
+# © ALARM Project, December 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(sf)
+    library(tidyverse)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg TX_cd_2010}")
+
+path_data <- download_redistricting_file("TX", "data-raw/TX", year = 2010, overwrite = TRUE)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/tx_2010_congress_2012-02-28_2021-12-31.zip"
+path_enacted <- "data-raw/TX/TX_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "TX_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/TX/TX_enacted/PLANC235/PLANC235.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/TX_2010/shp_vtd.rds"
+perim_path <- "data-out/TX_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong TX} shapefile")
+    # read in redistricting data
+    tx_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$TX)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("TX", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("TX"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("TX", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("TX"), vtd),
+                  cd_2000 = as.integer(cd))
+    tx_shp <- left_join(tx_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    cd_shp <- cd_shp %>% st_transform(4269)
+    tx_shp <- tx_shp %>% st_transform(4269)
+
+    tx_shp <- tx_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District)[
+            geo_match(tx_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    state <- "TX"
+    path_cvap <- here(paste0("data-raw/", state, "/cvap.rds"))
+
+    if (!file.exists(path_cvap)) {
+        cvap <-
+            cvap::cvap_distribute_censable(state, year = 2010) %>% select(GEOID, starts_with("cvap"))
+        vtd_baf <- get_baf_10(state)$VTD
+        cvap <- cvap %>%
+            left_join(vtd_baf %>% rename(GEOID = BLOCKID),
+                      by = "GEOID")
+        cvap <- cvap %>%
+            mutate(GEOID = paste0(COUNTYFP, "00", DISTRICT)) %>%
+            select(GEOID, starts_with("cvap"))
+        cvap <- cvap %>%
+            group_by(GEOID) %>%
+            summarize(across(.fns = sum))
+        saveRDS(cvap, path_cvap, compress = "xz")
+    } else {
+        cvap <- read_rds(path_cvap)
+    }
+
+    cvap <- cvap %>% mutate(GEOID = paste0("48", GEOID))
+
+    tx_shp <- tx_shp %>%
+        left_join(cvap, by = "GEOID") %>%
+        st_as_sf()
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = tx_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        tx_shp <- rmapshaper::ms_simplify(tx_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    tx_shp$adj <- redist.adjacency(tx_shp)
+
+    tx_shp <- tx_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(tx_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    tx_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong TX} shapefile")
+}

--- a/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/01_prep_TX_cd_2010.R
@@ -19,7 +19,7 @@ suppressMessages({
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg TX_cd_2010}")
 
-path_data <- download_redistricting_file("TX", "data-raw/TX", year = 2010, overwrite = TRUE)
+path_data <- download_redistricting_file("TX", "data-raw/TX", year = 2010)
 
 # download the enacted plan.
 url <- "https://redistricting.lls.edu/wp-content/uploads/tx_2010_congress_2012-02-28_2021-12-31.zip"

--- a/analyses/TX_cd_2010/02_setup_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/02_setup_TX_cd_2010.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `TX_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg TX_cd_2010}")
+
+map <- redist_map(tx_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = tx_shp$adj)
+
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "TX_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/TX_2010/TX_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/TX_cd_2010/02_setup_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/02_setup_TX_cd_2010.R
@@ -9,7 +9,7 @@ map <- redist_map(tx_shp, pop_tol = 0.005,
 
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TX_2010"

--- a/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
@@ -21,7 +21,7 @@ cli_process_start("Running simulations for {.pkg TX_cd_2010}")
 # https://www.dshs.texas.gov/center-health-statistics/center-health-statistics-texas-county-numbers-public-health-regions#:~:text=The%20county%20FIPS%20(Federal%20Information,county%20FIPS%20code%20of%2048xxx.
 # county code * 2 - 1
 clust1 <- c("015", "039", "071", "157",
-            "167", "201", "291", "339", "473")
+    "167", "201", "291", "339", "473")
 
 m1 <- map %>% filter(county %in% clust1)
 attr(m1, "pop_bounds") <-  attr(map, "pop_bounds")
@@ -41,28 +41,32 @@ border_idxs <- which(m1$row_id %in% z$row_id)
 
 constraints <- redist_constr(m1) %>%
     #########################################################
-# HISPANIC
-add_constr_grp_hinge(
-    3,
-    cvap_hisp,
-    total_pop = cvap,
-    tgts_group = c(0.45)
-) %>%
+    # HISPANIC
+    add_constr_grp_hinge(
+        3,
+        cvap_hisp,
+        total_pop = cvap,
+        tgts_group = c(0.45)
+    ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_hisp,
-                         cvap,
-                         0.35) %>%
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_hisp,
-                             cvap,
-                             0.70) %>%
+        cvap_hisp,
+        cvap,
+        0.70) %>%
     #########################################################
-# BLACK
-add_constr_grp_hinge(
-    3,
-    cvap_black,
-    total_pop = cvap,
-    tgts_group = c(0.45)) %>%
+    # BLACK
+    add_constr_grp_hinge(
+        3,
+        cvap_black,
+        total_pop = cvap,
+        tgts_group = c(0.45)) %>%
+    add_constr_grp_hinge(-3,
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_custom(strength = 10, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     })
@@ -71,18 +75,23 @@ n_steps <- (sum(m1$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2010)
 houston_plans <- redist_smc(m1, counties = pseudo_county,
-                            nsims = nsims, n_steps = n_steps, runs = 2L,
-                            seq_alpha = sa_city,
-                            constraints = constraints, pop_temper = pop_temp + 0.02, verbose = TRUE)
+    nsims = nsims, n_steps = n_steps, runs = 2L,
+    seq_alpha = sa_city,
+    constraints = constraints, pop_temper = pop_temp + 0.01, verbose = TRUE)
 
 houston_plans <- houston_plans %>%
     mutate(hvap = group_frac(m1, cvap_hisp, cvap),
-           bvap = group_frac(m1, cvap_black, cvap),
-           dem16 = group_frac(m1, adv_16, arv_16 + adv_16),
-           dem18 = group_frac(m1, adv_18, arv_18 + adv_18),
-           dem20 = group_frac(m1, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m1, cvap_black, cvap),
+        dem16 = group_frac(m1, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m1, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m1, adv_20, arv_20 + adv_20),
+        comp_edge = distr_compactness(m1),
+        county_splits = county_splits(m1, county),
+        muni_splits = muni_splits(m1, muni))
 
 summary(houston_plans)
+
+write_rds(houston_plans, here("data-raw/TX/houston_plans.rds"), compress = "xz")
 
 #############################################################
 ## Cluster #2: Austin and San Antonio
@@ -90,7 +99,7 @@ summary(houston_plans)
 
 clust2 <- c("021", "055", "209", "453", "491")
 clust4 <- c("013", "019", "029", "091", "187",
-            "259", "325", "493")
+    "259", "325", "493")
 clust2 <- c(clust2, clust4)
 
 m2 <- map %>% filter(county %in% clust2)
@@ -112,47 +121,53 @@ border_idxs <- which(m2$row_id %in% z$row_id)
 
 constraints <- redist_constr(m2) %>%
     #########################################################
-# HISPANIC
-add_constr_grp_hinge(
-    3,
-    cvap_hisp,
-    total_pop = cvap,
-    tgts_group = c(0.45)
-) %>%
+    # HISPANIC
+    add_constr_grp_hinge(
+        3,
+        cvap_hisp,
+        total_pop = cvap,
+        tgts_group = c(0.45)
+    ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_hisp,
-                         cvap,
-                         0.35) %>%
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_hisp,
-                             cvap,
-                             0.70) %>%
+        cvap_hisp,
+        cvap,
+        0.70) %>%
     #########################################################
-add_constr_custom(strength = 10, function(plan, distr) {
-    ifelse(any(plan[border_idxs] == 0), 0, 1)
-})
+    add_constr_custom(strength = 10, function(plan, distr) {
+        ifelse(any(plan[border_idxs] == 0), 0, 1)
+    })
 
 n_steps <- (sum(m2$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2010)
 austin_plans <- redist_smc(m2, counties = pseudo_county,
-                           nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
-                           constraints = constraints, pop_temper = pop_temp)
+    nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
+    constraints = constraints, pop_temper = pop_temp)
 
 austin_plans <- austin_plans %>%
     mutate(hvap = group_frac(m2, cvap_hisp, cvap),
-           bvap = group_frac(m2, cvap_black, cvap),
-           dem16 = group_frac(m2, adv_16, arv_16 + adv_16),
-           dem18 = group_frac(m2, adv_18, arv_18 + adv_18),
-           dem20 = group_frac(m2, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m2, cvap_black, cvap),
+        dem16 = group_frac(m2, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m2, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m2, adv_20, arv_20 + adv_20),
+        comp_edge = distr_compactness(m2),
+        county_splits = county_splits(m2, county),
+        muni_splits = muni_splits(m2, muni))
 
 summary(austin_plans)
+
+write_rds(austin_plans, here("data-raw/TX/austin_plans.rds"), compress = "xz")
+
 #########################################################################
 ## Cluster #3: Dallas
 
 clust3 <- c("085", "113", "121", "139", "231",
-            "257", "397", "251", "367",
-            "439", "497")
+    "257", "397", "251", "367",
+    "439", "497")
 
 m3 <- map %>% filter(county %in% clust3)
 attr(m3, "pop_bounds") <-  attr(map, "pop_bounds")
@@ -173,27 +188,31 @@ border_idxs <- which(m3$row_id %in% z$row_id)
 
 constraints <- redist_constr(m3) %>%
     #########################################################
-# HISPANIC
-add_constr_grp_hinge(
-    3,
-    cvap_hisp,
-    total_pop = cvap,
-    tgts_group = c(0.45)
-) %>%
+    # HISPANIC
+    add_constr_grp_hinge(
+        3,
+        cvap_hisp,
+        total_pop = cvap,
+        tgts_group = c(0.45)
+    ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_hisp,
-                         cvap,
-                         0.35) %>%
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_hisp,
-                             cvap,
-                             0.70) %>%
-# BLACK
+        cvap_hisp,
+        cvap,
+        0.70) %>%
+    # BLACK
     add_constr_grp_hinge(
         3,
         cvap_black,
         total_pop = cvap,
         tgts_group = c(0.45)) %>%
+    add_constr_grp_hinge(-3,
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_custom(strength = 10, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     })
@@ -202,17 +221,22 @@ n_steps <- (sum(m3$pop)/attr(map, "pop_bounds")[2]) %>% floor()
 
 set.seed(2010)
 dallas_plans <- redist_smc(m3, counties = pseudo_county,
-                           nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
-                           constraints = constraints, pop_temper = pop_temp)
+    nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
+    constraints = constraints, pop_temper = pop_temp - 0.01)
 
 dallas_plans <- dallas_plans %>%
     mutate(hvap = group_frac(m3, cvap_hisp, cvap),
-           bvap = group_frac(m3, cvap_black, cvap),
-           dem16 = group_frac(m3, adv_16, arv_16 + adv_16),
-           dem18 = group_frac(m3, adv_18, arv_18 + adv_18),
-           dem20 = group_frac(m3, adv_20, arv_20 + adv_20))
+        bvap = group_frac(m3, cvap_black, cvap),
+        dem16 = group_frac(m3, adv_16, arv_16 + adv_16),
+        dem18 = group_frac(m3, adv_18, arv_18 + adv_18),
+        dem20 = group_frac(m3, adv_20, arv_20 + adv_20),
+        comp_edge = distr_compactness(m3),
+        county_splits = county_splits(m3, county),
+        muni_splits = muni_splits(m3, muni))
 
 summary(dallas_plans)
+
+write_rds(dallas_plans, here("data-raw/TX/dallas_plans.rds"), compress = "xz")
 
 #############################################################
 
@@ -223,11 +247,11 @@ austin_plans$dist_keep <- ifelse(austin_plans$district == 0, FALSE, TRUE)
 dallas_plans$dist_keep <- ifelse(dallas_plans$district == 0, FALSE, TRUE)
 
 tx_plan_list <- list(list(map = m1, plans = houston_plans),
-                     list(map = m2, plans = austin_plans),
-                     list(map = m3, plans = dallas_plans))
+    list(map = m2, plans = austin_plans),
+    list(map = m3, plans = dallas_plans))
 
 prep_mat <- prep_particles(map = map, map_plan_list = tx_plan_list,
-                           uid = row_id, dist_keep = dist_keep, nsims = nsims*2)
+    uid = row_id, dist_keep = dist_keep, nsims = nsims*2)
 
 ## Check contiguity
 if (FALSE) {
@@ -246,22 +270,22 @@ if (FALSE) {
 
 constraints <- redist_constr(map) %>%
     #########################################################
-# HISPANIC
-add_constr_grp_hinge(
-    4,
-    cvap_hisp,
-    total_pop = cvap,
-    tgts_group = c(0.45)
-) %>%
+    # HISPANIC
+    add_constr_grp_hinge(
+        4,
+        cvap_hisp,
+        total_pop = cvap,
+        tgts_group = c(0.45)
+    ) %>%
     add_constr_grp_hinge(-4,
-                         cvap_hisp,
-                         cvap,
-                         0.35) %>%
+        cvap_hisp,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(4,
-                             cvap_hisp,
-                             cvap,
-                             0.70) %>%
-# BLACK
+        cvap_hisp,
+        cvap,
+        0.70) %>%
+    # BLACK
     add_constr_grp_hinge(
         3,
         cvap_black,
@@ -269,20 +293,20 @@ add_constr_grp_hinge(
         tgts_group = c(0.45)
     ) %>%
     add_constr_grp_hinge(-3,
-                         cvap_black,
-                         cvap,
-                         0.35) %>%
+        cvap_black,
+        cvap,
+        0.35) %>%
     add_constr_grp_inv_hinge(3,
-                             cvap_black,
-                             cvap,
-                             0.70)
+        cvap_black,
+        cvap,
+        0.70)
 
 
 set.seed(2010)
 plans <- redist_smc(map, nsims = nsims*2, runs = 2L,
-                    counties = pseudo_county, verbose = TRUE,
-                    constraints = constraints, init_particles = prep_mat,
-                    pop_temper = pop_temp, seq_alpha = sa)
+    counties = pseudo_county, verbose = TRUE,
+    constraints = constraints, init_particles = prep_mat,
+    pop_temper = pop_temp - 0.01, seq_alpha = sa)
 plans <- match_numbers(plans, "cd_2010")
 
 plans <- plans %>% filter(draw != "cd_2010")
@@ -291,39 +315,57 @@ plans <- plans %>%
     mutate(district = as.numeric(district)) %>%
     add_reference(ref_plan = as.numeric(map$cd_2010))
 
-plans_5k <- plans %>%
-    group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
-    ungroup()
-
-# correct reference plan label
-plans_5k <- plans_5k %>%
-    mutate(draw = ifelse(draw == "cd_2010)", "cd_2010", paste0("", draw)))
+# thin sample
+# plans_5k <- plans %>%
+#     group_by(chain) %>%
+#     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+#     ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 # Output the redist_map object. Do not edit this path.
-write_rds(plans_5k, here("data-out/TX_2010/TX_cd_2010_plans.rds"), compress = "xz")
+write_rds(plans, here("data-out/TX_2010/TX_cd_2010_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg TX_cd_2010}")
 
-plans_5k <- add_summary_stats(plans_5k, map) %>%
+plans <- add_summary_stats(plans, map) %>%
     mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
 
-summary(plans_5k)
+# plans_5k <- add_summary_stats(plans_5k, map) %>%
+#     mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
+
+summary(plans)
 
 # cvap columns
 cvap_cols <- names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
 for (col in rev(cvap_cols)) {
-    plans_5k <- mutate(plans_5k, {{ col }} := tally_var(map, map[[col]]), .after = vap_two)
+    plans <- mutate(plans, {{ col }} := tally_var(map, map[[col]]), .after = vap_two)
 }
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans_5k, "data-out/TX_2010/TX_cd_2010_stats.csv")
+save_summary_stats(plans, "data-out/TX_2010/TX_cd_2010_stats.csv")
 
 cli_process_done()
 
-validate_analysis(plans_5k, map)
+validate_analysis(plans, map)
+
+# plans_5k <- add_summary_stats(plans_5k, map) %>%
+#     mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
+#
+# summary(plans_5k)
+#
+# # cvap columns
+# cvap_cols <- names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
+# for (col in rev(cvap_cols)) {
+#     plans_5k <- mutate(plans_5k, {{ col }} := tally_var(map, map[[col]]), .after = vap_two)
+# }
+#
+# # Output the summary statistics. Do not edit this path.
+# save_summary_stats(plans_5k, "data-out/TX_2010/TX_cd_2010_stats.csv")
+#
+# cli_process_done()
+#
+# validate_analysis(plans_5k, map)

--- a/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
@@ -24,7 +24,6 @@ clust1 <- c("015", "039", "071", "157",
     "167", "201", "291", "339", "473")
 
 m1 <- map %>% filter(county %in% clust1)
-attr(m1, "pop_bounds") <-  attr(map, "pop_bounds")
 m1 <- set_pop_tol(m1, cluster_pop_tol)
 
 ########################################################################
@@ -103,7 +102,6 @@ clust4 <- c("013", "019", "029", "091", "187",
 clust2 <- c(clust2, clust4)
 
 m2 <- map %>% filter(county %in% clust2)
-attr(m2, "pop_bounds") <-  attr(map, "pop_bounds")
 m2 <- set_pop_tol(m2, cluster_pop_tol)
 
 ########################################################################
@@ -170,7 +168,6 @@ clust3 <- c("085", "113", "121", "139", "231",
     "439", "497")
 
 m3 <- map %>% filter(county %in% clust3)
-attr(m3, "pop_bounds") <-  attr(map, "pop_bounds")
 m3 <- set_pop_tol(m3, cluster_pop_tol)
 
 ########################################################################
@@ -255,7 +252,7 @@ prep_mat <- prep_particles(map = map, map_plan_list = tx_plan_list,
 
 ## Check contiguity
 if (FALSE) {
-    test_vec <- sapply(1:ncol(prep_mat), function(i) {
+    test_vec <- sapply(seq_len(ncol(prep_mat)), function(i) {
         cat(i, "\n")
         z <- map %>%
             mutate(ex_dist = ifelse(prep_mat[, i] == 0, 1, 0))

--- a/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
@@ -1,0 +1,331 @@
+###############################################################################
+# Simulate plans for `TX_cd_2010`
+# © ALARM Project, December 2022
+###############################################################################
+
+cluster_pop_tol <- 0.0025
+# nsims <- 12500
+nsims <- 7000
+pop_temp <- 0.03
+sa_city <- 0.99
+sa <- 0.95
+
+# Unique ID for each row, will use later to reconnect pieces
+map$row_id <- 1:nrow(map)
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg TX_cd_2010}")
+
+########################################################################
+# Cluster #1: Greater Houston
+
+# https://www.dshs.texas.gov/center-health-statistics/center-health-statistics-texas-county-numbers-public-health-regions#:~:text=The%20county%20FIPS%20(Federal%20Information,county%20FIPS%20code%20of%2048xxx.
+# county code * 2 - 1
+clust1 <- c("015", "039", "071", "157",
+            "167", "201", "291", "339", "473")
+
+m1 <- map %>% filter(county %in% clust1)
+attr(m1, "pop_bounds") <-  attr(map, "pop_bounds")
+m1 <- set_pop_tol(m1, cluster_pop_tol)
+
+########################################################################
+# Setup for cluster constraint
+map <- map %>%
+    mutate(cluster_edge = ifelse(row_id %in% m1$row_id, 1, 0))
+
+z <- geomander::seam_geom(map$adj, map, admin = "cluster_edge", seam = c(0, 1))
+
+z <- z[z$cluster_edge == 1, ]
+
+border_idxs <- which(m1$row_id %in% z$row_id)
+########################################################################
+
+constraints <- redist_constr(m1) %>%
+    #########################################################
+# HISPANIC
+add_constr_grp_hinge(
+    3,
+    cvap_hisp,
+    total_pop = cvap,
+    tgts_group = c(0.45)
+) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_hisp,
+                         cvap,
+                         0.35) %>%
+    add_constr_grp_inv_hinge(3,
+                             cvap_hisp,
+                             cvap,
+                             0.70) %>%
+    #########################################################
+# BLACK
+add_constr_grp_hinge(
+    3,
+    cvap_black,
+    total_pop = cvap,
+    tgts_group = c(0.50)) %>%
+    add_constr_custom(strength = 10, function(plan, distr) {
+        ifelse(any(plan[border_idxs] == 0), 0, 1)
+    })
+
+n_steps <- (sum(m1$pop)/attr(map, "pop_bounds")[2]) %>% floor()
+
+set.seed(2010)
+houston_plans <- redist_smc(m1, counties = pseudo_county,
+                            nsims = nsims, n_steps = n_steps, runs = 2L,
+                            seq_alpha = sa_city,
+                            constraints = constraints, pop_temper = pop_temp + 0.02, verbose = TRUE)
+
+houston_plans <- houston_plans %>%
+    mutate(hvap = group_frac(m1, cvap_hisp, cvap),
+           bvap = group_frac(m1, cvap_black, cvap),
+           dem16 = group_frac(m1, adv_16, arv_16 + adv_16),
+           dem18 = group_frac(m1, adv_18, arv_18 + adv_18),
+           dem20 = group_frac(m1, adv_20, arv_20 + adv_20))
+
+summary(houston_plans)
+
+#############################################################
+## Cluster #2: Austin and San Antonio
+## MSAs border each other
+
+clust2 <- c("021", "055", "209", "453", "491")
+clust4 <- c("013", "019", "029", "091", "187",
+            "259", "325", "493")
+clust2 <- c(clust2, clust4)
+
+m2 <- map %>% filter(county %in% clust2)
+attr(m2, "pop_bounds") <-  attr(map, "pop_bounds")
+m2 <- set_pop_tol(m2, cluster_pop_tol)
+
+########################################################################
+
+# Setup for cluster constraint
+map <- map %>%
+    mutate(cluster_edge = ifelse(row_id %in% m2$row_id, 1, 0))
+
+z <- geomander::seam_geom(map$adj, map, admin = "cluster_edge", seam = c(0, 1))
+
+z <- z[z$cluster_edge == 1, ]
+
+border_idxs <- which(m2$row_id %in% z$row_id)
+########################################################################
+
+constraints <- redist_constr(m2) %>%
+    #########################################################
+# HISPANIC
+add_constr_grp_hinge(
+    3,
+    cvap_hisp,
+    total_pop = cvap,
+    tgts_group = c(0.45)
+) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_hisp,
+                         cvap,
+                         0.35) %>%
+    add_constr_grp_inv_hinge(3,
+                             cvap_hisp,
+                             cvap,
+                             0.70) %>%
+    #########################################################
+add_constr_custom(strength = 10, function(plan, distr) {
+    ifelse(any(plan[border_idxs] == 0), 0, 1)
+})
+
+n_steps <- (sum(m2$pop)/attr(map, "pop_bounds")[2]) %>% floor()
+
+set.seed(2010)
+austin_plans <- redist_smc(m2, counties = pseudo_county,
+                           nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
+                           constraints = constraints, pop_temper = pop_temp)
+
+austin_plans <- austin_plans %>%
+    mutate(hvap = group_frac(m2, cvap_hisp, cvap),
+           bvap = group_frac(m2, cvap_black, cvap),
+           dem16 = group_frac(m2, adv_16, arv_16 + adv_16),
+           dem18 = group_frac(m2, adv_18, arv_18 + adv_18),
+           dem20 = group_frac(m2, adv_20, arv_20 + adv_20))
+
+summary(austin_plans)
+#########################################################################
+## Cluster #3: Dallas
+
+clust3 <- c("085", "113", "121", "139", "231",
+            "257", "397", "251", "367",
+            "439", "497")
+
+m3 <- map %>% filter(county %in% clust3)
+attr(m3, "pop_bounds") <-  attr(map, "pop_bounds")
+m3 <- set_pop_tol(m3, cluster_pop_tol)
+
+########################################################################
+
+# Setup for cluster constraint
+map <- map %>%
+    mutate(cluster_edge = ifelse(row_id %in% m3$row_id, 1, 0))
+
+z <- geomander::seam_geom(map$adj, map, admin = "cluster_edge", seam = c(0, 1))
+
+z <- z[z$cluster_edge == 1, ]
+
+border_idxs <- which(m3$row_id %in% z$row_id)
+########################################################################
+
+constraints <- redist_constr(m3) %>%
+    #########################################################
+# HISPANIC
+add_constr_grp_hinge(
+    3,
+    cvap_hisp,
+    total_pop = cvap,
+    tgts_group = c(0.45)
+) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_hisp,
+                         cvap,
+                         0.35) %>%
+    add_constr_grp_inv_hinge(3,
+                             cvap_hisp,
+                             cvap,
+                             0.70) %>%
+# BLACK
+    add_constr_grp_hinge(
+        5,
+        cvap_black,
+        total_pop = cvap,
+        tgts_group = c(0.45)) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_black,
+                         cvap,
+                         0.35) %>%
+    add_constr_custom(strength = 10, function(plan, distr) {
+        ifelse(any(plan[border_idxs] == 0), 0, 1)
+    })
+
+n_steps <- (sum(m3$pop)/attr(map, "pop_bounds")[2]) %>% floor()
+
+set.seed(2010)
+dallas_plans <- redist_smc(m3, counties = pseudo_county,
+                           nsims = nsims, n_steps = n_steps, runs = 2L, seq_alpha = sa_city,
+                           constraints = constraints, pop_temper = pop_temp)
+
+dallas_plans <- dallas_plans %>%
+    mutate(hvap = group_frac(m3, cvap_hisp, cvap),
+           bvap = group_frac(m3, cvap_black, cvap),
+           dem16 = group_frac(m3, adv_16, arv_16 + adv_16),
+           dem18 = group_frac(m3, adv_18, arv_18 + adv_18),
+           dem20 = group_frac(m3, adv_20, arv_20 + adv_20))
+
+summary(dallas_plans)
+
+#############################################################
+
+## Combine Clusters
+
+houston_plans$dist_keep <- ifelse(houston_plans$district == 0, FALSE, TRUE)
+austin_plans$dist_keep <- ifelse(austin_plans$district == 0, FALSE, TRUE)
+dallas_plans$dist_keep <- ifelse(dallas_plans$district == 0, FALSE, TRUE)
+
+tx_plan_list <- list(list(map = m1, plans = houston_plans),
+                     list(map = m2, plans = austin_plans),
+                     list(map = m3, plans = dallas_plans))
+
+prep_mat <- prep_particles(map = map, map_plan_list = tx_plan_list,
+                           uid = row_id, dist_keep = dist_keep, nsims = nsims*2)
+
+## Check contiguity
+if (FALSE) {
+    test_vec <- sapply(1:ncol(prep_mat), function(i) {
+        cat(i, "\n")
+        z <- map %>%
+            mutate(ex_dist = ifelse(prep_mat[, i] == 0, 1, 0))
+
+        z <- geomander::check_contiguity(adj = z$adj, group = z$ex_dist)
+
+        length(unique(z$component[z$group == 1]))
+    })
+
+    table(test_vec)/nsims
+}
+
+constraints <- redist_constr(map) %>%
+    #########################################################
+# HISPANIC
+add_constr_grp_hinge(
+    3,
+    cvap_hisp,
+    total_pop = cvap,
+    tgts_group = c(0.45)
+) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_hisp,
+                         cvap,
+                         0.35) %>%
+    add_constr_grp_inv_hinge(3,
+                             cvap_hisp,
+                             cvap,
+                             0.70) %>%
+# BLACK
+    add_constr_grp_hinge(
+        3,
+        cvap_black,
+        total_pop = cvap,
+        tgts_group = c(0.45)
+    ) %>%
+    add_constr_grp_hinge(-3,
+                         cvap_black,
+                         cvap,
+                         0.35) %>%
+    add_constr_grp_inv_hinge(3,
+                             cvap_black,
+                             cvap,
+                             0.70)
+
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = nsims*2, runs = 2L,
+                    counties = pseudo_county, verbose = TRUE,
+                    constraints = constraints, init_particles = prep_mat,
+                    pop_temper = pop_temp, seq_alpha = sa)
+plans <- match_numbers(plans, "cd_2010")
+
+plans <- plans %>% filter(draw != "cd_2010")
+
+plans <- plans %>%
+    mutate(district = as.numeric(district)) %>%
+    add_reference(ref_plan = as.numeric(map$cd_2010))
+
+# plans <- plans %>%
+#     group_by(chain) %>%
+#     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+#     ungroup()
+
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/TX_2010/TX_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg TX_cd_2010}")
+
+plans <- add_summary_stats(plans, map) %>%
+    mutate(total_cvap = tally_var(map, cvap), .after = total_vap)
+
+summary(plans)
+
+# cvap columns
+cvap_cols <- names(map)[tidyselect::eval_select(starts_with("cvap_"), map)]
+for (col in rev(cvap_cols)) {
+    plans <- mutate(plans, {{ col }} := tally_var(map, map[[col]]), .after = vap_two)
+}
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/TX_2010/TX_cd_2010_stats.csv")
+
+cli_process_done()
+
+validate_analysis(plans, map)

--- a/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/03_sim_TX_cd_2010.R
@@ -4,8 +4,7 @@
 ###############################################################################
 
 cluster_pop_tol <- 0.0025
-# nsims <- 12500
-nsims <- 7000
+nsims <- 12500
 pop_temp <- 0.03
 sa_city <- 0.99
 sa <- 0.95
@@ -63,7 +62,7 @@ add_constr_grp_hinge(
     3,
     cvap_black,
     total_pop = cvap,
-    tgts_group = c(0.50)) %>%
+    tgts_group = c(0.45)) %>%
     add_constr_custom(strength = 10, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     })
@@ -191,14 +190,10 @@ add_constr_grp_hinge(
                              0.70) %>%
 # BLACK
     add_constr_grp_hinge(
-        5,
+        3,
         cvap_black,
         total_pop = cvap,
         tgts_group = c(0.45)) %>%
-    add_constr_grp_hinge(-3,
-                         cvap_black,
-                         cvap,
-                         0.35) %>%
     add_constr_custom(strength = 10, function(plan, distr) {
         ifelse(any(plan[border_idxs] == 0), 0, 1)
     })
@@ -253,16 +248,16 @@ constraints <- redist_constr(map) %>%
     #########################################################
 # HISPANIC
 add_constr_grp_hinge(
-    3,
+    4,
     cvap_hisp,
     total_pop = cvap,
     tgts_group = c(0.45)
 ) %>%
-    add_constr_grp_hinge(-3,
+    add_constr_grp_hinge(-4,
                          cvap_hisp,
                          cvap,
                          0.35) %>%
-    add_constr_grp_inv_hinge(3,
+    add_constr_grp_inv_hinge(4,
                              cvap_hisp,
                              cvap,
                              0.70) %>%

--- a/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
@@ -140,6 +140,10 @@ psum <- plans %>%
         )/total_cvap) > 0.5)
     )
 
+# correct reference plan label
+plans <- plans %>%
+    mutate(draw = ifelse(draw == "cd_2010)", "cd_2010", paste0("", draw)))
+
 plans %>%
     filter(draw == "cd_2010)") %>%
     mutate(bvap_pct = cvap_black/total_cvap) %>%

--- a/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
@@ -1,0 +1,193 @@
+###############################################################################
+# Simulate plans for `TX_cd_2020`
+# © ALARM Project, February 2022
+###############################################################################
+
+library(patchwork)
+
+i <- 25
+p1 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+i <- 35
+p2 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+i <- 45
+p3 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+i <- 11
+p4 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+i <- 8
+p5 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+i <- 5
+p6 <- redist.plot.plans(houston_plans, draws = i, m1) +
+    geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
+            fill = "black")
+
+ggsave("data-raw/houston.pdf", (p1 + p2 + p3)/(p4 + p5 + p6), width = 20, height = 20)
+
+p <- redist.plot.plans(austin_plans, draws = c(10, 20, 30, 50), m2)
+ggsave("data-raw/austin.pdf")
+
+p <- redist.plot.plans(dallas_plans, draws = c(10, 20, 30, 50), m3)
+ggsave("data-raw/dallas.pdf")
+
+library(ggplot2)
+library(patchwork)
+
+## local results
+d1 <- redist.plot.distr_qtys(
+    plans,
+    cvap_black/total_cvap,
+    color_thresh = NULL,
+    color = ifelse(
+        subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+        "#3D77BB",
+        "#B25D4C"
+    ),
+    size = 0.5,
+    alpha = 0.5
+) +
+    scale_y_continuous("Percent Black by CVAP") +
+    labs(title = "TX Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2020_prop = "black"))
+
+d2 <- redist.plot.distr_qtys(
+    plans,
+    cvap_hisp/total_cvap,
+    color_thresh = NULL,
+    color = ifelse(
+        subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+        "#3D77BB",
+        "#B25D4C"
+    ),
+    size = 0.5,
+    alpha = 0.5
+) +
+    scale_y_continuous("Percent Hispanic by CVAP") +
+    labs(title = "TX Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2020_prop = "black"))
+
+d3 <-
+    redist.plot.distr_qtys(
+        plans,
+        (cvap_hisp + cvap_black)/total_cvap,
+        color_thresh = NULL,
+        color = ifelse(
+            subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+            "#3D77BB",
+            "#B25D4C"
+        ),
+        size = 0.5,
+        alpha = 0.5
+    ) +
+    scale_y_continuous("HCVAP + BCVAP / CVAP") +
+    labs(title = "TX Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2020_prop = "black"))
+
+ggsave(
+    plot = d1/d2,
+    filename = "data-raw/cvap_plots.pdf",
+    height = 9,
+    width = 9
+)
+ggsave(
+    plot = d3,
+    filename = "data-raw/cvap_sum_plots.pdf",
+    height = 9,
+    width = 9
+)
+
+psum <- plans %>%
+    group_by(draw) %>%
+    summarise(
+        all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
+        dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
+                            (ndv > nrv)),
+        rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
+                            (nrv > ndv))
+    )
+
+p1 <- redist.plot.hist(psum, all_hcvap)
+p2 <- redist.plot.hist(psum, dem_hcvap)
+p3 <- redist.plot.hist(psum, rep_hcvap)
+
+ggsave("data-raw/hist.pdf", p1/p2/p3)
+
+psum <- plans %>%
+    group_by(draw) %>%
+    mutate(cvap_nonwhite = total_cvap - cvap_white) %>%
+    summarise(
+        all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
+        dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
+                            (ndv > nrv)),
+        rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
+                            (nrv > ndv)),
+        all_bcvap = sum((cvap_black/total_cvap) > 0.4),
+        dem_bcvap = sum((cvap_black/total_cvap) > 0.4 &
+                            (ndv > nrv)),
+        rep_bcvap = sum((cvap_black/total_cvap) > 0.4 &
+                            (nrv > ndv)),
+        mmd_all = sum(cvap_nonwhite/total_cvap > 0.5),
+        mmd_coalition = sum(((
+            cvap_hisp + cvap_black
+        )/total_cvap) > 0.5)
+    )
+
+plans %>%
+    filter(draw == "cd_2010)") %>%
+    mutate(bvap_pct = cvap_black/total_cvap) %>%
+    arrange(desc(bvap_pct)) %>%
+    select(district, bvap_pct)
+
+map <- map %>% mutate(bvap_pct = cvap_black/cvap)
+
+p <- redist.plot.map(
+    map,
+    plan = cd_2010,
+    zoom_to = map$cd_2010 %in% c(30, 9, 18),
+    boundaries = FALSE,
+    fill_label = bvap_pct
+)
+ggsave("bcvap_zoom.pdf", p)
+
+p <- plans %>%
+    group_by(draw) %>%
+    mutate(cvap_nonwhite = total_cvap - cvap_white,
+           cvap_nw_prop = cvap_nonwhite/total_cvap)  %>%
+    redist.plot.distr_qtys(
+        cvap_nw_prop,
+        color = ifelse(
+            subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+            "#3D77BB",
+            "#B25D4C"
+        ),
+        color_thresh = NULL
+    ) +
+    scale_y_continuous("Percent Non-White by CVAP") +
+    labs(title = "TX Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2020_prop = "black"))
+ggsave("data-raw/qty_nonwhite.pdf", p, width = 9)
+
+p0 <-
+    redist.plot.hist(psum, mmd_all) + labs(x = "Nonwhite CVAP > 0.5", y = NULL)
+p1 <-
+    redist.plot.hist(psum, mmd_coalition) + labs(x = "HCVAP + BCVAP > 0.5", y = NULL)
+p2 <-
+    redist.plot.hist(psum, all_hcvap) + labs(x = "HCVAP > 0.4", y = NULL)
+p3 <-
+    redist.plot.hist(psum, dem_hcvap) + labs(x = "HCVAP > 0.4 & Dem. > Rep.", y = NULL)
+p4 <-
+    redist.plot.hist(psum, rep_hcvap) + labs(x = "HCVAP > 0.4 & Dem. < Rep.", y = NULL)
+p5 <-
+    redist.plot.hist(psum, all_bcvap) + labs(x = "BCVAP > 0.4", y = NULL)
+p6 <-
+    redist.plot.hist(psum, dem_bcvap) + labs(x = "BCVAP > 0.4 & Dem. > Rep.", y = NULL)
+
+ggsave("data-raw/hist.pdf", p0/p1/p2/p3/p4/p5/p6, height = 9)

--- a/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
@@ -200,12 +200,12 @@ enacted_map <- tx_shp %>%
     group_by(cd_2010) %>%
     summarise(geom = st_union(geometry),
         cvap_black = sum(cvap_black),
-        pct_black = sum(cvap_black) / sum(cvap),
+        pct_black = sum(cvap_black)/sum(cvap),
         cvap_hisp = sum(cvap_hisp),
-        pct_hisp = sum(cvap_hisp) / sum(cvap),
+        pct_hisp = sum(cvap_hisp)/sum(cvap),
         cvap_white = sum(cvap_white),
         cvap_nonwhite = sum(cvap) - sum(cvap_white),
-        pct_nonwhite = cvap_nonwhite / sum(cvap),
+        pct_nonwhite = cvap_nonwhite/sum(cvap),
         total_cvap = sum(cvap))
 
 # districts of interest
@@ -213,9 +213,9 @@ districts <- c("2", "7", "9", "18", "22", "29", "14", "36", "8", "10")
 
 # map of precincts
 all_precincts <- tx_shp %>%
-    mutate(pct_black = cvap_black / cvap,
-           pct_hisp = cvap_hisp / cvap,
-           pct_nonwhite = (cvap - cvap_white) / cvap)
+    mutate(pct_black = cvap_black/cvap,
+        pct_hisp = cvap_hisp/cvap,
+        pct_nonwhite = (cvap - cvap_white)/cvap)
 
 precincts <- all_precincts %>%
     filter(cd_2010 %in% districts)
@@ -239,20 +239,20 @@ enacted_map %>% filter(cd_2010 %in% districts) %>%
 precincts %>% ggplot(aes(fill = pct_hisp)) +
     geom_sf() +
     scale_fill_viridis_c("% Hispanic (2010)",
-                         labels = scales::percent_format(accuracy = 1),
-                         direction = 1,
-                         limits = c(0, 1)) +
+        labels = scales::percent_format(accuracy = 1),
+        direction = 1,
+        limits = c(0, 1)) +
     geom_sf(data = enacted_map %>% filter(cd_2010 %in% districts),
-            alpha = 0, linewidth = 0.5, color = "#ff7f00") +
+        alpha = 0, linewidth = 0.5, color = "#ff7f00") +
     geom_sf_label(data = enacted_map %>% filter(cd_2010 %in% districts), aes(label = cd_2010),
-                  label.padding = unit(0.1, "lines"), size = 4, fill = "white") +
+        label.padding = unit(0.1, "lines"), size = 4, fill = "white") +
     theme_map() +
     theme(legend.position = "bottom")
 
 # boxplot of black cvap percentage
 p <- redist.plot.distr_qtys(
     plans,
-    cvap_black / total_cvap,
+    cvap_black/total_cvap,
     geom = "boxplot",
     size = 0.5,
     alpha = 0.5
@@ -263,7 +263,7 @@ p <- redist.plot.distr_qtys(
 # boxplot of hispanic cvap percentage
 p <- redist.plot.distr_qtys(
     plans,
-    cvap_hisp / total_cvap,
+    cvap_hisp/total_cvap,
     geom = "boxplot",
     size = 0.5,
     alpha = 0.5
@@ -274,7 +274,7 @@ p <- redist.plot.distr_qtys(
 # boxplot of hcvap + bcvap percentage
 p <- redist.plot.distr_qtys(
     plans,
-    (cvap_hisp + cvap_black) / total_cvap,
+    (cvap_hisp + cvap_black)/total_cvap,
     geom = "boxplot",
     size = 0.5,
     alpha = 0.5
@@ -304,26 +304,26 @@ plans %>%
 
 # simulated draws
 shp <- tx_shp
-shp$dist <- get_plans_matrix(plans)[,5000]
+shp$dist <- get_plans_matrix(plans)[, 5000]
 shp_dist <- shp %>%
     group_by(dist) %>%
     summarize(
         geom = st_union(geometry),
-        pct_hisp = sum(cvap_hisp) / sum(cvap),
-        pct_black = sum(cvap_black) / sum(cvap),
-        pct_nonwhite = (sum(cvap) - sum(cvap_white)) / sum(cvap) )
+        pct_hisp = sum(cvap_hisp)/sum(cvap),
+        pct_black = sum(cvap_black)/sum(cvap),
+        pct_nonwhite = (sum(cvap) - sum(cvap_white))/sum(cvap))
 shp_dist_filter <- shp_dist %>%
     filter(dist %in% districts)
 precincts %>% ggplot(aes(fill = pct_nonwhite)) +
     geom_sf() +
     scale_fill_viridis_c("% Black (2010)",
-                         labels = scales::percent_format(accuracy = 1),
-                         direction = 1,
-                         limits = c(0, 1)) +
+        labels = scales::percent_format(accuracy = 1),
+        direction = 1,
+        limits = c(0, 1)) +
     geom_sf(data = shp_dist_filter,
-            alpha = 0, linewidth = 0.5, color = "#ff7f00") +
+        alpha = 0, linewidth = 0.5, color = "#ff7f00") +
     geom_sf_label(data = shp_dist_filter, aes(label = dist),
-                  label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
+        label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
     theme_map() +
     theme(legend.position = "bottom")
 
@@ -331,13 +331,13 @@ precincts %>% ggplot(aes(fill = pct_nonwhite)) +
 all_precincts %>% ggplot(aes(fill = pct_nonwhite)) +
     geom_sf() +
     scale_fill_viridis_c("% Nonwhite (2010)",
-                         labels = scales::percent_format(accuracy = 1),
-                         direction = 1,
-                         limits = c(0, 1)) +
+        labels = scales::percent_format(accuracy = 1),
+        direction = 1,
+        limits = c(0, 1)) +
     geom_sf(data = enacted_map,
-            alpha = 0, linewidth = 0.5, color = "#ff7f00") +
+        alpha = 0, linewidth = 0.5, color = "#ff7f00") +
     geom_sf_label(data = enacted_map, aes(label = cd_2010),
-                  label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
+        label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
     theme_map() +
     theme(legend.position = "bottom")
 
@@ -345,12 +345,12 @@ all_precincts %>% ggplot(aes(fill = pct_nonwhite)) +
 all_precincts %>% ggplot(aes(fill = pct_black + pct_hisp)) +
     geom_sf() +
     scale_fill_viridis_c("% HCVAP + BCVAP (2010)",
-                         labels = scales::percent_format(accuracy = 1),
-                         direction = 1,
-                         limits = c(0, 1)) +
+        labels = scales::percent_format(accuracy = 1),
+        direction = 1,
+        limits = c(0, 1)) +
     geom_sf(data = enacted_map,
-            alpha = 0, linewidth = 0.5, color = "#ff7f00") +
+        alpha = 0, linewidth = 0.5, color = "#ff7f00") +
     geom_sf_label(data = enacted_map, aes(label = cd_2010),
-                  label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
+        label.padding = unit(0.1, "lines"), size = 1, fill = "white") +
     theme_map() +
     theme(legend.position = "bottom")

--- a/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
+++ b/analyses/TX_cd_2010/04_diagnostics_TX_cd_2010.R
@@ -8,27 +8,27 @@ library(patchwork)
 i <- 25
 p1 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 35
 p2 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 45
 p3 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 11
 p4 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 8
 p5 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 i <- 5
 p6 <- redist.plot.plans(houston_plans, draws = i, m1) +
     geom_sf(data = m1 %>% filter(get_plans_matrix(houston_plans)[, i] == 0),
-            fill = "black")
+        fill = "black")
 
 ggsave("data-raw/houston.pdf", (p1 + p2 + p3)/(p4 + p5 + p6), width = 20, height = 20)
 
@@ -109,9 +109,9 @@ psum <- plans %>%
     summarise(
         all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
         dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (nrv > ndv))
+            (nrv > ndv))
     )
 
 p1 <- redist.plot.hist(psum, all_hcvap)
@@ -126,14 +126,14 @@ psum <- plans %>%
     summarise(
         all_hcvap = sum((cvap_hisp/total_cvap) > 0.4),
         dem_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_hcvap = sum((cvap_hisp/total_cvap) > 0.4 &
-                            (nrv > ndv)),
+            (nrv > ndv)),
         all_bcvap = sum((cvap_black/total_cvap) > 0.4),
         dem_bcvap = sum((cvap_black/total_cvap) > 0.4 &
-                            (ndv > nrv)),
+            (ndv > nrv)),
         rep_bcvap = sum((cvap_black/total_cvap) > 0.4 &
-                            (nrv > ndv)),
+            (nrv > ndv)),
         mmd_all = sum(cvap_nonwhite/total_cvap > 0.5),
         mmd_coalition = sum(((
             cvap_hisp + cvap_black
@@ -141,8 +141,8 @@ psum <- plans %>%
     )
 
 # correct reference plan label
-plans <- plans %>%
-    mutate(draw = ifelse(draw == "cd_2010)", "cd_2010", paste0("", draw)))
+# plans <- plans %>%
+#     mutate(draw = ifelse(draw == "cd_2010)", "cd_2010", paste0("", draw)))
 
 plans %>%
     filter(draw == "cd_2010)") %>%
@@ -164,7 +164,7 @@ ggsave("bcvap_zoom.pdf", p)
 p <- plans %>%
     group_by(draw) %>%
     mutate(cvap_nonwhite = total_cvap - cvap_white,
-           cvap_nw_prop = cvap_nonwhite/total_cvap)  %>%
+        cvap_nw_prop = cvap_nonwhite/total_cvap)  %>%
     redist.plot.distr_qtys(
         cvap_nw_prop,
         color = ifelse(
@@ -195,3 +195,25 @@ p6 <-
     redist.plot.hist(psum, dem_bcvap) + labs(x = "BCVAP > 0.4 & Dem. > Rep.", y = NULL)
 
 ggsave("data-raw/hist.pdf", p0/p1/p2/p3/p4/p5/p6, height = 9)
+
+library(ggthemes)
+enacted <- plans %>% filter(draw == "cd_2010)")
+enacted_map <- tx_shp %>%
+    group_by(cd_2010) %>%
+    summarise(geom = st_union(geometry),
+        cvap_black = sum(cvap_black),
+        cvap_hisp = sum(cvap_hisp),
+        total_cvap = sum(cvap))
+enacted_map %>% filter(cd_2010 %in% c("15", "20", "21", "27", "28", "34", "35")) %>%
+    mutate(prop_black = cvap_black/total_cvap,
+        prop_hisp = cvap_hisp/total_cvap) %>%
+    ggplot(aes(fill = prop_hisp)) +
+    geom_sf() +
+    scale_fill_viridis_c("% Hispanic (2010)",
+        labels = scales::percent_format(accuracy = 1),
+        direction = 1,
+        limits = c(0, 1)) +
+    geom_sf_label(aes(label = cd_2010),
+        label.padding = unit(0.1, "lines"), size = 4, fill = "white") +
+    theme_map() +
+    theme(legend.position = "bottom")

--- a/analyses/TX_cd_2010/doc_TX_cd_2010.md
+++ b/analyses/TX_cd_2010/doc_TX_cd_2010.md
@@ -16,7 +16,7 @@ We estimate CVAP populations with the `cvap` R package.
 We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
 
 ## Simulation Notes
-We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm. We use a pseudo-county constraint to limit the county and municipality splits. Due to the size and complexity of Texas, we split the simulations into multiple steps. 
+We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. We use a pseudo-county constraint to limit the county and municipality splits. Due to the size and complexity of Texas, we split the simulations into multiple steps. 
 
 ### 1. Clustering procedure
 First, we run simulations in three major metropolitan areas: Greater Houston, a combination of Greater San Antonio and Austin, and Dallas-Fort Worth. We use collections of counties that define the Metropolitan Statistical Areas.
@@ -38,4 +38,4 @@ These simulations run the SMC algorithm within each cluster with a 0.25% populat
 In each cluster, we apply hinge Gibbs constraints of strength 3 to encourage the formation of Hispanic CVAP opportunity districts. In Houston and Dallas, we also apply a hinge Gibbs constraint of strength 3 to encourage the formation of Black CVAP opportunity districts. These districts nudge the formation of opportunity districts are above 35%, and penalize districts with minority populations above 70%.
 
 ### 2. Combination procedure
-Then, these partial map simulations are combined to run statewide simulations. We again apply Gibbs hinge constraints to encourage the formation of minority opportunity districts, with strength 4 to further encourage Hispanic CVAP opportunity districts.
+Then, these partial map simulations are combined to run statewide simulations. We again apply Gibbs hinge constraints to encourage the formation of minority opportunity districts, with strength 3 to further encourage Hispanic CVAP opportunity districts.

--- a/analyses/TX_cd_2010/doc_TX_cd_2010.md
+++ b/analyses/TX_cd_2010/doc_TX_cd_2010.md
@@ -1,23 +1,41 @@
 # 2010 Texas Congressional Districts
 
 ## Redistricting requirements
-In Texas, districts must:
-
-1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+In Texas, districts must meet US constitutional requirements, but there are
+[no state-specific statutes](https://redistricting.capitol.texas.gov/pdf/Guide_to_2011_Redistricting.pdf).
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We estimate CVAP populations with the `cvap` R package.
+We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Texas.
-No special techniques were needed to produce the sample.
+We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm. We use a pseudo-county constraint to limit the county and municipality splits. Due to the size and complexity of Texas, we split the simulations into multiple steps. 
+
+### 1. Clustering procedure
+First, we run simulations in three major metropolitan areas: Greater Houston, a combination of Greater San Antonio and Austin, and Dallas-Fort Worth. We use collections of counties that define the Metropolitan Statistical Areas.
+The counties in each cluster are those in each Census MSA:
+
+- Houston–The Woodlands–Sugar Land: Austin, Brazoria, Chambers, Fort Bend,
+Galveston, Harris, Liberty, Montgomery, Waller.
+
+- Austin–Round Rock-Georgetown: Bastrop, Caldwell, Hays, Travis, Williamson.
+
+- San Antonio–New Braunfels: Atascosa, Bandera, Bexar, Comal, Guadalupe,
+Kendall, Medina, Wilson.
+
+- Dallas–Fort Worth–Arlington: Collin, Dallas, Denton, Ellis, Hunt,
+Kaufman, Rockwall, Johnson, Parker, Tarrant, Wise.
+
+These simulations run the SMC algorithm within each cluster with a 0.25% population tolerance. Because each cluster will have leftover population, we apply an additional constraint that incentivizes leaving any unassigned areas on the edge of these clusters to avoid discontiguities.
+
+In each cluster, we apply hinge Gibbs constraints of strength 3 to encourage the formation of Hispanic CVAP opportunity districts. In Houston and Dallas, we also apply a hinge Gibbs constraint of strength 3 to encourage the formation of Black CVAP opportunity districts. These districts nudge the formation of opportunity districts are above 35%, and penalize districts with minority populations above 70%.
+
+### 2. Combination procedure
+Then, these partial map simulations are combined to run statewide simulations. We again apply Gibbs hinge constraints to encourage the formation of minority opportunity districts, with strength 4 to further encourage Hispanic CVAP opportunity districts.

--- a/analyses/TX_cd_2010/doc_TX_cd_2010.md
+++ b/analyses/TX_cd_2010/doc_TX_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Texas Congressional Districts
+
+## Redistricting requirements
+In Texas, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Texas.
+No special techniques were needed to produce the sample.

--- a/analyses/TX_cd_2010/doc_TX_cd_2010.md
+++ b/analyses/TX_cd_2010/doc_TX_cd_2010.md
@@ -9,11 +9,10 @@ In Texas, districts must meet US constitutional requirements, but there are
 We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
-Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). We estimate CVAP populations with the `cvap` R package.
 
 ## Pre-processing Notes
-We estimate CVAP populations with the `cvap` R package.
-We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
+We pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.
 
 ## Simulation Notes
 We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. We use a pseudo-county constraint to limit the county and municipality splits. Due to the size and complexity of Texas, we split the simulations into multiple steps. 


### PR DESCRIPTION
## Redistricting requirements
In Texas, districts must meet US constitutional requirements, but there are
[no state-specific statutes](https://redistricting.capitol.texas.gov/pdf/Guide_to_2011_Redistricting.pdf).


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Texas comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
We estimate CVAP populations with the `cvap` R package.
We also pre-process the map to split it into clusters for simulation, which has a slight effect on the types of district plans that will be sampled.

## Simulation Notes
We sample 50,000 districting plans for Texas across two independent runs of the SMC algorithm, and then thin the sample to down to 5,000 plans. We use a pseudo-county constraint to limit the county and municipality splits. Due to the size and complexity of Texas, we split the simulations into multiple steps. 

### 1. Clustering procedure
First, we run simulations in three major metropolitan areas: Greater Houston, a combination of Greater San Antonio and Austin, and Dallas-Fort Worth. We use collections of counties that define the Metropolitan Statistical Areas.
The counties in each cluster are those in each Census MSA:

- Houston–The Woodlands–Sugar Land: Austin, Brazoria, Chambers, Fort Bend,
Galveston, Harris, Liberty, Montgomery, Waller.

- Austin–Round Rock-Georgetown: Bastrop, Caldwell, Hays, Travis, Williamson.

- San Antonio–New Braunfels: Atascosa, Bandera, Bexar, Comal, Guadalupe,
Kendall, Medina, Wilson.

- Dallas–Fort Worth–Arlington: Collin, Dallas, Denton, Ellis, Hunt,
Kaufman, Rockwall, Johnson, Parker, Tarrant, Wise.

These simulations run the SMC algorithm within each cluster with a 0.25% population tolerance. Because each cluster will have leftover population, we apply an additional constraint that incentivizes leaving any unassigned areas on the edge of these clusters to avoid discontiguities.

In each cluster, we apply hinge Gibbs constraints of strength 3 to encourage the formation of Hispanic CVAP opportunity districts. In Houston and Dallas, we also apply a hinge Gibbs constraint of strength 3 to encourage the formation of Black CVAP opportunity districts. These districts nudge the formation of opportunity districts are above 35%, and penalize districts with minority populations above 70%.

### 2. Combination procedure
Then, these partial map simulations are combined to run statewide simulations. We again apply Gibbs hinge constraints to encourage the formation of minority opportunity districts, with strength 3 to further encourage Hispanic CVAP opportunity districts.

## Validation

![image](https://user-images.githubusercontent.com/55368740/217384415-1240107f-5b92-46cc-9009-3beec87d487c.png)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/55368740/217384768-4fa214d8-26b9-4d79-9db1-762433954029.png">


```
SMC: 50,000 sampled plans of 36 districts on 8,324 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.95
`est_label_mult`=1 • `pop_temper`=0.015

Plan diversity 80% range: 0.76 to 0.89

R-hat values for summary statistics:
   pop_overlap      total_vap     total_cvap       plan_dev      comp_edge    comp_polsby 
      1.019713       1.000765       1.001368       1.063390       1.021500       1.025287 
     pop_white      pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi 
      1.034317       1.076107       1.030654       1.006023       1.009740       1.008619 
     pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian 
      1.033250       1.026214       1.041864       1.074831       1.056603       1.001449 
     vap_asian       vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli 
      1.021050       1.009738       1.024545       1.003553       1.006802       1.057141 
pre_20_rep_tru pre_20_dem_bid uss_18_rep_cru uss_18_dem_oro uss_20_rep_cor uss_20_dem_heg 
      1.020598       1.014786       1.023798       1.007303       1.020234       1.020215 
gov_18_rep_abb gov_18_dem_val atg_18_rep_pax atg_18_dem_nel         adv_16         adv_18 
      1.023213       1.014576       1.019327       1.015313       1.057141       1.013074 
        adv_20         arv_16         arv_18         arv_20  county_splits    muni_splits 
      1.018537       1.006802       1.022502       1.020548       1.052084       1.010568 
           ndv            nrv        ndshare          e_dvs          e_dem          pbias 
      1.020112       1.018530       1.050662       1.050483       1.039622       1.038730 
          egap 
      1.108590 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    18,016 (72.1%)     20.3%        0.63 15,737 (100%)      7 
Split 2    16,643 (66.6%)     25.3%        0.73 14,481 ( 92%)      5 
Split 3    14,456 (57.8%)     27.7%        0.73 14,152 ( 90%)      4 
Split 4    12,521 (50.1%)     15.3%        0.73 13,752 ( 87%)      7 
Split 5    10,636 (42.5%)     23.0%        0.75 13,305 ( 84%)      4 
Split 6    10,459 (41.8%)     20.8%        0.76 12,830 ( 81%)      4 
Split 7    10,614 (42.5%)     18.7%        0.75 12,586 ( 80%)      4 
Split 8     9,657 (38.6%)     20.4%        0.76 12,346 ( 78%)      3 
Split 9     8,687 (34.7%)     22.0%        0.76 12,070 ( 76%)      2 
Split 10    8,578 (34.3%)     17.9%        0.74 11,263 ( 71%)      2 
Split 11    8,295 (33.2%)     13.9%        0.79 10,628 ( 67%)      3 
Split 12    7,703 (30.8%)      5.2%        0.73 10,793 ( 68%)      3 
Split 13    4,932 (19.7%)      1.4%        0.80  8,379 ( 53%)      4 
Resample    4,441 (17.8%)       NA%        1.40  9,729 ( 62%)     NA 

Sampling diagnostics for SMC run 2 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    18,009 (72.0%)      8.9%        0.63 15,693 ( 99%)     16 
Split 2    16,198 (64.8%)     14.3%        0.72 14,524 ( 92%)      9 
Split 3    14,872 (59.5%)     22.9%        0.73 14,118 ( 89%)      5 
Split 4    13,042 (52.2%)     17.7%        0.74 13,861 ( 88%)      6 
Split 5    11,721 (46.9%)     19.1%        0.73 13,404 ( 85%)      5 
Split 6    10,776 (43.1%)     20.8%        0.75 12,988 ( 82%)      4 
Split 7     9,521 (38.1%)     18.9%        0.76 12,602 ( 80%)      4 
Split 8     9,907 (39.6%)     20.0%        0.75 12,351 ( 78%)      3 
Split 9     8,963 (35.9%)     16.8%        0.74 12,078 ( 76%)      3 
Split 10    7,927 (31.7%)     18.9%        0.77 11,332 ( 72%)      2 
Split 11   10,217 (40.9%)     11.4%        0.74 10,329 ( 65%)      4 
Split 12    8,081 (32.3%)      5.2%        0.72 10,647 ( 67%)      3 
Split 13    3,756 (15.0%)      2.5%        0.75  8,201 ( 52%)      2 
Resample    3,274 (13.1%)       NA%        1.45  8,960 ( 57%)     NA 

• Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low plan diversity or
bottlenecks as well, address those issues first.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny
@tylersimko
