### PR TITLE
Oregon 2010 Congressional Districts 

### DIFF
--- a/analyses/OR_cd_2010/01_prep_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/01_prep_OR_cd_2010.R
@@ -17,7 +17,7 @@ suppressMessages({
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg OR_cd_2010}")
 
-path_data <- download_redistricting_file("OR", "data-raw/OR", year = 2010)
+path_data <- download_redistricting_file("OR", "data-raw/OR", year = 2010, type = "block")
 
 cli_process_done()
 
@@ -28,51 +28,68 @@ perim_path <- "data-out/OR_2010/perim.rds"
 if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong OR} shapefile")
     # read in redistricting data
-    or_shp <- read_csv(here(path_data)) %>%
-        join_vtd_shapefile(year = 2010) %>%
+    or_shp <- read_csv(path_data, col_types = cols(GEOID = "c")) %>%
+        left_join(y = tinytiger::tt_blocks("OR", year = 2010), by = c("GEOID" = "GEOID10")) %>%
+        st_as_sf() %>%
         st_transform(EPSG$OR)  %>%
         rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # add municipalities
-    d_muni <- make_from_baf("OR", "INCPLACE_CDP", "VTD", year = 2010)  %>%
-        mutate(GEOID = paste0(censable::match_fips("OR"), vtd)) %>%
-        select(-vtd)
-    d_cd <- make_from_baf("OR", "CD", "VTD", year = 2010)  %>%
-        transmute(GEOID = paste0(censable::match_fips("OR"), vtd),
-                  cd_2000 = as.integer(cd))
+    d_muni <- get_baf_10("OR")$INCPLACE_CDP  %>%
+        transmute(
+            GEOID = BLOCKID,
+            muni = PLACEFP
+        )
+    d_cd <- get_baf_10("OR")$CD  %>%
+        transmute(
+            GEOID = BLOCKID,
+            cd_2000 = DISTRICT
+        )
     or_shp <- left_join(or_shp, d_muni, by = "GEOID") %>%
         left_join(d_cd, by="GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
     # add the enacted plan
-    baf_cd113 <- make_from_baf('OR', from = read_baf_cd113('OR'), year = 2010) %>%
-        rename(GEOID = vtd) %>% mutate(GEOID = paste0('41', GEOID))
+    baf_cd113 <- read_baf_cd113("OR") %>%
+        rename(GEOID = BLOCKID)
     or_shp <- or_shp %>%
         left_join(baf_cd113, by = "GEOID")
 
-    mi_shp <- mi_shp %>%
-        mutate(
-            cd_2010 = as.integer(cd_2010)
-        )
+    or_shp <- or_shp %>%
+        as_tibble() %>%
+        mutate(GEOID = str_sub(GEOID, 1, 11)) %>%
+        group_by(GEOID) %>%
+        summarize(
+            state = state[1],
+            county = county[1],
+            muni = Mode(muni),
+            cd_2000 = Mode(cd_2000),
+            cd_2010 = Mode(cd_2010),
+            across(where(is.numeric), sum)
+        ) %>%
+        left_join(y = tinytiger::tt_tracts("OR", year = 2010) %>%
+                      select(GEOID = GEOID10),
+                  by = c("GEOID")) %>%
+        st_as_sf() %>%
+        st_transform(EPSG$OR)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = or_shp,
-                             perim_path = here(perim_path)) %>%
+                               perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+                                          keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
     # create adjacency graph
     or_shp$adj <- redist.adjacency(or_shp)
-
-    # TODO any custom adjacency graph edits here
 
     or_shp <- or_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/OR_cd_2010/01_prep_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/01_prep_OR_cd_2010.R
@@ -1,0 +1,85 @@
+###############################################################################
+# Download and prepare data for `OR_cd_2010` analysis
+# © ALARM Project, October 2022
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OR_cd_2010}")
+
+path_data <- download_redistricting_file("OR", "data-raw/OR", year = 2010)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OR_2010/shp_vtd.rds"
+perim_path <- "data-out/OR_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong OR} shapefile")
+    # read in redistricting data
+    or_shp <- read_csv(here(path_data)) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$OR)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("OR", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("OR"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("OR", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("OR"), vtd),
+                  cd_2000 = as.integer(cd))
+    or_shp <- left_join(or_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    baf_cd113 <- make_from_baf('OR', from = read_baf_cd113('OR'), year = 2010) %>%
+        rename(GEOID = vtd) %>% mutate(GEOID = paste0('41', GEOID))
+    or_shp <- or_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+
+    mi_shp <- mi_shp %>%
+        mutate(
+            cd_2010 = as.integer(cd_2010)
+        )
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = or_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    or_shp$adj <- redist.adjacency(or_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    or_shp <- or_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(or_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    or_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong OR} shapefile")
+}

--- a/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
@@ -4,20 +4,12 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2010}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(or_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = or_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "OR_2010"

--- a/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `OR_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2010}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(or_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = or_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OR_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OR_2010/OR_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/02_setup_OR_cd_2010.R
@@ -7,10 +7,6 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2010}")
 map <- redist_map(or_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = or_shp$adj)
 
-map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "OR_2010"
 

--- a/analyses/OR_cd_2010/03_sim_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/03_sim_OR_cd_2010.R
@@ -6,27 +6,16 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 5000, runs = 2L, counties = county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/OR_2010/OR_cd_2010_plans.rds"), compress = "xz")
@@ -42,10 +31,3 @@ save_summary_stats(plans, "data-out/OR_2010/OR_cd_2010_stats.csv")
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-}

--- a/analyses/OR_cd_2010/03_sim_OR_cd_2010.R
+++ b/analyses/OR_cd_2010/03_sim_OR_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `OR_cd_2010`
+# © ALARM Project, October 2022
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OR_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OR_2010/OR_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OR_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OR_2010/OR_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/OR_cd_2010/doc_OR_cd_2010.md
+++ b/analyses/OR_cd_2010/doc_OR_cd_2010.md
@@ -1,23 +1,23 @@
 # 2010 Oregon Congressional Districts
 
 ## Redistricting requirements
-In Oregon, districts must:
+In Oregon, according to [Or. Rev. Stat. § 188.010](https://www.oregonlegislature.gov/bills_laws/archive/2011ors188.pdf) of the state constitution, districts must:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
+2. have equal populations
+3. be geographically compact
+4. be connected by transportation links
+5. preserve county and municipality boundaries as much as possible
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
 
 ## Data Sources
 Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+Oregon does not submit precinct boundaries to the Census Bureau. The base shapefile consists of tracts, but where tracts are split by the enacted congressional districts, we create separate sub-tracts. As described above, counties not linked by a state or federal highway were manually disconnected. The full list of these counties can be found in the '01_prep_OR_cd_2010.R' file.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Oregon.
-No special techniques were needed to produce the sample.
+We sample 5,000 districting plans for Oregon across two independent runs of the SMC algorithm. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well. Multnomah county were chosen since it is necessarily split by congressional districts.

--- a/analyses/OR_cd_2010/doc_OR_cd_2010.md
+++ b/analyses/OR_cd_2010/doc_OR_cd_2010.md
@@ -1,0 +1,23 @@
+# 2010 Oregon Congressional Districts
+
+## Redistricting requirements
+In Oregon, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Oregon.
+No special techniques were needed to produce the sample.

--- a/analyses/OR_cd_2010/doc_OR_cd_2010.md
+++ b/analyses/OR_cd_2010/doc_OR_cd_2010.md
@@ -11,7 +11,7 @@ In Oregon, according to [Or. Rev. Stat. § 188.010](https://www.oregonlegislatur
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
+We enforce a maximum population deviation of 0.5%. 
 
 ## Data Sources
 Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
@@ -20,4 +20,4 @@ Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](h
 Oregon does not submit precinct boundaries to the Census Bureau. The base shapefile consists of tracts, but where tracts are split by the enacted congressional districts, we create separate sub-tracts. As described above, counties not linked by a state or federal highway were manually disconnected. The full list of these counties can be found in the '01_prep_OR_cd_2010.R' file.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Oregon across two independent runs of the SMC algorithm. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well. Multnomah county were chosen since it is necessarily split by congressional districts.
+We sample 5,000 districting plans for Oregon across two independent runs of the SMC algorithm.


### PR DESCRIPTION
# 2010 Oregon Congressional Districts

## Redistricting requirements
In Oregon, according to [Or. Rev. Stat. § 188.010](https://www.oregonlegislature.gov/bills_laws/archive/2011ors188.pdf) of the state constitution, districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. be connected by transportation links
5. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.

## Data Sources
Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Oregon does not submit precinct boundaries to the Census Bureau. The base shapefile consists of tracts, but where tracts are split by the enacted congressional districts, we create separate sub-tracts. As described above, counties not linked by a state or federal highway were manually disconnected. The full list of these counties can be found in the '01_prep_OR_cd_2010.R' file.

## Simulation Notes
We sample 5,000 districting plans for Oregon across two independent runs of the SMC algorithm. To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well. Multnomah county were chosen since it is necessarily split by congressional districts.


## Validation

![OR 2010 final validation](https://user-images.githubusercontent.com/57640740/221023750-109e3ec7-7c4f-4200-afa3-d1e9baac44b6.png)


```
SMC: 5,000 sampled plans of 5 districts on 834 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.35 to 0.75

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp       pop_aian 
     1.0018453      1.0001369      1.0043743      1.0022470      1.0005272      1.0061739      1.0010765      1.0043509      1.0056432 
     pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
     1.0000606      1.0011823      1.0003512      1.0018002      1.0037476      1.0012633      1.0049747      1.0039295      1.0001582 
      vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru uss_16_dem_wyd uss_16_rep_cal 
     1.0015294      1.0005987      1.0050048      1.0014088      1.0001919      1.0016342      1.0000447      1.0017933      1.0005970 
uss_20_dem_mer uss_20_rep_per gov_16_dem_bro gov_16_rep_pie gov_18_dem_bro gov_18_rep_bue atg_16_dem_ros atg_16_rep_cro atg_20_dem_ros 
     1.0016200      1.0001879      1.0015517      1.0007389      1.0011512      1.0022999      1.0013519      1.0010803      1.0015005 
atg_20_rep_cro sos_16_dem_ava sos_16_rep_ric sos_20_dem_fag sos_20_rep_tha         adv_16         adv_18         adv_20         arv_16 
     1.0002920      1.0012610      1.0026402      1.0015028      1.0003979      1.0014845      1.0011512      1.0015880      1.0008996 
        arv_18         arv_20  county_splits    muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem 
     1.0022999      1.0002019      1.0008520      1.0009042      1.0014794      1.0005645      1.0001575      1.0001307      1.0002261 
         e_dem          pbias           egap 
     1.0010953      0.9999779      1.0005998 

Sampling diagnostics for SMC run 1 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,884 (97.7%)      8.5%        0.30 3,176 (100%)      6 
Split 2     4,745 (94.9%)     11.1%        0.42 3,098 ( 98%)      4 
Split 3     4,656 (93.1%)     13.4%        0.50 3,032 ( 96%)      3 
Split 4     4,608 (92.2%)      6.6%        0.54 2,733 ( 86%)      2 
Resample    3,455 (69.1%)       NA%        0.53 3,868 (122%)     NA 

Sampling diagnostics for SMC run 2 of 2 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,885 (97.7%)      8.5%        0.29 3,144 ( 99%)      6 
Split 2     4,742 (94.8%)     11.4%        0.42 3,051 ( 97%)      4 
Split 3     4,592 (91.8%)     13.5%        0.52 3,050 ( 97%)      3 
Split 4     4,524 (90.5%)      6.4%        0.56 2,754 ( 87%)      2 
Resample    2,880 (57.6%)       NA%        0.55 3,772 (119%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [ ] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
@christopherkenny
