### PR TITLE
2010 Oklahoma Congressional Districts

### DIFF
--- a/analyses/OK_cd_2010/01_prep_OK_cd_2010.R
+++ b/analyses/OK_cd_2010/01_prep_OK_cd_2010.R
@@ -1,0 +1,94 @@
+###############################################################################
+# Download and prepare data for `OK_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OK_cd_2010}")
+
+path_data <- download_redistricting_file("OK", "data-raw/OK", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ok_2010_congress_2011-05-10_2021-12-31.zip"
+path_enacted <- "data-raw/OK/OK_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "OK_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/OK/OK_enacted/HB1527 - OK Congressional Districts.shp"
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OK_2010/shp_vtd.rds"
+perim_path <- "data-out/OK_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong OK} shapefile")
+    # read in redistricting data
+    ok_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$OK)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("OK", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("OK"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("OK", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("OK"), vtd),
+                  cd_2000 = as.integer(cd))
+    ok_shp <- left_join(ok_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ok_shp <- ok_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$District_N)[
+            geo_match(ok_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ok_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ok_shp <- rmapshaper::ms_simplify(ok_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ok_shp$adj <- redist.adjacency(ok_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ok_shp <- ok_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ok_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ok_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong OK} shapefile")
+}

--- a/analyses/OK_cd_2010/02_setup_OK_cd_2010.R
+++ b/analyses/OK_cd_2010/02_setup_OK_cd_2010.R
@@ -4,20 +4,12 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg OK_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ok_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ok_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni))
 
 # fix state label on map
 map$state <- "OK"

--- a/analyses/OK_cd_2010/02_setup_OK_cd_2010.R
+++ b/analyses/OK_cd_2010/02_setup_OK_cd_2010.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `OK_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OK_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ok_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ok_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# fix state label on map
+map$state <- "OK"
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OK_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OK_2010/OK_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OK_cd_2010/03_sim_OK_cd_2010.R
+++ b/analyses/OK_cd_2010/03_sim_OK_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `OK_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OK_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OK_2010/OK_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OK_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OK_2010/OK_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/OK_cd_2010/03_sim_OK_cd_2010.R
+++ b/analyses/OK_cd_2010/03_sim_OK_cd_2010.R
@@ -6,27 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OK_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 5e3, counties = pseudo_county, runs = 2)
+
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
+
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/OK_2010/OK_cd_2010_plans.rds"), compress = "xz")
@@ -41,11 +29,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/OK_2010/OK_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/OK_cd_2010/doc_OK_cd_2010.md
+++ b/analyses/OK_cd_2010/doc_OK_cd_2010.md
@@ -1,25 +1,22 @@
 # 2010 Oklahoma Congressional Districts
 
 ## Redistricting requirements
-In Oklahoma, districts must:
+In Oklahoma, [districts must](https://web.archive.org/web/20120910205322/http://www.okhouse.gov/Research/2010LegislativeGuidetoRedistricting.pdf):
 
-TODO: Complete this part 
 1. be contiguous
 1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
-Data for Oklahoma comes from the ALARM Project's [All About Redistricting](https://redistricting.lls.edu/state/oklahoma/?cycle=2010&level=Congress&startdate=2011-05-10)
+Data for Oklahoma comes from the ALARM Project's [All About Redistricting](https://redistricting.lls.edu/state/oklahoma/?cycle=2010&level=Congress&startdate=2011-05-10) and the ALARM Project's [Redistricting Data Files](https://alarm-redist.org/posts/2021-08-10-census-2020/).
 
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Oklahoma.
+We sample 10,000 districting plans for Oklahoma via two independent runs of 5,000 each.
 No special techniques were needed to produce the sample.

--- a/analyses/OK_cd_2010/doc_OK_cd_2010.md
+++ b/analyses/OK_cd_2010/doc_OK_cd_2010.md
@@ -1,0 +1,25 @@
+# 2010 Oklahoma Congressional Districts
+
+## Redistricting requirements
+In Oklahoma, districts must:
+
+TODO: Complete this part 
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Oklahoma comes from the ALARM Project's [All About Redistricting](https://redistricting.lls.edu/state/oklahoma/?cycle=2010&level=Congress&startdate=2011-05-10)
+
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Oklahoma.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Oklahoma, [districts must](https://web.archive.org/web/20120910205322/http://www.okhouse.gov/Research/2010LegislativeGuidetoRedistricting.pdf):

1. be contiguous
1. have equal populations


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Oklahoma comes from the ALARM Project's [All About Redistricting](https://redistricting.lls.edu/state/oklahoma/?cycle=2010&level=Congress&startdate=2011-05-10) and the ALARM Project's [Redistricting Data Files](https://alarm-redist.org/posts/2021-08-10-census-2020/).


## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Oklahoma via two independent runs of 5,000 each.
No special techniques were needed to produce the sample.

## Validation


![validation_20230208_2001](https://user-images.githubusercontent.com/97004864/217885307-ae9b903b-c928-4551-a558-73bc710338e2.png)

```
SMC: 10,000 sampled plans of 5 districts on 2,151 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.56 to 0.88

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian 
     1.0027973      1.0013874      0.9999491      1.0018459      1.0008178      1.0019665      1.0002424      1.0001877      1.0008727 
     pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
     1.0003430      1.0009853      1.0026425      1.0014192      1.0013892      1.0003048      1.0011146      1.0011400      1.0005652 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru pre_20_dem_bid uss_16_rep_lan uss_16_dem_wor 
     1.0014140      1.0018056      1.0026059      1.0006817      1.0010457      1.0013962      1.0017259      1.0003023      1.0006715 
uss_20_rep_inh uss_20_dem_bro gov_18_rep_sti gov_18_dem_edm atg_18_rep_hun atg_18_dem_myl         adv_16         adv_18         adv_20 
     1.0010858      1.0014671      1.0013107      1.0013198      1.0008813      1.0011188      1.0007534      1.0012572      1.0016321 
        arv_16         arv_18         arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs 
     1.0008248      1.0015668      1.0012181      1.0086697      1.0003711      1.0013360      1.0011584      1.0014808      1.0014225 
        pr_dem          e_dem          pbias           egap 
     1.0000000      1.0002674      1.0025347      1.0040958 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,922 (98.4%)      7.4%        0.25 3,159 (100%)     12 
Split 2     4,807 (96.1%)     12.3%        0.38 3,149 (100%)      7 
Split 3     4,721 (94.4%)     14.8%        0.45 3,061 ( 97%)      5 
Split 4     4,658 (93.2%)      7.8%        0.49 2,793 ( 88%)      3 
Resample    3,418 (68.4%)       NA%        0.48 3,998 (126%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,921 (98.4%)      9.2%        0.25 3,161 (100%)     10 
Split 2     4,825 (96.5%)     14.1%        0.38 3,120 ( 99%)      6 
Split 3     4,708 (94.2%)     18.3%        0.45 3,074 ( 97%)      4 
Split 4     4,488 (89.8%)      7.7%        0.54 2,795 ( 88%)      3 
Resample    2,001 (40.0%)       NA%        0.52 3,843 (122%)     NA
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the master branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@tylersimko

