### PR TITLE
2010 Kentucky Congressional Districts

### DIFF
--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -43,16 +43,16 @@ if (!file.exists(here(shp_path))) {
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # add municipalities
-    place_shp <- tinytiger::tt_places('KY', year = 2010)
+    place_shp <- tinytiger::tt_places("KY", year = 2010)
     matches_muni <- geomander::geo_match(from = ky_shp, to = place_shp, tiebreaker = FALSE)
     matches_muni[matches_muni < 0] <- NA
     d_muni <- tibble(GEOID = ky_shp$GEOID, muni = place_shp$PLACENS10[matches_muni])
-    d_cd <- get_baf_10(state = 'KY', "CD")[[1]]  %>%
+    d_cd <- get_baf_10(state = "KY", "CD")[[1]]  %>%
         transmute(GEOID = BLOCKID,
-                  cd_2000 = as.integer(DISTRICT))
+            cd_2000 = as.integer(DISTRICT))
 
     ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -68,8 +68,8 @@ if (!file.exists(here(shp_path))) {
             across(where(is.numeric), sum)
         ) %>%
         left_join(y = tinytiger::tt_tracts("KY", year = 2010) %>%
-                      select(GEOID = GEOID10),
-                  by = c("GEOID")) %>%
+            select(GEOID = GEOID10),
+        by = c("GEOID")) %>%
         st_as_sf() %>%
         st_transform(EPSG$KY)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
@@ -93,13 +93,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ky_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -17,7 +17,7 @@ suppressMessages({
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg KY_cd_2010}")
 
-path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2010)
+path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2010, type = "block")
 
 # download the enacted plan.
 # TODO try to find a download URL at <https://redistricting.lls.edu/state/kentucky/>
@@ -26,7 +26,7 @@ path_enacted <- "data-raw/KY/KY_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KY_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/KY/KY_enacted/CH302C02.shp" # TODO use actual SHP
+path_enacted <- "data-raw/KY/KY_enacted/CH302C02.shp"
 
 cli_process_done()
 
@@ -37,20 +37,31 @@ perim_path <- "data-out/KY_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong KY} shapefile")
     # read in redistricting data
-    ky_shp <- read_csv(here(path_data)) %>%
-        join_vtd_shapefile(year = 2010) %>%
+    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        left_join(y = tigris::blocks("KY", year = 2010), by = c("GEOID" = "GEOID10")) %>%
+        st_as_sf() %>%
         st_transform(EPSG$KY)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # add municipalities
-    d_muni <- make_from_baf("KY", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+    d_muni <- make_from_baf("KY", "INCPLACE_CDP", "VTD", year = 2010) %>%
         mutate(GEOID = paste0(censable::match_fips("KY"), vtd)) %>%
         select(-vtd)
-    d_cd <- make_from_baf("KY", "CD", "VTD", year = 2010)  %>%
-        transmute(GEOID = paste0(censable::match_fips("KY"), vtd),
-                  cd_2000 = as.integer(cd))
+    # d_cd <- make_from_baf("KY", "CD", "VTD", year = 2010)  %>%
+    #     transmute(GEOID = paste0(censable::match_fips("KY"), vtd),
+    #               cd_2000 = as.integer(cd))
+    # ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
+    #     left_join(d_cd, by="GEOID") %>%
+    #     mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    #     relocate(muni, county_muni, cd_2000, .after = county)
+
+    d_muni <- PL94171::pl_get_baf("KY", "INCPLACE_CDP")[[1]] %>%
+        rename(GEOID = BLOCKID, muni = PLACEFP)
+    d_cd <- PL94171::pl_get_baf("KY", "CD")[[1]]  %>%
+        transmute(GEOID = BLOCKID,
+                  cd_2000 = as.integer(DISTRICT))
     ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -69,7 +80,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -78,8 +88,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     ky_shp$adj <- redist.adjacency(ky_shp)
-
-    # TODO any custom adjacency graph edits here
 
     ky_shp <- ky_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `KY_cd_2010` analysis
+# © ALARM Project, January 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg KY_cd_2010}")
+
+path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2010)
+
+# download the enacted plan.
+# TODO try to find a download URL at <https://redistricting.lls.edu/state/kentucky/>
+url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+path_enacted <- "data-raw/KY/KY_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KY_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/KY/KY_enacted/XXXXXXX.shp" # TODO use actual SHP
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/KY_2010/shp_vtd.rds"
+perim_path <- "data-out/KY_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong KY} shapefile")
+    # read in redistricting data
+    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$KY)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("KY", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("KY"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("KY", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("KY"), vtd),
+                  cd_2000 = as.integer(cd))
+    ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    ky_shp <- ky_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(ky_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ky_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ky_shp$adj <- redist.adjacency(ky_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ky_shp <- ky_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ky_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ky_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong KY} shapefile")
+}

--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -84,13 +84,6 @@ if (!file.exists(here(shp_path))) {
     ky_shp <- ky_shp %>%
         left_join(baf_cd113, by = "GEOID")
 
-    # # add the enacted plan
-    # cd_shp <- st_read(here(path_enacted))
-    # ky_shp <- ky_shp %>%
-    #     mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
-    #         geo_match(ky_shp, cd_shp, method = "area")],
-    #         .after = cd_2000)
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ky_shp,
         perim_path = here(perim_path)) %>%

--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -20,7 +20,6 @@ cli_process_start("Downloading files for {.pkg KY_cd_2010}")
 path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2010, type = "block")
 
 # download the enacted plan.
-# TODO try to find a download URL at <https://redistricting.lls.edu/state/kentucky/>
 url <- "https://redistricting.lls.edu/wp-content/uploads/ky_2010_congress_2012-02-10_2021-12-31.zip"
 path_enacted <- "data-raw/KY/KY_enacted.zip"
 download(url, here(path_enacted))
@@ -37,42 +36,60 @@ perim_path <- "data-out/KY_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong KY} shapefile")
     # read in redistricting data
-    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c", county = "c")) %>%
         left_join(y = tigris::blocks("KY", year = 2010), by = c("GEOID" = "GEOID10")) %>%
         st_as_sf() %>%
         st_transform(EPSG$KY)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # add municipalities
-    d_muni <- make_from_baf("KY", "INCPLACE_CDP", "VTD", year = 2010) %>%
-        mutate(GEOID = paste0(censable::match_fips("KY"), vtd)) %>%
-        select(-vtd)
-    # d_cd <- make_from_baf("KY", "CD", "VTD", year = 2010)  %>%
-    #     transmute(GEOID = paste0(censable::match_fips("KY"), vtd),
-    #               cd_2000 = as.integer(cd))
-    # ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
-    #     left_join(d_cd, by="GEOID") %>%
-    #     mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
-    #     relocate(muni, county_muni, cd_2000, .after = county)
-
-    d_muni <- PL94171::pl_get_baf("KY", "INCPLACE_CDP")[[1]] %>%
-        rename(GEOID = BLOCKID, muni = PLACEFP)
-    d_cd <- PL94171::pl_get_baf("KY", "CD")[[1]]  %>%
+    place_shp <- tinytiger::tt_places('KY', year = 2010)
+    matches_muni <- geomander::geo_match(from = ky_shp, to = place_shp, tiebreaker = FALSE)
+    matches_muni[matches_muni < 0] <- NA
+    d_muni <- tibble(GEOID = ky_shp$GEOID, muni = place_shp$PLACENS10[matches_muni])
+    d_cd <- get_baf_10(state = 'KY', "CD")[[1]]  %>%
         transmute(GEOID = BLOCKID,
                   cd_2000 = as.integer(DISTRICT))
+
     ky_shp <- left_join(ky_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
-    # add the enacted plan
-    cd_shp <- st_read(here(path_enacted))
     ky_shp <- ky_shp %>%
-        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
-            geo_match(ky_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        as_tibble() %>%
+        mutate(GEOID = str_sub(GEOID, 1, 11)) %>%
+        group_by(GEOID) %>%
+        summarize(
+            state = state[1],
+            county = county[1],
+            muni = Mode(muni),
+            cd_2000 = Mode(cd_2000),
+            across(where(is.numeric), sum)
+        ) %>%
+        left_join(y = tinytiger::tt_tracts("KY", year = 2010) %>%
+                      select(GEOID = GEOID10),
+                  by = c("GEOID")) %>%
+        st_as_sf() %>%
+        st_transform(EPSG$KY)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
-    # TODO any additional columns or data you want to add should go here
+    baf_cd113 <- read_baf_cd113("KY") %>%
+        transmute(
+            GEOID = str_sub(BLOCKID, 1, 11),
+            cd_2010 = as.integer(cd_2010)
+        ) %>%
+        group_by(GEOID) %>%
+        summarize(cd_2010 = Mode(cd_2010))
+    ky_shp <- ky_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    # # add the enacted plan
+    # cd_shp <- st_read(here(path_enacted))
+    # ky_shp <- ky_shp %>%
+    #     mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+    #         geo_match(ky_shp, cd_shp, method = "area")],
+    #         .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ky_shp,

--- a/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/01_prep_KY_cd_2010.R
@@ -21,15 +21,12 @@ path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2010)
 
 # download the enacted plan.
 # TODO try to find a download URL at <https://redistricting.lls.edu/state/kentucky/>
-url <- "https://redistricting.lls.edu/wp-content/uploads/`state`_2020_congress_XXXXX.zip"
+url <- "https://redistricting.lls.edu/wp-content/uploads/ky_2010_congress_2012-02-10_2021-12-31.zip"
 path_enacted <- "data-raw/KY/KY_enacted.zip"
 download(url, here(path_enacted))
 unzip(here(path_enacted), exdir = here(dirname(path_enacted), "KY_enacted"))
 file.remove(path_enacted)
-path_enacted <- "data-raw/KY/KY_enacted/XXXXXXX.shp" # TODO use actual SHP
-
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
+path_enacted <- "data-raw/KY/KY_enacted/CH302C02.shp" # TODO use actual SHP
 
 cli_process_done()
 
@@ -40,7 +37,7 @@ perim_path <- "data-out/KY_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong KY} shapefile")
     # read in redistricting data
-    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+    ky_shp <- read_csv(here(path_data)) %>%
         join_vtd_shapefile(year = 2010) %>%
         st_transform(EPSG$KY)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))

--- a/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
@@ -4,14 +4,9 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg KY_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ky_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ky_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `KY_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg KY_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ky_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ky_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "KY_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/KY_2010/KY_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/02_setup_KY_cd_2010.R
@@ -10,9 +10,7 @@ map <- redist_map(ky_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KY_2010"

--- a/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
@@ -25,16 +25,9 @@ cli_process_start("Computing summary statistics for {.pkg KY_cd_2010}")
 
 plans <- add_summary_stats(plans, map)
 
-summary(plans)
+summary(select(plans, -pr_dem))
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/KY_2010/KY_cd_2010_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-    validate_analysis(plans, map %>% mutate(state = "KY"))
-}

--- a/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
@@ -36,5 +36,5 @@ cli_process_done()
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
-    validate_analysis(plans, map)
+    validate_analysis(plans, map %>% mutate(state = "KY"))
 }

--- a/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `KY_cd_2010`
+# © ALARM Project, January 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg KY_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/KY_2010/KY_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg KY_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/KY_2010/KY_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
+++ b/analyses/KY_cd_2010/03_sim_KY_cd_2010.R
@@ -6,27 +6,15 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg KY_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 4e3, runs = 2L, counties = pseudo_county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/KY_2010/KY_cd_2010_plans.rds"), compress = "xz")
@@ -37,15 +25,16 @@ cli_process_start("Computing summary statistics for {.pkg KY_cd_2010}")
 
 plans <- add_summary_stats(plans, map)
 
+summary(plans)
+
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/KY_2010/KY_cd_2010_stats.csv")
 
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
-
+    validate_analysis(plans, map)
 }

--- a/analyses/KY_cd_2010/doc_KY_cd_2010.md
+++ b/analyses/KY_cd_2010/doc_KY_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Kentucky Congressional Districts
+
+## Redistricting requirements
+In Kentucky, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Kentucky.
+No special techniques were needed to produce the sample.

--- a/analyses/KY_cd_2010/doc_KY_cd_2010.md
+++ b/analyses/KY_cd_2010/doc_KY_cd_2010.md
@@ -1,16 +1,16 @@
 # 2010 Kentucky Congressional Districts
 
 ## Redistricting requirements
-In Kentucky, districts must:
+In Kentucky, under the Criteria and Standards for Congressional Redistricting adopted by Interim Joint Committee on State Government’s Redistricting Subcommittee in 1991, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible
+5. preserve communities of interest as much as possible
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Kentucky of generally preserving county, city, and township boundaries.
 
 ## Data Sources
 Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -19,5 +19,5 @@ Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Kentucky.
-No special techniques were needed to produce the sample.
+We sample 8,000 districting plans for Kentucky across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
+We use a pseudo-county constraint to limit the county and municipality (i.e. city and township) splits. Municipality lines are used in Jefferson County, which has a population larger than the target population for a congressional district.

--- a/analyses/KY_cd_2010/doc_KY_cd_2010.md
+++ b/analyses/KY_cd_2010/doc_KY_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Kentucky Congressional Districts
 
 ## Redistricting requirements
-In Kentucky, under the Criteria and Standards for Congressional Redistricting adopted by Interim Joint Committee on State Government’s Redistricting Subcommittee in 1991, districts must:
+In Kentucky, under the [Criteria and Standards for Congressional Redistricting](https://web.archive.org/web/20220101204327/http://ncsl.org/Portals/1/Documents/Redistricting/Redistricting_2010.pdf) adopted by Interim Joint Committee on State Government’s Redistricting Subcommittee in 1991, districts must:
 
 1. be contiguous
 2. have equal populations

--- a/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
@@ -25,7 +25,8 @@ cli_process_start("Computing summary statistics for {.pkg KY_cd_2020}")
 
 plans <- add_summary_stats(plans, map)
 
-summary(plans)
+# remove NA columns
+summary(select(plans, -arv_18, -adv_18, -arv_20, -adv_20, -pr_dem))
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/KY_2020/KY_cd_2020_stats.csv")

--- a/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
+++ b/analyses/KY_cd_2020/03_sim_KY_cd_2020.R
@@ -26,7 +26,7 @@ cli_process_start("Computing summary statistics for {.pkg KY_cd_2020}")
 plans <- add_summary_stats(plans, map)
 
 # remove NA columns
-summary(select(plans, -arv_18, -adv_18, -arv_20, -adv_20, -pr_dem))
+summary(plans)
 
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/KY_2020/KY_cd_2020_stats.csv")


### PR DESCRIPTION
## Redistricting requirements
In Kentucky, under the [Criteria and Standards for Congressional Redistricting](https://web.archive.org/web/20220101204327/http://ncsl.org/Portals/1/Documents/Redistricting/Redistricting_2010.pdf) adopted by Interim Joint Committee on State Government’s Redistricting Subcommittee in 1991, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible
5. preserve communities of interest as much as possible

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in Kentucky of generally preserving county, city, and township boundaries.

## Data Sources
Data for Kentucky comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 8,000 districting plans for Kentucky across two independent runs of the SMC algorithm, and then thin the sample down to 5,000 plans.
We use a pseudo-county constraint to limit the county and municipality (i.e. city and township) splits. Municipality lines are used in Jefferson County, which has a population larger than the target population for a congressional district.


## Validation

![validation_20230217_0704](https://user-images.githubusercontent.com/26680063/219649461-bb75102f-44d8-454d-96bc-c4b5977feb11.png)

```
SMC: 5,000 sampled plans of 6 districts on 1,115 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5      
`est_label_mult`=1 • `pop_temper`=0           
ℹ Computing summary statistics for KY_cd_2010
Plan diversity 80% range: 0.51 to 0.80        
ℹ Computing summary statistics for KY_cd_2010
R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black 
      1.000675       1.000500       1.003909       1.002915       1.005447       1.001063       1.000897 
      pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white 
      1.002734       1.004164       1.004969       1.001571       1.000456       1.001518       1.000505 
     vap_black       vap_hisp       vap_aian      vap_asian       vap_nhpi      vap_other        vap_two 
      1.001050       1.002371       1.004039       1.004584       1.003398       1.001579       1.002407 
pre_16_rep_tru pre_16_dem_cli uss_16_rep_pau uss_16_dem_gra         adv_16         arv_16  county_splits 
      1.004017       1.001787       1.004750       1.000248       1.000165       1.009719       1.001581 
   muni_splits            ndv            nrv        ndshare          e_dvs          e_dem          pbias 
      1.000385       1.000165       1.009719       1.001076       1.001128       1.001735       1.003936 
          egap 
      1.000288 

Sampling diagnostics for SMC run 1 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    3,876 (155.0%)     12.0%        0.36 2,519 (159%)      5 
Split 2    3,849 (153.9%)     13.0%        0.36 2,461 (156%)      4 
Split 3    3,797 (151.9%)     15.8%        0.47 2,444 (155%)      3 
Split 4    3,714 (148.6%)     13.1%        0.54 2,393 (151%)      3 
Split 5    3,688 (147.5%)      6.2%        0.52 2,157 (136%)      2 
Resample   2,797 (111.9%)       NA%        0.54 2,292 (145%)     NA 

Sampling diagnostics for SMC run 2 of 2       
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    3,876 (155.0%)      8.4%        0.36 2,521 (160%)      7 
Split 2    3,846 (153.8%)     10.2%        0.36 2,521 (160%)      5 
Split 3    3,817 (152.7%)     11.7%        0.45 2,473 (156%)      4 
Split 4    3,725 (149.0%)     12.9%        0.53 2,414 (153%)      3 
Split 5    3,725 (149.0%)      4.3%        0.50 2,197 (139%)      3 
Resample   2,956 (118.3%)       NA%        0.52 2,319 (147%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
