### PR TITLE
2010 Rhode Island Congressional Districts

### DIFF
--- a/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
@@ -17,7 +17,7 @@ suppressMessages({
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg RI_cd_2010}")
 
-path_data <- download_redistricting_file("RI", "data-raw/RI", type = 'block', year = 2010)
+path_data <- download_redistricting_file("RI", "data-raw/RI", type = "block", year = 2010)
 
 # download the enacted plan.
 url <- "https://redistricting.lls.edu/wp-content/uploads/ri_2010_congress_2012-02-08_2021-12-31.zip"
@@ -60,7 +60,7 @@ if (!file.exists(here(shp_path))) {
         transmute(
             GEOID = BLOCKID,
             cd_2000 = as.integer(DISTRICT)
-            )
+        )
 
     ri_shp <- left_join(ri_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
@@ -79,8 +79,8 @@ if (!file.exists(here(shp_path))) {
             across(where(is.numeric), sum)
         ) %>%
         left_join(y = tinytiger::tt_tracts("RI", year = 2010) %>%
-                      select(GEOID = GEOID10),
-                  by = c("GEOID")) %>%
+            select(GEOID = GEOID10),
+        by = c("GEOID")) %>%
         st_as_sf() %>%
         st_transform(EPSG$RI)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
@@ -90,7 +90,7 @@ if (!file.exists(here(shp_path))) {
         transmute(
             GEOID = str_sub(BLOCKID, 1, 11),
             cd_2010 = as.integer(cd_2010)
-            ) %>%
+        ) %>%
         group_by(GEOID) %>%
         summarize(cd_2010 = Mode(cd_2010))
     ri_shp <- ri_shp %>%
@@ -101,7 +101,7 @@ if (!file.exists(here(shp_path))) {
     ri_shp <- ri_shp %>%
         mutate(ssd_2010 = as.integer(ssd_shp$SLDUST)[
             geo_match(ri_shp, ssd_shp, method = "area")],
-            .after = cd_2010)
+        .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ri_shp,

--- a/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
@@ -1,0 +1,92 @@
+###############################################################################
+# Download and prepare data for `RI_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg RI_cd_2010}")
+
+path_data <- download_redistricting_file("RI", "data-raw/RI", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ri_2010_congress_2012-02-08_2021-12-31.zip"
+path_enacted <- "data-raw/RI/RI_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "RI_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/RI/RI_enacted/2a3f5ece-e912-4099-9a63-56417f74a25e202044-1-zjh6dc.92ezj.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/RI_2010/shp_vtd.rds"
+perim_path <- "data-out/RI_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong RI} shapefile")
+    # read in redistricting block data
+    redistricting_data <- read.csv("https://raw.githubusercontent.com/alarm-redist/census-2020/main/census-vest-2010/ri_2010_block.csv")
+    redistricting_data$GEOID <- as.character(redistricting_data$GEOID)
+    redistricting_data$county <- as.character(redistricting_data$county)
+    ri_shp <- redistricting_data %>%
+        left_join(y = tigris::blocks("RI", year = 2010), by = c("GEOID" = "GEOID10")) %>%
+        st_as_sf() %>%
+        st_transform(EPSG$RI)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    place_shp <- tinytiger::tt_places("RI", year = 2010)
+    matches_muni <- geomander::geo_match(from = ri_shp, to = place_shp, tiebreaker = FALSE)
+    matches_muni[matches_muni < 0] <- NA
+    d_muni <- tibble(GEOID = ri_shp$GEOID, muni = place_shp$PLACENS10[matches_muni])
+    d_cd <- get_baf_10(state = "RI", "CD")[[1]]  %>%
+        transmute(GEOID = BLOCKID,
+            cd_2000 = as.integer(DISTRICT))
+
+    ri_shp <- left_join(ri_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ri_shp <- ri_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ri_shp, cd_shp, method = "area")],
+        .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ri_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ri_shp <- rmapshaper::ms_simplify(ri_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ri_shp$adj <- redist.adjacency(ri_shp)
+
+    ri_shp <- ri_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ri_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ri_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong RI} shapefile")
+}

--- a/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
@@ -70,14 +70,14 @@ if (!file.exists(here(shp_path))) {
     # add the enacted plan
     cd_shp <- st_read(here(path_enacted))
     ri_shp <- ri_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+        mutate(cd_2010 = as.integer(cd_shp$CD115FP)[
             geo_match(ri_shp, cd_shp, method = "area")],
         .after = cd_2000)
 
     # add state senate districts
     sd_shp <- st_read(here(path_enacted_sd))
     ri_shp <- ri_shp %>%
-        mutate(sd_2010 = as.integer(sd_shp$DISTRICT)[
+        mutate(sd_2010 = as.integer(sd_shp$SLDUST)[
             geo_match(ri_shp, sd_shp, method = "area")],
         .after = cd_2010)
 

--- a/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
@@ -27,6 +27,14 @@ unzip(here(path_enacted), exdir = here(dirname(path_enacted), "RI_enacted"))
 file.remove(path_enacted)
 path_enacted <- "data-raw/RI/RI_enacted/2a3f5ece-e912-4099-9a63-56417f74a25e202044-1-zjh6dc.92ezj.shp"
 
+# download enacted state senate plan
+url_sd <- "https://redistricting.lls.edu/wp-content/uploads/ri_2010_state_upper_2012-02-08_2021-12-31.zip"
+path_enacted_sd <- "data-raw/RI/RI_enacted_sd.zip"
+download(url_sd, here(path_enacted_sd))
+unzip(here(path_enacted_sd), exdir = here(dirname(path_enacted_sd), "RI_enacted_sd"))
+file.remove(path_enacted_sd)
+path_enacted_sd <- "data-raw/RI/RI_enacted_sd/Senate_Districts.shp"
+
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -65,6 +73,13 @@ if (!file.exists(here(shp_path))) {
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(ri_shp, cd_shp, method = "area")],
         .after = cd_2000)
+
+    # add state senate districts
+    sd_shp <- st_read(here(path_enacted_sd))
+    ri_shp <- ri_shp %>%
+        mutate(sd_2010 = as.integer(sd_shp$DISTRICT)[
+            geo_match(ri_shp, sd_shp, method = "area")],
+        .after = cd_2010)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ri_shp,

--- a/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/01_prep_RI_cd_2010.R
@@ -96,6 +96,12 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     ri_shp$adj <- redist.adjacency(ri_shp)
 
+    # fix contiguity
+    # add Judith Point - Block Island ferry
+    ri_shp$adj <- add_edge(ri_shp$adj, 25156, 25180)
+    # Connect island in Money Swamp Pond
+    ri_shp$adj <- add_edge(ri_shp$adj, 21986, 21884)
+
     ri_shp <- ri_shp %>%
         fix_geo_assignment(muni)
 

--- a/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `RI_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg RI_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ri_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ri_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "RI_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/RI_2010/RI_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/02_setup_RI_cd_2010.R
@@ -4,23 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg RI_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ri_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ri_shp$adj)
-
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-        pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+map$sd_2010 <- ri_shp$sd_2010
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "RI_2010"
+map$state <- "RI"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/RI_2010/RI_cd_2010_map.rds", compress = "xz")

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `RI_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg RI_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/RI_2010/RI_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg RI_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/RI_2010/RI_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -6,27 +6,14 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg RI_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+
+# Minimize the number of state senate district splits
+plans <- redist_smc(map, nsims = 2500, runs = 2L, counties = sd_2010)
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/RI_2010/RI_cd_2010_plans.rds"), compress = "xz")
@@ -43,9 +30,16 @@ save_summary_stats(plans, "data-out/RI_2010/RI_cd_2010_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
+    plans %>%
+        mutate(sd_split = county_splits(map, map$sd_2020)) %>%
+        group_by(draw) %>%
+        summarize(sd_split = sd_split[1]) %>%
+        hist(sd_split) +
+        labs(title = "Senate district splits") +
+        theme_bw() +
+        theme(aspect.ratio = 3/4)
 }

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -9,7 +9,7 @@ cli_process_start("Running simulations for {.pkg RI_cd_2010}")
 set.seed(2010)
 
 constr <- redist_constr(map) %>%
-    add_constr_total_splits(strength = 0.5, admin = ssd_2010)
+    add_constr_splits(strength = 0.5, admin = ssd_2010)
 
 # Minimize the number of state senate district splits
 plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = county, constraints = constr)

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -35,7 +35,7 @@ if (interactive()) {
     library(patchwork)
 
     plans %>%
-        mutate(sd_split = county_splits(map, map$sd_2020)) %>%
+        mutate(sd_split = county_splits(map, map$sd_2010)) %>%
         group_by(draw) %>%
         summarize(sd_split = sd_split[1]) %>%
         hist(sd_split) +

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -35,11 +35,11 @@ if (interactive()) {
     library(patchwork)
 
     plans %>%
-        mutate(sd_split = county_splits(map, map$sd_2010)) %>%
+        mutate(ssd_split = county_splits(map, map$ssd_2010)) %>%
         group_by(draw) %>%
-        summarize(sd_split = sd_split[1]) %>%
-        hist(sd_split) +
-        labs(title = "Senate district splits") +
+        summarize(ssd_split = ssd_split[1]) %>%
+        hist(ssd_split) +
+        labs(title = "State Senate District Splits") +
         theme_bw() +
         theme(aspect.ratio = 3/4)
 }

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -8,8 +8,11 @@ cli_process_start("Running simulations for {.pkg RI_cd_2010}")
 
 set.seed(2010)
 
+constr <- redist_constr(map) %>%
+    add_constr_total_splits(strength = 0.5, admin = ssd_2010)
+
 # Minimize the number of state senate district splits
-plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = ssd_2010)
+plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = county, constraints = constr)
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -14,11 +14,11 @@ plans <- redist_smc(map, nsims = 1500, runs = 4L, counties = county)
 # used in forming CDs in each plan.
 plans <- plans %>% mutate(min_ssd_overlap = 0)
 plans_mat <- get_plans_matrix(plans)
-for (i in seq(length(plans_mat[1,]))) {
-    ssd_overlap <- redist.dist.pop.overlap(plan_old = map$ssd_2010, plan_new = plans_mat[,i], total_pop = map, normalize_rows = NULL)
+for (i in seq(length(plans_mat[1, ]))) {
+    ssd_overlap <- redist.dist.pop.overlap(plan_old = map$ssd_2010, plan_new = plans_mat[, i], total_pop = map, normalize_rows = NULL)
     min_overlap <- min(ssd_overlap[ssd_overlap > 0])
-    plans[2*i - 1,] <- plans[2*i - 1,] %>% mutate(min_ssd_overlap = min_overlap)
-    plans[2*i,] <- plans[2*i,] %>% mutate(min_ssd_overlap = min_overlap)
+    plans[2*i - 1, ] <- plans[2*i - 1, ] %>% mutate(min_ssd_overlap = min_overlap)
+    plans[2*i, ] <- plans[2*i, ] %>% mutate(min_ssd_overlap = min_overlap)
 }
 
 # keep only plans where the smallest SSD division has more than 100 residents.
@@ -63,7 +63,7 @@ if (interactive()) {
         theme(aspect.ratio = 3/4)
 
     plans %>%
-        hist(min_ssd_overlap, breaks = seq(0, max(plans$min_ssd_overlap)+500, 500)) +
+        hist(min_ssd_overlap, breaks = seq(0, max(plans$min_ssd_overlap) + 500, 500)) +
         scale_x_continuous(breaks = seq(0, max(plans$min_ssd_overlap), 2000)) +
         labs(title = "Smallest SSD Voting District in any CD") +
         theme_bw() +

--- a/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
+++ b/analyses/RI_cd_2010/03_sim_RI_cd_2010.R
@@ -8,11 +8,27 @@ cli_process_start("Running simulations for {.pkg RI_cd_2010}")
 
 set.seed(2010)
 
-constr <- redist_constr(map) %>%
-    add_constr_splits(strength = 0.5, admin = ssd_2010)
+plans <- redist_smc(map, nsims = 1500, runs = 4L, counties = county)
 
-# Minimize the number of state senate district splits
-plans <- redist_smc(map, nsims = 1250, runs = 4L, counties = county, constraints = constr)
+# count the population of the smallest division of a state senate district
+# used in forming CDs in each plan.
+plans <- plans %>% mutate(min_ssd_overlap = 0)
+plans_mat <- get_plans_matrix(plans)
+for (i in seq(length(plans_mat[1,]))) {
+    ssd_overlap <- redist.dist.pop.overlap(plan_old = map$ssd_2010, plan_new = plans_mat[,i], total_pop = map, normalize_rows = NULL)
+    min_overlap <- min(ssd_overlap[ssd_overlap > 0])
+    plans[2*i - 1,] <- plans[2*i - 1,] %>% mutate(min_ssd_overlap = min_overlap)
+    plans[2*i,] <- plans[2*i,] %>% mutate(min_ssd_overlap = min_overlap)
+}
+
+# keep only plans where the smallest SSD division has more than 100 residents.
+plans <- plans %>%
+    filter(min_ssd_overlap > 100 | draw == "cd_2010")
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(droplevels(draw)) < min(as.integer(droplevels(draw))) + 1250) %>% # thin samples
+    ungroup()
+
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
@@ -43,6 +59,13 @@ if (interactive()) {
         summarize(ssd_split = ssd_split[1]) %>%
         hist(ssd_split) +
         labs(title = "State Senate District Splits") +
+        theme_bw() +
+        theme(aspect.ratio = 3/4)
+
+    plans %>%
+        hist(min_ssd_overlap, breaks = seq(0, max(plans$min_ssd_overlap)+500, 500)) +
+        scale_x_continuous(breaks = seq(0, max(plans$min_ssd_overlap), 2000)) +
+        labs(title = "Smallest SSD Voting District in any CD") +
         theme_bw() +
         theme(aspect.ratio = 3/4)
 }

--- a/analyses/RI_cd_2010/doc_RI_cd_2010.md
+++ b/analyses/RI_cd_2010/doc_RI_cd_2010.md
@@ -6,7 +6,7 @@ In Rhode Island, according to [Chapter 106, Section 2 of the 2011 Rhode Island L
 1. be contiguous
 1. have equal populations
 1. be geographically compact
-1. preserve state senate districts as much as possible
+1. preserve state senate districts as much as possible. In particular, plans ought to avoid the creation of voting districts composed of fewer than one hundred (100) potential voters with respect to the division of state house and state senate districts.
 
 
 ### Algorithmic Constraints
@@ -19,5 +19,4 @@ Data for Rhode Island comes from the ALARM Project's [Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Rhode Island across four independent runs of the SMC algorithm.
-We assign state senate districts to act like counties so that the simulations minimize the number of state senate district splits.
+We sample 6,000 districting plans for Rhode Island across four independent runs of the SMC algorithm and then thin down to 5,000 plans districting which do not result in the creation of voting districts composed of fewer than 100 residents located in a unique combination of state house, state senate, and congressional district.

--- a/analyses/RI_cd_2010/doc_RI_cd_2010.md
+++ b/analyses/RI_cd_2010/doc_RI_cd_2010.md
@@ -19,4 +19,4 @@ Data for Rhode Island comes from the ALARM Project's [Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 6,000 districting plans for Rhode Island across four independent runs of the SMC algorithm and then thin down to 5,000 plans districting which do not result in the creation of voting districts composed of fewer than 100 residents located in a unique combination of state house, state senate, and congressional district.
+We sample 6,000 districting plans for Rhode Island across four independent runs of the SMC algorithm and then thin down to 5,000 districting plans which do not contain fewer than 100 residents from a single state senate district that is included in a proposed congressional district.

--- a/analyses/RI_cd_2010/doc_RI_cd_2010.md
+++ b/analyses/RI_cd_2010/doc_RI_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Rhode Island Congressional Districts
+
+## Redistricting requirements
+In Rhode Island, according to [Chapter 106, Section 2 of the 2011 Rhode Island Laws](http://webserver.rilin.state.ri.us/PublicLaws/law11/law11106.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve state senate districts as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Rhode Island comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Rhode Island across two independent runs of the SMC algorithm.
+We assign state senate districts to act like counties so that the simulations minimize the number of state senate district splits.

--- a/analyses/RI_cd_2010/doc_RI_cd_2010.md
+++ b/analyses/RI_cd_2010/doc_RI_cd_2010.md
@@ -19,5 +19,5 @@ Data for Rhode Island comes from the ALARM Project's [Redistricting Data Files](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Rhode Island across two independent runs of the SMC algorithm.
+We sample 5,000 districting plans for Rhode Island across four independent runs of the SMC algorithm.
 We assign state senate districts to act like counties so that the simulations minimize the number of state senate district splits.


### PR DESCRIPTION
## Redistricting requirements
In Rhode Island, according to [Chapter 106, Section 2 of the 2011 Rhode Island Laws](http://webserver.rilin.state.ri.us/PublicLaws/law11/law11106.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve state senate districts as much as possible

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Rhode Island comes from the ALARM Project's [Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Rhode Island across four independent runs of the SMC algorithm.
We assign state senate districts to act like counties so that the simulations minimize the number of state senate district splits.

## Validation

![validation_20230209_0017](https://user-images.githubusercontent.com/46555283/217725207-c2c9e693-7d31-47ea-aa41-070f191fbebf.png)

```
SMC: 5,000 sampled plans of 2 districts on 244 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.31 to 0.69

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby 
      1.001005       1.002249       1.000207       1.000637       1.000967 
     pop_white      pop_black       pop_hisp       pop_aian      pop_asian 
      1.001288       1.000822       1.001146       1.000412       1.001699 
      pop_nhpi      pop_other        pop_two      vap_white      vap_black 
      1.000754       1.000956       1.000862       1.001325       1.001029 
      vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other 
      1.001301       1.000432       1.001856       1.000469       1.000946 
       vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru 
      1.000653       1.000819       1.000625       1.000466       1.000649 
uss_18_dem_whi uss_18_rep_fla uss_20_dem_ree uss_20_rep_wat gov_18_dem_rai 
      1.000424       1.000471       1.001127       1.000737       1.000366 
gov_18_rep_fun atg_18_dem_ner sos_18_dem_gor sos_18_rep_cor         adv_16 
      1.000156       1.002423       1.000715       1.000524       1.000819 
        adv_18         adv_20         arv_16         arv_18         arv_20 
      1.000577       1.000564       1.000625       1.000366       1.000721 
 county_splits    muni_splits            ndv            nrv        ndshare 
      1.000040       1.000260       1.000495       1.000494       1.000400 
         e_dvs          e_dem           egap 
      1.000527       1.000143       1.001440 

Sampling diagnostics for SMC run 1 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,223 (97.9%)      4.7%        0.29   800 (101%)      4 
Resample    1,148 (91.8%)       NA%        0.29   772 ( 98%)     NA 

Sampling diagnostics for SMC run 2 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,223 (97.8%)      4.7%         0.3   802 (101%)      4 
Resample    1,146 (91.7%)       NA%         0.3   761 ( 96%)     NA 

Sampling diagnostics for SMC run 3 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,224 (97.9%)      4.7%        0.29   793 (100%)      4 
Resample    1,150 (92.0%)       NA%        0.29   784 ( 99%)     NA 

Sampling diagnostics for SMC run 4 of 4 (1,250 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,224 (97.9%)      4.8%        0.29   793 (100%)      4 
Resample    1,150 (92.0%)       NA%        0.29   767 ( 97%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%),
large std. devs. of the log weights (more than 3 or so), and low numbers of unique
plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny