### PR TITLE
 2010 Washington Congressional Districts

### DIFF
--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -68,7 +68,7 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("WA", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("WA"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     wa_shp <- left_join(wa_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
@@ -79,7 +79,7 @@ if (!file.exists(here(shp_path))) {
     wa_shp <- wa_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$District_N)[
             geo_match(wa_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
 
     # Create perimeters in case shapes are simplified
@@ -88,7 +88,7 @@ if (!file.exists(here(shp_path))) {
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         wa_shp <- rmapshaper::ms_simplify(wa_shp, keep = 0.05,
-                                          keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
@@ -113,15 +113,15 @@ if (!file.exists(here(shp_path))) {
             geom_sf(size = 0.05, color = "white") +
             geom_sf(data = d_water, size = 0.0, fill = "white", color = NA) +
             geom_sf(size = 0.7, color = "red", fill = NA, inherit.aes = FALSE,
-                    data = summarize(group_by(wa_shp, cd_2010), is_coverage = TRUE)) +
+                data = summarize(group_by(wa_shp, cd_2010), is_coverage = TRUE)) +
             geom_sf(size = 0.4, color = "black", inherit.aes = FALSE,
-                    data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
+                data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
             scale_fill_manual(values = sf.colors(39, categorical = TRUE), guide = "none") +
             scale_alpha_continuous(range = c(0, 1), guide = "none") +
             theme_void()
 
         p + geom_sf_text(aes(label = str_glue("{county}\n{vtd}")), size = 2.2, color = "black",
-                         data = filter(wa_shp, area_land >= 5e8))
+            data = filter(wa_shp, area_land >= 5e8))
 
         plot_zoom <- function(cty) {
             bbox <- st_bbox(filter(wa_shp, county == paste(cty, "County")))
@@ -209,21 +209,27 @@ if (!file.exists(here(shp_path))) {
     add_update_edge("53073000101", "53073000102")
 
     # Clark County
-    add_update_edge("53011WVCR49", "5301111090")
+    add_update_edge("53011WVCR49", "53011011090")
+
+    # TODO Finish Clark
 
     # Grays Harbor County
-    add_update_edge("53027WVPO24", "5302727045")
+    add_update_edge("53027WVPO24", "53027027045")
 
     # Island County
-    add_update_edge("53029WVSTJF", "5302929027")
+    add_update_edge("53029WVSTJF", "53029029027")
     add_update_edge("53061WVPG21", "53061WVPGED")
-    add_update_edge("53029WVPUGS", "5302929040")
-    add_update_edge("53029WVHOLH", "5302929023")
-    add_update_edge("53029WVPTSU", "5302929032")
-    add_update_edge("53029WVSKGB", "5302929057")
+    add_update_edge("53029WVPUGS", "53029029040")
+    add_update_edge("53029WVHOLH", "53029029023")
+    add_update_edge("53029WVPTSU", "53029029032")
+    add_update_edge("53029WVSKGB", "53029029057")
+
+    # TODO Add others from Island
 
     # Jefferson County
-    add_update_edge("53031WVPACO", "5300909262")
+    add_update_edge("53031WVPACO", "53009009262")
+
+    # TODO jefferson
 
     # King County
     add_update_edge("53033WVS361", "53033332200")
@@ -238,10 +244,12 @@ if (!file.exists(here(shp_path))) {
     add_update_edge("53033331818", "53033331817")
 
     # Pierce County
-    add_update_edge("53053WVROCB", "5305353211")
+    add_update_edge("53053WVROCB", "53053053211")
+
+    # TODO Pierce
 
     # San Juan County
-    add_update_edge("5305555015", "5305555004")
+    add_update_edge("53055055015", "53055055004")
 
     # Snohomish County
     add_update_edge("53061WVPGWY", "53061WVPG32")
@@ -252,8 +260,8 @@ if (!file.exists(here(shp_path))) {
         x <- redist:::contiguity(wa_shp$adj, rep(1, length(wa_shp$adj)))
         unique(wa_shp$county[x > 1])
 
-        idx <- which(x > 1 & str_detect(wa_shp$county, "033"))
-        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 500))
+        idx <- which(x > 1 & str_detect(wa_shp$county, "055"))
+        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 800))
         lbls <- rep("", nrow(wa_shp))
         adj_idxs <- c(idx, unlist(adj_nowater[idx]) + 1L)
         # adj_idxs = c(adj_idxs, unlist(adj_nowater[adj_idxs]) + 1L)

--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -252,8 +252,8 @@ if (!file.exists(here(shp_path))) {
         x <- redist:::contiguity(wa_shp$adj, rep(1, length(wa_shp$adj)))
         unique(wa_shp$county[x > 1])
 
-        idx <- which(x > 1 & str_detect(wa_shp$county, "055"))
-        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 800))
+        idx <- which(x > 1 & str_detect(wa_shp$county, "011"))
+        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 4000))
         lbls <- rep("", nrow(wa_shp))
         adj_idxs <- c(idx, unlist(adj_nowater[idx]) + 1L)
         # adj_idxs = c(adj_idxs, unlist(adj_nowater[adj_idxs]) + 1L)

--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -211,8 +211,6 @@ if (!file.exists(here(shp_path))) {
     # Clark County
     add_update_edge("53011WVCR49", "53011011090")
 
-    # TODO Finish Clark
-
     # Grays Harbor County
     add_update_edge("53027WVPO24", "53027027045")
 
@@ -224,12 +222,8 @@ if (!file.exists(here(shp_path))) {
     add_update_edge("53029WVPTSU", "53029029032")
     add_update_edge("53029WVSKGB", "53029029057")
 
-    # TODO Add others from Island
-
     # Jefferson County
     add_update_edge("53031WVPACO", "53009009262")
-
-    # TODO jefferson
 
     # King County
     add_update_edge("53033WVS361", "53033332200")
@@ -245,8 +239,6 @@ if (!file.exists(here(shp_path))) {
 
     # Pierce County
     add_update_edge("53053WVROCB", "53053053211")
-
-    # TODO Pierce
 
     # San Juan County
     add_update_edge("53055055015", "53055055004")

--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -1,0 +1,284 @@
+###############################################################################
+# Download and prepare data for `WA_cd_2010` analysis
+# © ALARM Project, July 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WA_cd_2010}")
+
+path_data <- download_redistricting_file("WA", "data-raw/WA", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/wa_2010_congress_2012-02-07_2021-12-31.zip"
+path_enacted <- "data-raw/WA/WA_enacted_2010.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "WA_enacted_2010"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/WA/WA_enacted_2010/CONG_AMEND_FINAL.shp"
+
+# download ferry routes
+url <- "https://data.wsdot.wa.gov/geospatial/DOT_TDO/FerryRoutes/FerryRoutes.zip"
+path_ferries <- "data-raw/WA/WA_ferries.zip"
+download(url, path_ferries)
+unzip(here(path_ferries), exdir = here(dirname(path_ferries), "WA_ferries"))
+file.remove(path_ferries)
+path_ferries <- "data-raw/WA/WA_ferries/FerryRoutes/FerryRoutes.shp"
+
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WA_2010/shp_vtd.rds"
+perim_path <- "data-out/WA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WA} shapefile")
+    # read in redistricting data
+    wa_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$WA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID")) %>%
+        relocate(GEOID, .before = state)
+
+    # fill Mt. Rainier hole
+    geom_pierce <- filter(wa_shp, county == "053") %>%
+        summarize() %>%
+        pull(geometry)
+    geom_pierce_nohole <- lapply(geom_pierce, function(x) x[1]) %>%
+        st_multipolygon() %>%
+        st_sfc(crs = st_crs(geom_pierce))
+    geom_hole <- st_difference(geom_pierce_nohole, geom_pierce)
+    wa_shp$geometry[st_geometry_type(wa_shp$geometry) == "GEOMETRYCOLLECTION"] <- geom_hole
+
+
+    # add municipalities
+    d_muni <- make_from_baf("WA", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("WA"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("WA", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("WA"), vtd),
+                  cd_2000 = as.integer(cd))
+    wa_shp <- left_join(wa_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    wa_shp <- wa_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District_N)[
+            geo_match(wa_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = wa_shp, perim_path = here(perim_path)) %>% invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wa_shp <- rmapshaper::ms_simplify(wa_shp, keep = 0.05,
+                                          keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # for geographic links
+    # need to use 2011 data due to 2010 not being available
+    d_roads <- tigris::primary_secondary_roads("53", year = 2011) %>%
+        st_transform(EPSG$WA)
+    d_water <- filter(tigris::fips_codes, state == "WA")$county_code %>%
+        lapply(function(cty) tigris::area_water("53", cty, year = 2011)) %>%
+        do.call(bind_rows, .) %>%
+        st_transform(EPSG$WA)
+    d_ferries <- read_sf(path_ferries) %>%
+        st_transform(EPSG$WA) %>%
+        st_cast("MULTILINESTRING")
+
+    # Highway plot for geographical links constraint
+    # WSF (ferries) is part of the state highway system but doesn't show up in TIGER
+    if (FALSE) {
+        library(ggplot2)
+
+        p <- ggplot(wa_shp, aes(fill = county)) +
+            geom_sf(size = 0.05, color = "white") +
+            geom_sf(data = d_water, size = 0.0, fill = "white", color = NA) +
+            geom_sf(size = 0.7, color = "red", fill = NA, inherit.aes = FALSE,
+                    data = summarize(group_by(wa_shp, cd_2010), is_coverage = TRUE)) +
+            geom_sf(size = 0.4, color = "black", inherit.aes = FALSE,
+                    data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
+            scale_fill_manual(values = sf.colors(39, categorical = TRUE), guide = "none") +
+            scale_alpha_continuous(range = c(0, 1), guide = "none") +
+            theme_void()
+
+        p + geom_sf_text(aes(label = str_glue("{county}\n{vtd}")), size = 2.2, color = "black",
+                         data = filter(wa_shp, area_land >= 5e8))
+
+        plot_zoom <- function(cty) {
+            bbox <- st_bbox(filter(wa_shp, county == paste(cty, "County")))
+            p +
+                coord_sf(xlim = bbox[c(1, 3)], ylim = bbox[c(2, 4)])
+        }
+    }
+
+    # create adjacency graph
+    wa_shp <- st_make_valid(wa_shp)
+    sf::sf_use_s2(FALSE)
+    wa_shp$adj <- redist.adjacency(wa_shp)
+
+    # disconnect water
+    d_bigwater <- filter(d_water, as.numeric(st_area(d_water)) > 1e7) %>%
+        summarize() %>% st_make_valid() %>%
+        rmapshaper::ms_simplify(keep = 0.05) %>%
+        st_snap(wa_shp$geometry, tolerance = 100) %>% # 100 ft
+        st_buffer(1.0)
+    geom_adj <- st_difference(wa_shp, d_bigwater$geometry)
+    geom_adj <- bind_rows(
+        geom_adj,
+        st_buffer(filter(wa_shp, !GEOID %in% geom_adj$GEOID), -50)
+    )
+    geom_adj <- slice(geom_adj, match(wa_shp$GEOID, geom_adj$GEOID))
+
+    adj_nowater <- redist.adjacency(wa_shp)
+    adj_0 <- redist.adjacency(geom_adj)
+    wa_shp$adj <- adj_0
+
+
+    # disconnect all counties
+    # Since counties follow the Cascade crest and the Columbia river,
+    #   this will take care of major geographic barriers. Smaller features,
+    #   e.g., lakes, bays and estuaries, won't be disconnected.
+    for (i in seq_along(wa_shp$adj)) {
+        cty_i <- wa_shp$county[i]
+        adj_i <- wa_shp$adj[[i]] + 1L
+        cty_j <- wa_shp$county[adj_i]
+        diff_cty <- which(cty_j != cty_i)
+        if (length(diff_cty) > 0) {
+            wa_shp$adj <- remove_edge(wa_shp$adj, rep(i, length(diff_cty)), adj_i[diff_cty])
+        }
+    }
+
+    # reconnect precincts across county borders by roads
+    geom_roads_ferries <- c(d_roads$geometry, d_ferries$geometry)
+    rel_roads_ferries <- st_crosses(geom_roads_ferries, wa_shp)
+    for (i in seq_along(rel_roads_ferries)) {
+        rel_i <- rel_roads_ferries[[i]]
+        if (length(rel_i) == 1) next
+        for (j in rel_i) {
+            adj_j <- setdiff(intersect(adj_nowater[[j]] + 1L, rel_i), wa_shp$adj[[j]] + 1L)
+            if (length(adj_j) > 0) {
+                wa_shp$adj <- add_edge(wa_shp$adj, rep(j, length(adj_j)), adj_j)
+            }
+        }
+    }
+
+    # manual connections
+    add_update_edge <- function(vtd1, vtd2) {
+        wa_shp$adj <<- add_edge(wa_shp$adj, which(wa_shp$GEOID == vtd1), which(wa_shp$GEOID == vtd2))
+    }
+
+    # Vashon and N Seattle
+    add_update_edge("53033WV0732", "53033000514")
+    add_update_edge("53033001818", "53033001817")
+    add_update_edge("53033WV0734", "53033001150")
+    add_update_edge("53033WV0733", "53033000853")
+    add_update_edge("53033WV0933", "53033002416")
+    add_update_edge("53033WV0930", "53033003014")
+
+    # Bremerton
+    add_update_edge("53035000007", "53035000006")
+
+    # Harstine Island
+    add_update_edge("53045000114", "53045000113")
+
+    # Fox, McNeil, and Ketron islands
+    add_update_edge("53053026350", "53053026342")
+    add_update_edge("53053028575", "53053028542")
+    add_update_edge("53053028571", "53053028574")
+
+    # Point Roberts
+    add_update_edge("53073000101", "53073000102")
+
+    # Clark County
+    add_update_edge("53011WVCR49", "5301111090")
+
+    # Grays Harbor County
+    add_update_edge("53027WVPO24", "5302727045")
+
+    # Island County
+    add_update_edge("53029WVSTJF", "5302929027")
+    add_update_edge("53061WVPG21", "53061WVPGED")
+    add_update_edge("53029WVPUGS", "5302929040")
+    add_update_edge("53029WVHOLH", "5302929023")
+    add_update_edge("53029WVPTSU", "5302929032")
+    add_update_edge("53029WVSKGB", "5302929057")
+
+    # Jefferson County
+    add_update_edge("53031WVPACO", "5300909262")
+
+    # King County
+    add_update_edge("53033WVS361", "53033332200")
+    add_update_edge("53033WVPS30", "53033WVPS33")
+    add_update_edge("53033303PS67", "5033330846")
+    add_update_edge("53033WVPSB9", "53033WVPS34")
+    add_update_edge("53033WVLW37", "53033330273")
+    add_update_edge("53033WVPSB7", "53033331057")
+    add_update_edge("53033WVLW41", "53033331010")
+    add_update_edge("53033WVL327", "53033330003")
+    add_update_edge("53033WVPSNP", "53033330856")
+    add_update_edge("53033331818", "53033331817")
+
+    # Pierce County
+    add_update_edge("53053WVROCB", "5305353211")
+
+    # San Juan County
+    add_update_edge("5305555015", "5305555004")
+
+    # Snohomish County
+    add_update_edge("53061WVPGWY", "53061WVPG32")
+
+    # manual connection helpers
+    if (FALSE) {
+        redist.plot.adj(wa_shp, wa_shp$adj, centroids = F)
+        x <- redist:::contiguity(wa_shp$adj, rep(1, length(wa_shp$adj)))
+        unique(wa_shp$county[x > 1])
+
+        idx <- which(x > 1 & str_detect(wa_shp$county, "033"))
+        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 500))
+        lbls <- rep("", nrow(wa_shp))
+        adj_idxs <- c(idx, unlist(adj_nowater[idx]) + 1L)
+        # adj_idxs = c(adj_idxs, unlist(adj_nowater[adj_idxs]) + 1L)
+        lbls[adj_idxs] <- wa_shp$GEOID[adj_idxs]
+        ggplot(wa_shp) +
+            geom_sf(aes(fill = x > 1), size = 0.1) +
+            geom_sf(data = d_water, size = 0.0, fill = "#ffffff55", color = NA) +
+            coord_sf(xlim = bbox[c(1, 3)], ylim = bbox[c(2, 4)]) +
+            geom_sf_text(aes(label = lbls), size = 2.5) +
+            theme_void()
+
+        table(redist:::contiguity(wa_shp$adj, wa_shp$cd_2010))
+    }
+
+
+    wa_shp <- wa_shp %>%
+        fix_geo_assignment(muni)
+
+    wa_shp <- st_cast(wa_shp, "MULTIPOLYGON") %>%
+        suppressWarnings()
+    write_rds(wa_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+
+} else {
+    wa_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WA} shapefile")
+}
+enforce_style("WA", year = 2010)

--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -187,26 +187,15 @@ if (!file.exists(here(shp_path))) {
     }
 
     # Vashon and N Seattle
-    add_update_edge("53033WV0732", "53033000514")
-    add_update_edge("53033001818", "53033001817")
-    add_update_edge("53033WV0734", "53033001150")
-    add_update_edge("53033WV0733", "53033000853")
-    add_update_edge("53033WV0933", "53033002416")
-    add_update_edge("53033WV0930", "53033003014")
+
 
     # Bremerton
-    add_update_edge("53035000007", "53035000006")
 
     # Harstine Island
-    add_update_edge("53045000114", "53045000113")
 
     # Fox, McNeil, and Ketron islands
-    add_update_edge("53053026350", "53053026342")
-    add_update_edge("53053028575", "53053028542")
-    add_update_edge("53053028571", "53053028574")
 
     # Point Roberts
-    add_update_edge("53073000101", "53073000102")
 
     # Clark County
     add_update_edge("53011WVCR49", "53011011090")
@@ -215,27 +204,31 @@ if (!file.exists(here(shp_path))) {
     add_update_edge("53027WVPO24", "53027027045")
 
     # Island County
-    add_update_edge("53029WVSTJF", "53029029027")
+    # Check this one
+    add_update_edge("53029WVSTJF", "53029029001")
     add_update_edge("53061WVPG21", "53061WVPGED")
-    add_update_edge("53029WVPUGS", "53029029040")
+    add_update_edge("53061WVPTSU", "53029029053")
+    add_update_edge("53029WVSKGB", "53057057124")
     add_update_edge("53029WVHOLH", "53029029023")
-    add_update_edge("53029WVPTSU", "53029029032")
-    add_update_edge("53029WVSKGB", "53029029057")
+    add_update_edge("53029WVPUGS", "53029029011")
+    add_update_edge("53029WVPTSU", "53029029053")
 
     # Jefferson County
     add_update_edge("53031WVPACO", "53009009262")
 
     # King County
-    add_update_edge("53033WVS361", "53033332200")
     add_update_edge("53033WVPS30", "53033WVPS33")
-    add_update_edge("53033303PS67", "5033330846")
-    add_update_edge("53033WVPSB9", "53033WVPS34")
-    add_update_edge("53033WVLW37", "53033330273")
-    add_update_edge("53033WVPSB7", "53033331057")
-    add_update_edge("53033WVLW41", "53033331010")
-    add_update_edge("53033WVL327", "53033330003")
+    add_update_edge("53033WVS361", "53033332209")
+    add_update_edge("53033WVPS30", "53033330954")
+    add_update_edge("53031WVPACO", "53009009262")
+    add_update_edge("53033WVLW41", "53033330989")
+    add_update_edge("53033WVLW37", "53033WVLW41")
     add_update_edge("53033WVPSNP", "53033330856")
-    add_update_edge("53033331818", "53033331817")
+    add_update_edge("53033WVPSB9", "53033WVPSNP")
+    add_update_edge("53033WVPSB7", "53033331059")
+    add_update_edge("53033331818", "53033331317")
+    add_update_edge("53033WVL327", "53033330003")
+
 
     # Pierce County
     add_update_edge("53053WVROCB", "53053053211")
@@ -252,8 +245,8 @@ if (!file.exists(here(shp_path))) {
         x <- redist:::contiguity(wa_shp$adj, rep(1, length(wa_shp$adj)))
         unique(wa_shp$county[x > 1])
 
-        idx <- which(x > 1 & str_detect(wa_shp$county, "011"))
-        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 4000))
+        idx <- which(x > 1 & str_detect(wa_shp$county, "033"))
+        bbox <- st_bbox(st_buffer(wa_shp$geometry[idx], 2000))
         lbls <- rep("", nrow(wa_shp))
         adj_idxs <- c(idx, unlist(adj_nowater[idx]) + 1L)
         # adj_idxs = c(adj_idxs, unlist(adj_nowater[adj_idxs]) + 1L)
@@ -262,7 +255,7 @@ if (!file.exists(here(shp_path))) {
             geom_sf(aes(fill = x > 1), size = 0.1) +
             geom_sf(data = d_water, size = 0.0, fill = "#ffffff55", color = NA) +
             coord_sf(xlim = bbox[c(1, 3)], ylim = bbox[c(2, 4)]) +
-            geom_sf_text(aes(label = lbls), size = 2.5) +
+            geom_sf_text(aes(label = lbls), size = 2) +
             theme_void()
 
         table(redist:::contiguity(wa_shp$adj, wa_shp$cd_2010))

--- a/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/01_prep_WA_cd_2010.R
@@ -186,17 +186,6 @@ if (!file.exists(here(shp_path))) {
         wa_shp$adj <<- add_edge(wa_shp$adj, which(wa_shp$GEOID == vtd1), which(wa_shp$GEOID == vtd2))
     }
 
-    # Vashon and N Seattle
-
-
-    # Bremerton
-
-    # Harstine Island
-
-    # Fox, McNeil, and Ketron islands
-
-    # Point Roberts
-
     # Clark County
     add_update_edge("53011WVCR49", "53011011090")
 

--- a/analyses/WA_cd_2010/02_setup_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/02_setup_WA_cd_2010.R
@@ -1,0 +1,24 @@
+###############################################################################
+# Set up redistricting simulation for `WA_cd_2010`
+# © ALARM Project, July 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WA_cd_2010}")
+
+
+map <- redist_map(wa_shp, pop_tol = 0.005,
+                  existing_plan = cd_2010, adj = wa_shp$adj)
+
+
+# Create pseudo counties to avoid county/municipality splitting
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WA_2010"
+
+map$state <- "WA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WA_2010/WA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WA_cd_2010/02_setup_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/02_setup_WA_cd_2010.R
@@ -6,13 +6,13 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg WA_cd_2010}")
 
 
 map <- redist_map(wa_shp, pop_tol = 0.005,
-                  existing_plan = cd_2010, adj = wa_shp$adj)
+    existing_plan = cd_2010, adj = wa_shp$adj)
 
 
 # Create pseudo counties to avoid county/municipality splitting
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "WA_2010"

--- a/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
@@ -7,13 +7,12 @@
 cli_process_start("Running simulations for {.pkg WA_cd_2010}")
 
 constr <- redist_constr(map) %>%
-    add_constr_grp_hinge(8.0, vap - vap_white, vap, c(0.52, 0.35, 0.25)) %>%
-    add_constr_grp_hinge(-8.0, vap - vap_white, vap, c(0.35, 0.25))
-
-
+    add_constr_grp_hinge(12.0, vap - vap_white, vap, c(0.52, 0.35, 0.25)) %>%
+    add_constr_grp_hinge(-12.0, vap - vap_white, vap, c(0.35, 0.25))
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 4000, counties = pseudo_county, constraints = constr, runs = 2L) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
+plans <- redist_smc(map, nsims = 6500, counties = pseudo_county, constraints = constr, runs = 2L) %>%
+    match_numbers("cd_2010") %>% group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 
@@ -21,7 +20,6 @@ plans <- match_numbers(plans, map$cd_2010)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
 
 # Output the redist_map object.
 write_rds(plans, here("data-out/WA_2010/WA_cd_2010_plans.rds"), compress = "xz")

--- a/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
@@ -13,7 +13,7 @@ constr <- redist_constr(map) %>%
 
 
 set.seed(2010)
-plans <- redist_smc(map, nsims = 7000, counties = pseudo_county, constraints = constr, runs = 2L) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
+plans <- redist_smc(map, nsims = 4000, counties = pseudo_county, constraints = constr, runs = 2L) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 

--- a/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
@@ -1,0 +1,38 @@
+###############################################################################
+# Simulate plans for `WA_cd_2010`
+# © ALARM Project, July 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WA_cd_2010}")
+
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(8.0, vap - vap_white, vap, c(0.52, 0.35, 0.25)) %>%
+    add_constr_grp_hinge(-8.0, vap - vap_white, vap, c(0.35, 0.25))
+
+
+
+set.seed(2010)
+plans <- redist_smc(map, nsims = 7000, counties = pseudo_county, constraints = constr, runs = 2L) %>% match_numbers("cd_2010") %>% group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, map$cd_2010)
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+
+# Output the redist_map object.
+write_rds(plans, here("data-out/WA_2010/WA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics.
+save_summary_stats(plans, "data-out/WA_2010/WA_cd_2010_stats.csv")
+
+cli_process_done()

--- a/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
+++ b/analyses/WA_cd_2010/03_sim_WA_cd_2010.R
@@ -12,7 +12,8 @@ constr <- redist_constr(map) %>%
 
 set.seed(2010)
 plans <- redist_smc(map, nsims = 6500, counties = pseudo_county, constraints = constr, runs = 2L) %>%
-    match_numbers("cd_2010") %>% group_by(chain) %>%
+    match_numbers("cd_2010") %>%
+    group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
     ungroup()
 

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -7,12 +7,11 @@ In Washington, districts must according to [RCW 44.05.090](https://app.leg.wa.go
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
-5. provide fair and effective representation and encourage electoral competition
-6. RCW 44.05.090(c): "Land areas may be deemed contiguous if they share a common land border or are connected by a ferry, highway, bridge, or tunnel. Areas separated by geographical boundaries or artificial barriers that prevent transportation within a district should not be deemed contiguous"
-
+5. not be connected across geographic barriers, although ferries across water may establish contiguity
+6. provide fair and effective representation and ... encourage electoral competition"
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.5%. We also used ferry routes in order to create districts linking precincts that are offshore. 
+We enforce a maximum population deviation of 0.5%. 
 To reflect the barriers and contiguity requirements, we remove edges across water regions and mountains in the adjacency graph, but reconnect precincts which are linked by a bridge, highway, or ferry.
 
 ## Data Sources
@@ -23,5 +22,4 @@ As described above, the adjacency graph was modified by hand to reflect Washingt
 
 ## Simulation Notes
 We sample 13,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
-To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that King County, Pierce County, and Snohomish County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.
-
+To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of King County, Pierce County, and Snohomish County. Within King County, Pierce County, and Snohomish County, each municipality is its own pseudocounty as well. King County, Pierce County, and Snohomish County were chosen since they are necessarily split by congressional districts.

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Washington Congressional Districts
 
 ## Redistricting requirements
-In Washington, districts must:
+In Washington, districts must according to HCR 4409 [https://apps.leg.wa.gov/billsummary/?BillNumber=4409&Year=2011&Initiative=false]:
 
 1. be contiguous
 2. have equal populations
@@ -10,7 +10,7 @@ In Washington, districts must:
 
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see '02_setup_WA_cd_2010.R' file). We also used ferry routes in order to create districts linking precincts that are offshore. 
+We enforce a maximum population deviation of 0.5%. We also used ferry routes in order to create districts linking precincts that are offshore. 
 
 ## Data Sources
 Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,5 +19,6 @@ Data for Washington comes from the ALARM Project's [2020 Redistricting Data File
 As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the '01_prep_WA_cd_2010.R' file.
 
 ## Simulation Notes
-We sample 8,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
+We sample 13,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that King County, Pierce County, and Snohomish County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.
 

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -10,13 +10,13 @@ In Washington, districts must:
 
 
 ### Interpretation of requirements
-We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see 02_setup_WA_cd_2010 file). We also used ferry routes in order to create districts linking precincts that are offshore. 
+We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see '02_setup_WA_cd_2010.R' file). We also used ferry routes in order to create districts linking precincts that are offshore. 
 
 ## Data Sources
 Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the 01_prep_WA_cd_2010.R file.
+As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the '01_prep_WA_cd_2010.R' file.
 
 ## Simulation Notes
 We sample 8,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Washington Congressional Districts
 
 ## Redistricting requirements
-In Washington, districts must according to HCR 4409 [https://apps.leg.wa.gov/billsummary/?BillNumber=4409&Year=2011&Initiative=false]:
+In Washington, districts must according to HCR 4409 (https://apps.leg.wa.gov/billsummary/?BillNumber=4409&Year=2011&Initiative=false):
 
 1. be contiguous
 2. have equal populations

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Washington Congressional Districts
+
+## Redistricting requirements
+In Washington, districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.05%. We applied a constraint to limit county and municipality splits (see 02_setup_WA_cd_2010 file). We also used ferry routes in order to create districts linking precincts that are offshore. 
+
+## Data Sources
+Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the 01_prep_WA_cd_2010.R file.
+
+## Simulation Notes
+We sample 14,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
+

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -19,5 +19,5 @@ Data for Washington comes from the ALARM Project's [2020 Redistricting Data File
 As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the 01_prep_WA_cd_2010.R file.
 
 ## Simulation Notes
-We sample 14,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
+We sample 8,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
 

--- a/analyses/WA_cd_2010/doc_WA_cd_2010.md
+++ b/analyses/WA_cd_2010/doc_WA_cd_2010.md
@@ -1,16 +1,19 @@
 # 2010 Washington Congressional Districts
 
 ## Redistricting requirements
-In Washington, districts must according to HCR 4409 (https://apps.leg.wa.gov/billsummary/?BillNumber=4409&Year=2011&Initiative=false):
+In Washington, districts must according to [RCW 44.05.090](https://app.leg.wa.gov/RCW/default.aspx?cite=44.05.090):
 
 1. be contiguous
 2. have equal populations
 3. be geographically compact
 4. preserve county and municipality boundaries as much as possible
+5. provide fair and effective representation and encourage electoral competition
+6. RCW 44.05.090(c): "Land areas may be deemed contiguous if they share a common land border or are connected by a ferry, highway, bridge, or tunnel. Areas separated by geographical boundaries or artificial barriers that prevent transportation within a district should not be deemed contiguous"
 
 
 ### Interpretation of requirements
 We enforce a maximum population deviation of 0.5%. We also used ferry routes in order to create districts linking precincts that are offshore. 
+To reflect the barriers and contiguity requirements, we remove edges across water regions and mountains in the adjacency graph, but reconnect precincts which are linked by a bridge, highway, or ferry.
 
 ## Data Sources
 Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).


### PR DESCRIPTION
# 2010 Washington Congressional Districts

## Redistricting requirements
In Washington, districts must according to HCR 4409 (https://apps.leg.wa.gov/billsummary/?BillNumber=4409&Year=2011&Initiative=false):

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible


### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. We also used ferry routes in order to create districts linking precincts that are offshore. 

## Data Sources
Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. The full list of these changes can be found in the '01_prep_WA_cd_2010.R' file.

## Simulation Notes
We sample 13,000 districting plans for Washington using the SMC algorithm and thinned the samples down to 5,000. To comply with the federal VRA and to respect communities of interest, we add a weak VRA constraint targeting one majority-minority district (currently WA-09).
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint. Note that King County, Pierce County, and Snohomish County must all be split due to their large populations, although within the counties, we avoid splitting any municipality.



## Validation

![WA2010NewADJ](https://user-images.githubusercontent.com/57640740/217733835-e7787822-5204-449f-940e-676f51818918.png)


```
SMC: 5,000 sampled plans of 10 districts on 6,966 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.46 to 0.75

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian 
      1.001646       1.001990       1.047810       1.000324       1.016263       1.007529       1.010500       1.003960       1.018536 
     pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
      1.016474       1.029484       1.000878       1.031311       1.017548       1.009942       1.002920       1.018697       1.016003 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_mur uss_16_rep_van 
      1.029103       1.000622       1.023141       1.006931       1.001036       1.007730       1.000398       1.011018       1.002541 
uss_18_dem_can uss_18_rep_hut gov_16_dem_ins gov_16_rep_bry gov_20_dem_ins gov_20_rep_cul atg_16_dem_fer atg_16_rep_tru atg_20_dem_fer 
      1.014578       1.000803       1.017507       1.002236       1.005800       1.000463       1.010223       1.002179       1.011421 
atg_20_rep_lar sos_16_dem_pod sos_16_rep_wym sos_20_dem_tar sos_20_rep_wym         adv_16         adv_18         adv_20         arv_16 
      1.000299       1.018101       1.001819       1.017244       1.001672       1.010871       1.014578       1.011348       1.001800 
        arv_18         arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
      1.000803       1.000182       1.012592       1.000323       1.010621       1.000878       1.003832       1.003847       1.010574 
         e_dem          pbias           egap 
      1.003377       1.005177       1.002774 

Sampling diagnostics for SMC run 1 of 2 (6,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,577 (85.8%)     12.2%        0.80 4,127 (100%)     16 
Split 2     5,438 (83.7%)     19.2%        0.83 3,953 ( 96%)      9 
Split 3     5,405 (83.1%)     22.0%        0.83 3,850 ( 94%)      7 
Split 4     5,139 (79.1%)     26.1%        0.83 3,820 ( 93%)      5 
Split 5     5,257 (80.9%)     27.4%        0.82 3,822 ( 93%)      4 
Split 6     5,304 (81.6%)     29.1%        0.81 3,773 ( 92%)      3 
Split 7     5,253 (80.8%)     15.6%        0.81 3,734 ( 91%)      6 
Split 8     5,095 (78.4%)     17.1%        0.85 3,529 ( 86%)      4 
Split 9     4,924 (75.7%)      7.0%        0.87 3,091 ( 75%)      3 
Resample    1,550 (23.9%)       NA%        1.00 3,983 ( 97%)     NA 

Sampling diagnostics for SMC run 2 of 2 (6,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,576 (85.8%)     13.7%        0.80 4,120 (100%)     14 
Split 2     5,353 (82.4%)     19.3%        0.86 3,932 ( 96%)      9 
Split 3     5,428 (83.5%)     24.2%        0.82 3,897 ( 95%)      6 
Split 4     5,405 (83.2%)     12.8%        0.80 3,875 ( 94%)     11 
Split 5     5,242 (80.6%)     17.6%        0.81 3,834 ( 93%)      7 
Split 6     5,313 (81.7%)     24.1%        0.79 3,825 ( 93%)      4 
Split 7     5,246 (80.7%)     24.8%        0.81 3,748 ( 91%)      3 
Split 8     5,192 (79.9%)     18.6%        0.82 3,602 ( 88%)      3 
Split 9     5,333 (82.0%)      7.7%        0.78 3,106 ( 76%)      2 
Resample    2,846 (43.8%)       NA%        0.93 4,253 (104%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [ ] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
