### PR TITLE
2010 Idaho Congressional Districts

### DIFF
--- a/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
@@ -47,9 +47,9 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_cd <- make_from_baf("ID", "CD", "VTD", year = 2010)  %>%
         transmute(GEOID = paste0(censable::match_fips("ID"), vtd),
-                  cd_2000 = as.integer(cd))
+            cd_2000 = as.integer(cd))
     id_shp <- left_join(id_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by="GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, .after = county)
 
@@ -58,17 +58,17 @@ if (!file.exists(here(shp_path))) {
     id_shp <- id_shp %>%
         mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
             geo_match(id_shp, cd_shp, method = "area")],
-            .after = cd_2000)
+        .after = cd_2000)
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = id_shp,
-                             perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         id_shp <- rmapshaper::ms_simplify(id_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
@@ -107,12 +107,12 @@ if (!file.exists(here(shp_path))) {
 
     cty_pair <- cty_pair %>%
         mutate(x = cty$county[x],
-               y = cty$county[y])
+            y = cty$county[y])
 
     adj <- id_shp$adj
     for (i in seq_len(nrow(cty_pair))) {
         adj <- seam_rip(adj, shp = id_shp,
-                        admin = "county", seam = c(cty_pair$x[i], cty_pair$y[i])
+            admin = "county", seam = c(cty_pair$x[i], cty_pair$y[i])
         )
     }
 
@@ -127,4 +127,3 @@ if (!file.exists(here(shp_path))) {
     id_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong ID} shapefile")
 }
-

--- a/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
@@ -1,0 +1,130 @@
+###############################################################################
+# Download and prepare data for `ID_cd_2010` analysis
+# © ALARM Project, March 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg ID_cd_2010}")
+
+path_data <- download_redistricting_file("ID", "data-raw/ID", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/id_2010_congress_2011-10-17_2021-12-31.zip"
+path_enacted <- "data-raw/ID/ID_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "ID_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/ID/ID_enacted/C52.shp" # TODO use actual SHP
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/ID_2010/shp_vtd.rds"
+perim_path <- "data-out/ID_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong ID} shapefile")
+    # read in redistricting data
+    id_shp <- read_csv(here(path_data), col_types = cols(GEOID10 = "c")) %>%
+        join_vtd_shapefile(year = 2010) %>%
+        st_transform(EPSG$ID)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("ID", "INCPLACE_CDP", "VTD", year = 2010)  %>%
+        mutate(GEOID = paste0(censable::match_fips("ID"), vtd)) %>%
+        select(-vtd)
+    d_cd <- make_from_baf("ID", "CD", "VTD", year = 2010)  %>%
+        transmute(GEOID = paste0(censable::match_fips("ID"), vtd),
+                  cd_2000 = as.integer(cd))
+    id_shp <- left_join(id_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    cd_shp <- st_read(here(path_enacted))
+    id_shp <- id_shp %>%
+        mutate(cd_2010 = as.integer(cd_shp$DISTRICT)[
+            geo_match(id_shp, cd_shp, method = "area")],
+            .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = id_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        id_shp <- rmapshaper::ms_simplify(id_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    id_shp$adj <- redist.adjacency(id_shp)
+
+    cty <- id_shp %>%
+        group_by(county) %>%
+        summarize(geometry = sf::st_as_sfc(geos::geos_unary_union(geos::geos_make_collection(geometry))))
+
+    cty_adj <- adjacency(cty) %>% lapply(\(x) x + 1)
+
+    cty_pair <- purrr::map_dfr(seq_along(cty_adj), \(x){
+        tibble(x = x, y = cty_adj[[x]])
+    })
+
+    roads <- tigris::primary_secondary_roads("ID") %>%
+        st_transform(st_crs(id_shp)) %>%
+        geos::as_geos_geometry()
+
+    ints <- geos::geos_intersects_matrix(geom = roads, tree = cty)
+    tbl <- purrr::map_dfr(ints, \(x){
+        if (length(x) > 1) {
+            tidyr::expand_grid(x = x, y = x) %>% filter(
+                x != y
+            )
+        } else {
+            data.frame()
+        }
+    }) %>% distinct() %>%
+        mutate(magic = TRUE)
+
+    cty_pair <- cty_pair %>%
+        left_join(tbl, by = c("x", "y")) %>%
+        filter(is.na(magic))
+
+    cty_pair <- cty_pair %>%
+        mutate(x = cty$county[x],
+               y = cty$county[y])
+
+    adj <- id_shp$adj
+    for (i in seq_len(nrow(cty_pair))) {
+        adj <- seam_rip(adj, shp = id_shp,
+                        admin = "county", seam = c(cty_pair$x[i], cty_pair$y[i])
+        )
+    }
+
+    id_shp$adj <- adj
+
+    id_shp <- id_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(id_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    id_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong ID} shapefile")
+}
+

--- a/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/01_prep_ID_cd_2010.R
@@ -127,3 +127,4 @@ if (!file.exists(here(shp_path))) {
     id_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong ID} shapefile")
 }
+

--- a/analyses/ID_cd_2010/02_setup_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/02_setup_ID_cd_2010.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `ID_cd_2010`
+# © ALARM Project, March 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg ID_cd_2010}")
+
+map <- redist_map(id_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = id_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "ID_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/ID_2010/ID_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
@@ -1,0 +1,45 @@
+###############################################################################
+# Simulate plans for `ID_cd_2010`
+# © ALARM Project, March 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg ID_cd_2010}")
+
+set.seed(2010)
+plans <- redist_smc(map,
+                    nsims = 15e3,
+                    runs = 2L,
+                    counties = county_muni)
+
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/ID_2010/ID_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg ID_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/ID_2010/ID_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    redist.plot.adj(id_shp, id_shp$adj, plan = redist.sink.plan(id_shp$county)) +
+        geom_sf(data = tigris::primary_secondary_roads("ID"), color = "red") +
+        theme_void() +
+        guides(fill = "none")
+}
+

--- a/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
@@ -12,6 +12,11 @@ plans <- redist_smc(map,
     runs = 2L,
     counties = county_muni)
 
+plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
 plans <- match_numbers(plans, "cd_2010")
 
 cli_process_done()
@@ -42,3 +47,4 @@ if (interactive()) {
         theme_void() +
         guides(fill = "none")
 }
+

--- a/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
+++ b/analyses/ID_cd_2010/03_sim_ID_cd_2010.R
@@ -8,9 +8,9 @@ cli_process_start("Running simulations for {.pkg ID_cd_2010}")
 
 set.seed(2010)
 plans <- redist_smc(map,
-                    nsims = 15e3,
-                    runs = 2L,
-                    counties = county_muni)
+    nsims = 15e3,
+    runs = 2L,
+    counties = county_muni)
 
 plans <- match_numbers(plans, "cd_2010")
 
@@ -42,4 +42,3 @@ if (interactive()) {
         theme_void() +
         guides(fill = "none")
 }
-

--- a/analyses/ID_cd_2010/doc_ID_cd_2010.md
+++ b/analyses/ID_cd_2010/doc_ID_cd_2010.md
@@ -20,6 +20,6 @@ Data for Idaho comes from the [Loyala Law School (LLS) All About Redistricting](
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 15,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
+We sample 15,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm, and then thin to 5,000 sampled population.
 We sample using the standard algorithmic municipality constraint.
 No special techniques were needed to produce the sample.

--- a/analyses/ID_cd_2010/doc_ID_cd_2010.md
+++ b/analyses/ID_cd_2010/doc_ID_cd_2010.md
@@ -1,0 +1,25 @@
+# 2010 Idaho Congressional Districts
+
+## Redistricting requirements
+[In Idaho, districts must:](https://legislature.idaho.gov/statutesrules/idstat/Title72/T72CH15/SECT72-1506/)
+
+1. be contiguous (72-1506(6)).
+2. have equal populations (72-1506(3)).
+3. be geographically compact (72-1506(4), 72-1506(5)).
+4. preserve county and municipality boundaries as much as possible (72-1506(2)).
+5. not be drawn to favor party or incumbents (72-1506(8)).
+6. connect counties based on highways (72-1506(9)).
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Idaho comes from the [Loyala Law School (LLS) All About Redistricting](https://redistricting.lls.edu/state/idaho/?cycle=2010&level=Congress&startdate=2011-10-17) project
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 15,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
+We sample using the standard algorithmic municipality constraint.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2010 Idaho Congressional Districts

## Redistricting requirements
[In Idaho, districts must:](https://legislature.idaho.gov/statutesrules/idstat/Title72/T72CH15/SECT72-1506/)

1. be contiguous (72-1506(6)).
2. have equal populations (72-1506(3)).
3. be geographically compact (72-1506(4), 72-1506(5)).
4. preserve county and municipality boundaries as much as possible (72-1506(2)).
5. not be drawn to favor party or incumbents (72-1506(8)).
6. connect counties based on highways (72-1506(9)).

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Idaho comes from the [Loyala Law School (LLS) All About Redistricting](https://redistricting.lls.edu/state/idaho/?cycle=2010&level=Congress&startdate=2011-10-17) project

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 15,000 districting plans for Idaho, across 2 independent runs of the SMC algorithm.
We sample using the standard algorithmic municipality constraint.
No special techniques were needed to produce the sample.

## Validation

![validation_20230303_1412](https://user-images.githubusercontent.com/42868909/222807041-af8f86f0-65ba-456b-8e65-4cf24f409a5b.png)

```
SMC: 30,000 sampled plans of 2 districts on 922 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.00 to 0.69
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
     1.0000763      1.0000477      1.0000422      1.0000343      0.9999983      1.0000142 
     pop_black       pop_hisp       pop_aian      pop_asian       pop_nhpi      pop_other 
     1.0000588      1.0000549      1.0000673      1.0000921      1.0001120      1.0001892 
       pop_two      vap_white      vap_black       vap_hisp       vap_aian      vap_asian 
     1.0001284      1.0000298      1.0000802      1.0000640      1.0000557      1.0000990 
      vap_nhpi      vap_other        vap_two pre_16_rep_tru pre_16_dem_cli pre_20_rep_tru 
     1.0000699      1.0001531      1.0000987      1.0000118      1.0000496      1.0000090 
pre_20_dem_bid uss_16_rep_cra uss_16_dem_stu uss_20_rep_ris uss_20_dem_jor gov_18_rep_lit 
     1.0000232      1.0000137      1.0000407      1.0000183      1.0000245      1.0000625 
gov_18_dem_jor atg_18_rep_was atg_18_dem_bis sos_18_rep_den sos_18_dem_hum         adv_16 
     1.0000375      1.0000434      1.0000486      1.0000658      1.0000445      1.0000465 
        adv_18         adv_20         arv_16         arv_18         arv_20  county_splits 
     1.0000458      1.0000230      1.0000021      1.0000732      1.0000155      1.0000026 
   muni_splits            ndv            nrv        ndshare          e_dvs           egap 
     0.9999667      1.0000420      1.0000373      1.0000328      1.0000320      1.0000194 

Sampling diagnostics for SMC run 1 of 2 (15,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    14,453 (96.4%)      2.9%        0.41 9,547 (101%)      7 
Resample   13,236 (88.2%)       NA%        0.41 9,091 ( 96%)     NA 

Sampling diagnostics for SMC run 2 of 2 (15,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    14,447 (96.3%)      3.3%        0.41 9,518 (100%)      6 
Resample   13,219 (88.1%)       NA%        0.41 9,095 ( 96%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large
std. devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat
values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine
the diversity plot with `hist(plans_diversity(plans), breaks=24)`. Consider weakening or
removing constraints, or increasing the population tolerance. If the accpetance rate
drops quickly in the final splits, try increasing `pop_temper` by 0.01.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@christopherkenny

