### PR TITLE
tract change + use `ssd` for project-wide consistency

### DIFF
--- a/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
@@ -6,7 +6,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg RI_cd_2010}")
 
 map <- redist_map(ri_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ri_shp$adj)
-map$sd_2010 <- ri_shp$sd_2010
+map$ssd_2010 <- ri_shp$ssd_2010
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "RI_2010"

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -9,7 +9,7 @@ cli_process_start("Running simulations for {.pkg RI_cd_2010}")
 set.seed(2010)
 
 # Minimize the number of state senate district splits
-plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = sd_2010)
+plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = ssd_2010)
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()


### PR DESCRIPTION
Hi @mzhao80, just gave a quick look over it. I think the issue came from using blocks, whereas it should be a tract-level analysis since there are no vtds. I made the necessary changes and also updated `sd` -> `ssd` so it's consistent with variable names that we've used in the broader ALARM Project naming schemes.

Feel free to merge or just pull out the pieces that are helpful to you.
