### PR TITLE
2010 California Congressional Districts

### DIFF
--- a/analyses/CA_cd_2010/01_prep_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/01_prep_CA_cd_2010.R
@@ -1,0 +1,115 @@
+###############################################################################
+# Download and prepare data for `CA_cd_2010` analysis
+# © ALARM Project, February 2023
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CA_cd_2010}")
+
+path_data <- download_redistricting_file("CA", "data-raw/CA", type = "block", year = 2010)
+
+# download the enacted plan.
+url <- "https://redistricting.lls.edu/wp-content/uploads/ca_2010_congress_2012-01-17_2021-12-31.zip"
+path_enacted <- "data-raw/CA/CA_enacted.zip"
+download(url, here(path_enacted))
+unzip(here(path_enacted), exdir = here(dirname(path_enacted), "CA_enacted"))
+file.remove(path_enacted)
+path_enacted <- "data-raw/CA/CA_enacted/viz_20110728_q2_cd_finaldraft_shp/20110727_q2_congressional_final_draft.shp"
+path_dbf <- "data-raw/CA/CA_enacted/viz_20110728_q2_cd_finaldraft_shp/20110727_Q2_CONGRESSIONAL_FINAL_DRAFT.DBF"
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CA_2010/shp_vtd.rds"
+perim_path <- "data-out/CA_2010/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CA} shapefile")
+    # read in redistricting data
+    ca_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        left_join(y = tigris::blocks("CA", year = 2010), by = c("GEOID" = "GEOID10")) %>%
+        st_as_sf() %>%
+        st_transform(EPSG$CA)  %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- get_baf_10("CA", "INCPLACE_CDP")[[1]] %>%
+        rename(GEOID = BLOCKID, muni = PLACEFP)
+    d_cd <- get_baf_10("CA", "CD")[[1]] %>%
+        rename(GEOID = BLOCKID, cd_2000 = DISTRICT)
+    ca_shp <- left_join(ca_shp, d_muni, by = "GEOID") %>%
+        left_join(d_cd, by="GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, .after = county)
+
+    # add the enacted plan
+    ca_shp <- ca_shp %>%
+        as_tibble() %>%
+        mutate(GEOID = str_sub(GEOID, 1, 11)) %>%
+        group_by(GEOID) %>%
+        summarize(cd_2000 = Mode(cd_2000),
+                  muni = Mode(muni),
+                  state = unique(state),
+                  county = unique(county),
+                  across(where(is.numeric), sum)
+        ) %>%
+        left_join(y = tinytiger::tt_tracts("CA", year = 2010) %>%
+                  select(GEOID = GEOID10), by = c("GEOID")) %>%
+        st_as_sf() %>%
+        st_transform(EPSG$CA)
+
+    baf_cd113 <- read_baf_cd113("CA") %>%
+        transmute(
+            GEOID = str_sub(BLOCKID, 1, 11),
+            cd_2010 = as.integer(cd_2010)
+        ) %>%
+        group_by(GEOID) %>%
+        summarize(cd_2010 = Mode(cd_2010))
+    ca_shp <- ca_shp %>%
+        left_join(baf_cd113, by = "GEOID")
+    ca_shp <- ca_shp  %>%
+        relocate(cd_2010, .after = cd_2000)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ca_shp,
+                             perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ca_shp <- rmapshaper::ms_simplify(ca_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ca_shp$adj <- redist.adjacency(ca_shp)
+
+    # connect islands
+    nbrs <- geomander::suggest_component_connection(ca_shp, ca_shp$adj)
+    ca_shp$adj <- add_edge(ca_shp$adj, nbrs$x, nbrs$y)
+
+    ca_shp <- ca_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ca_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ca_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CA} shapefile")
+}

--- a/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
@@ -10,7 +10,7 @@ map <- redist_map(ca_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 map <- map %>%
     mutate(
@@ -21,7 +21,7 @@ map <- map %>%
     )
 
 counties_south <- c("037", "071", "059",
-                    "065", "073", "025")
+    "065", "073", "025")
 map_south <- map %>%
     `attr<-`("existing_col", NULL) %>%
     filter(county %in% counties_south) %>%
@@ -29,10 +29,10 @@ map_south <- map %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 
 counties_bay <- c("001", "013", "039",
-                  "047", "053", "067",
-                  "069", "075", "077",
-                  "081", "085", "087",
-                  "095", "099", "113")
+    "047", "053", "067",
+    "069", "075", "077",
+    "081", "085", "087",
+    "095", "099", "113")
 map_bay <- map %>%
     `attr<-`("existing_col", NULL) %>%
     filter(county %in% counties_bay) %>%
@@ -41,8 +41,8 @@ map_bay <- map %>%
 
 map <- map %>%
     mutate(cluster = case_when(county %in% counties_bay ~ "Bay",
-                               county %in% counties_south ~ "South",
-                               TRUE ~ "Remainder"))
+        county %in% counties_south ~ "South",
+        TRUE ~ "Remainder"))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CA_2010"

--- a/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
@@ -7,7 +7,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg CA_cd_2010}")
 map <- redist_map(ca_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = ca_shp$adj)
 
-# make pseudo counties with default settings
+# Make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
         pop_muni = get_target(map)))

--- a/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/02_setup_CA_cd_2010.R
@@ -1,0 +1,52 @@
+###############################################################################
+# Set up redistricting simulation for `CA_cd_2010`
+# © ALARM Project, February 2023
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CA_cd_2010}")
+
+map <- redist_map(ca_shp, pop_tol = 0.005,
+    existing_plan = cd_2010, adj = ca_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+
+map <- map %>%
+    mutate(
+        uid = row_number(),
+        across(contains(c("_16", "_18", "_20")) & !contains("cd"), \(x) coalesce(x, 0)),
+        ndv = coalesce(ndv, 0),
+        nrv = coalesce(nrv, 0)
+    )
+
+counties_south <- c("037", "071", "059",
+                    "065", "073", "025")
+map_south <- map %>%
+    `attr<-`("existing_col", NULL) %>%
+    filter(county %in% counties_south) %>%
+    `attr<-`("ndists", 31) %>%
+    `attr<-`("pop_bounds", attr(map, "pop_bounds"))
+
+counties_bay <- c("001", "013", "039",
+                  "047", "053", "067",
+                  "069", "075", "077",
+                  "081", "085", "087",
+                  "095", "099", "113")
+map_bay <- map %>%
+    `attr<-`("existing_col", NULL) %>%
+    filter(county %in% counties_bay) %>%
+    `attr<-`("ndists", 17) %>%
+    `attr<-`("pop_bounds", attr(map, "pop_bounds"))
+
+map <- map %>%
+    mutate(cluster = case_when(county %in% counties_bay ~ "Bay",
+                               county %in% counties_south ~ "South",
+                               TRUE ~ "Remainder"))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CA_2010"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CA_2010/CA_cd_2010_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
@@ -8,7 +8,7 @@ cli_process_start("Running simulations for {.pkg CA_cd_2010}")
 
 nsim <- 12500
 
-# simulate southern CA ----
+# Simulate southern CA ----
 seam_south <- sapply(
     list(
         c("037", "111"),
@@ -62,7 +62,7 @@ plans_south <- redist_smc(
 
 write_rds(plans_south, here("data-raw/CA/plans_south.rds"), compress = "xz")
 
-# simulate large bay area ----
+# Simulate large bay area ----
 seam_bay <- sapply(
     list(
         c("075", "041"),
@@ -155,7 +155,7 @@ plans_bay <- redist_smc(
 write_rds(plans_bay, here("data-raw/CA/plans_bay.rds"), compress = "xz")
 
 
-# pull it all together ----
+# Pull it all together ----
 init <- prep_particles(
     map = map,
     map_plan_list = list(
@@ -186,7 +186,7 @@ plans <- redist_smc(
 
 attr(plans, "prec_pop") <- map$pop
 
-# thin plans
+# Thin plans
 plans_5k <- plans %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
@@ -245,6 +245,7 @@ if (interactive()) {
             mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
         labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
         theme_bw()
+
     ggsave("data-raw/CA/hist_5k.pdf", p1, width = 11, height = 8)
 
 
@@ -309,6 +310,7 @@ if (interactive()) {
         labs(title = "CA Enacted versus Simulations") +
         scale_color_manual(values = c(cd_2020 = "black")) +
         geom_hline(yintercept = 0.5, linetype = "dotted")
+
     ggsave("data-raw/CA/boxplot.pdf", p2, width = 11, height = 8)
 
 }

--- a/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
@@ -6,39 +6,208 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CA_cd_2010}")
 
-# TODO any pre-computation (VRA targets, etc.)
+nsim <- 12500
 
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
+# simulate southern CA ----
+seam_south <- sapply(
+    list(
+        c("037", "111"),
+        c("037", "029"),
+        c("071", "029"),
+        c("071", "027")
+    ),
+    FUN = \(x) seam_geom(adj = map$adj, shp = map, admin = "county", seam = x) %>%
+        pull(GEOID)
+) %>% unlist()
+
+map_south$boundary <- map_south$GEOID %in% seam_south
+
+cons_south <- redist_constr(map_south) %>%
+    add_constr_grp_hinge(
+        strength = 9,
+        group_pop = vap_hisp,
+        total_pop = vap,
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -6,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -6,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .2
+    ) %>%
+    add_constr_custom(
+        strength = 10,
+        fn = function(plan, distr) {
+            as.numeric(!any(plan[map_south$boundary] == 0))
+        }
+    )
+
+n_steps <- (sum(map_south$pop)/attr(map, "pop_bounds")[2]) %>% floor()
+
 set.seed(2010)
-plans <- redist_smc(map, nsims = 5e3, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
-plans <- match_numbers(plans, "cd_2010")
+
+plans_south <- redist_smc(
+    map_south,
+    nsims = nsim, runs = 2L, ncores = 8,
+    counties = pseudo_county,
+    compactness = 1,
+    constraints = cons_south,
+    n_steps = n_steps, pop_temper = 0.03, seq_alpha = 0.95
+)
+
+write_rds(plans_south, here("data-raw/CA/plans_south.rds"), compress = "xz")
+
+# simulate large bay area ----
+seam_bay <- sapply(
+    list(
+        c("075", "041"),
+        c("013", "041"),
+        c("095", "097"),
+        c("095", "055"),
+        c("113", "055"),
+        c("113", "033"),
+        c("113", "011"),
+        c("113", "101"),
+        c("067", "101"),
+        c("067", "061"),
+        c("067", "017"),
+        c("067", "005"),
+        c("077", "005"),
+        c("077", "009"),
+        c("099", "009"),
+        c("099", "109"),
+        c("047", "043"),
+        c("047", "019"),
+        c("039", "043"),
+        c("039", "109"),
+        c("039", "051"),
+        c("039", "019"),
+        c("069", "019"),
+        c("053", "079"),
+        c("053", "031"),
+        c("053", "029")
+    ),
+    FUN = \(x) seam_geom(adj = map$adj, shp = map, admin = "county", seam = x) %>%
+        pull(GEOID)
+) %>% unlist()
+
+map_bay$boundary <- map_bay$GEOID %in% seam_bay
+
+cons_bay <- redist_constr(map_bay) %>%
+    add_constr_grp_hinge(
+        strength = 3,
+        group_pop = vap_hisp,
+        total_pop = vap,
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -3,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -3,
+        group_pop = vap_hisp,
+        total_pop = vap,
+        tgts_group = .2
+    ) %>%
+    add_constr_grp_hinge(
+        strength = 4,
+        group_pop = vap_asian,
+        total_pop = vap,
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -4,
+        group_pop = vap_asian,
+        total_pop = vap,
+        tgts_group = .3
+    ) %>%
+    add_constr_grp_hinge(
+        strength = -4,
+        group_pop = vap_asian,
+        total_pop = vap,
+        tgts_group = .2
+    ) %>%
+    add_constr_custom(
+        strength = 10,
+        fn = function(plan, distr) {
+            as.numeric(!any(plan[map_bay$boundary] == 0))
+        }
+    )
+
+n_steps <- (sum(map_bay$pop)/attr(map, "pop_bounds")[2]) %>% floor()
+
+set.seed(2010)
+
+plans_bay <- redist_smc(
+    map_bay,
+    nsims = nsim, runs = 2L, ncores = 8,
+    counties = pseudo_county,
+    constraints = cons_bay,
+    n_steps = n_steps, pop_temper = 0.05
+)
+
+write_rds(plans_bay, here("data-raw/CA/plans_bay.rds"), compress = "xz")
+
+
+# pull it all together ----
+init <- prep_particles(
+    map = map,
+    map_plan_list = list(
+        south = list(
+            map = map_south,
+            plans = plans_south %>% mutate(keep = district > 0)
+        ),
+        bay = list(
+            map = map_bay,
+            plans = plans_bay %>% mutate(keep = district > 0)
+        )
+    ),
+    uid = uid,
+    dist_keep = keep,
+    nsims = nsim*2
+)
+
+
+set.seed(2010)
+
+plans <- redist_smc(
+    map,
+    nsims = nsim*2, runs = 2L, ncores = 8,
+    counties = county,
+    compactness = 1,
+    init_particles = init
+)
+
+attr(plans, "prec_pop") <- map$pop
+
+# thin plans
+plans_5k <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup()
+
+plans_5k <- match_numbers(plans_5k, "cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/CA_2010/CA_cd_2010_plans.rds"), compress = "xz")
+write_rds(plans_5k, here("data-out/CA_2010/CA_cd_2010_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg CA_cd_2010}")
 
-plans <- add_summary_stats(plans, map)
+plans_5k <- add_summary_stats(plans_5k, map)
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/CA_2010/CA_cd_2010_stats.csv")
+save_summary_stats(plans_5k, "data-out/CA_2010/CA_cd_2010_stats.csv")
 
 cli_process_done()
 
@@ -47,5 +216,99 @@ cli_process_done()
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
+
+    p1 <- redist.plot.hist(plans_5k %>% group_by(draw) %>%
+        mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic > 40% and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic > 30% and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
+        labs(x = "Number of Hispanic + Asian and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic + Asian > 40% and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Hispanic + Asian > 30% and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
+        labs(x = "Number of Asian and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+        labs(x = "Number of Asian > 40% and Dem. Majority") +
+        redist.plot.hist(plans_5k %>% group_by(draw) %>%
+            mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
+        labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
+        theme_bw()
+    ggsave("data-raw/CA/hist_5k.pdf", p1, width = 11, height = 8)
+
+
+    enac_sum <- plans_5k %>%
+        subset_ref() %>%
+        mutate(minority = (total_vap - vap_white)/(total_vap),
+            dist_lab = str_pad(district, width = 2, pad = "0"),
+            minority_rank = rank(minority), # ascending order
+            hisp_rank = rank(vap_hisp),
+            asian_rank = rank(vap_asian),
+            ha_rank = rank(vap_hisp + vap_asian),
+            coalition_rank = rank(vap_hisp + vap_asian + vap_black),
+            compact_rank = rank(comp_polsby)
+        )
+
+    p2 <- redist.plot.distr_qtys(plans_5k, vap_hisp/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Hispanic by VAP") +
+        labs(title = "CA Enacted versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        geom_hline(yintercept = 0.5, linetype = "dotted") +
+        geom_text(data = enac_sum, aes(x = hisp_rank, label = round(e_dvs, 2)),
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans_5k, vap_asian/total_vap,
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Asian by VAP") +
+        labs(title = "CA Enacted versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        geom_hline(yintercept = 0.5, linetype = "dotted") +
+        geom_text(data = enac_sum, aes(x = asian_rank, label = round(e_dvs, 2)),
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans_5k, (vap_asian + vap_hisp)/total_vap,
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Hispanic or Asian by VAP") +
+        labs(title = "CA Enacted versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        geom_hline(yintercept = 0.5, linetype = "dotted") +
+        geom_text(data = enac_sum, aes(x = ha_rank, label = round(e_dvs, 2)),
+            vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+            color = ifelse(subset_ref(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+        redist.plot.distr_qtys(plans_5k, (vap_asian + vap_hisp + vap_black)/total_vap,
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Coalition by VAP") +
+        labs(title = "CA Enacted versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        geom_hline(yintercept = 0.5, linetype = "dotted") +
+        redist.plot.distr_qtys(plans_5k %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
+            color_thresh = NULL,
+            color = ifelse(subset_sampled(plans_5k)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+            size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Coalition by VAP") +
+        labs(title = "CA Enacted versus Simulations") +
+        scale_color_manual(values = c(cd_2020 = "black")) +
+        geom_hline(yintercept = 0.5, linetype = "dotted")
+    ggsave("data-raw/CA/boxplot.pdf", p2, width = 11, height = 8)
 
 }

--- a/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
@@ -212,7 +212,6 @@ save_summary_stats(plans_5k, "data-out/CA_2010/CA_cd_2010_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
+++ b/analyses/CA_cd_2010/03_sim_CA_cd_2010.R
@@ -1,0 +1,51 @@
+###############################################################################
+# Simulate plans for `CA_cd_2010`
+# © ALARM Project, February 2023
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CA_cd_2010}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2010)
+plans <- redist_smc(map, nsims = 5e3, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "cd_2010")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CA_2010/CA_cd_2010_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CA_cd_2010}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CA_2010/CA_cd_2010_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+}

--- a/analyses/CA_cd_2010/doc_CA_cd_2010.md
+++ b/analyses/CA_cd_2010/doc_CA_cd_2010.md
@@ -12,14 +12,30 @@ In California, according to the [California Constitution Article XXI](https://le
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to limit the county and municipality splits. We add VRA constraints encouraging Hispanic VAP and Asian VAP majorities in districts.
 
 ## Data Sources
-Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 California enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/california/?cycle=2010&level=Congress&startdate=2012-01-17).
+Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 California enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/california/?cycle=2010&level=Congress&startdate=2012-01-17). 
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+Islands were connected to their nearest point within county on the mainland.
 
 ## Simulation Notes
-We sample 5,000 districting plans for California.
-No special techniques were needed to produce the sample.
+We sample 25,000 districting plans in each cluster across 2 independent runs of the SMC algorithm.
+We next sample 50,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
+We then thin the sample to down to 5,000 plans.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
+A small population tempering value was used for each cluster to avoid losing diversity at the final step based on initial runs.
+
+### 1. Clustering Procedure
+First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:
+- South: Los Angeles, San Bernardino, Orange, Riverside, San Diego, and Imperial
+- Bay: Alameda, Contra Costa, Fresno, Kings, Madera, Madera, Merced, Monterey, Sacramento, San Benito, San Francisco, San Joaquin, San Mateo, Santa Clara, Santa Cruz, Solano, Stanislaus, Tulare, and Yolo
+
+We sample in each of these regions with a population deviation of 0.5%. We sample 28 districts in the southern region and 14 districts in the Bay Area. Because each cluster will have leftover population, we apply an additional constraint that
+incentivizes leaving any unassigned areas on the edge of these clusters to
+avoid discontiguities. For each cluster, we add VRA constraints encouraging Hispanic VAP and Asian VAP concentrations in districts, in line with the enacted plan.
+
+### 2. Combination Procedure
+
+Then, these partial map simulations are combined to run statewide simulations. We sample 11 districts in the remainder.

--- a/analyses/CA_cd_2010/doc_CA_cd_2010.md
+++ b/analyses/CA_cd_2010/doc_CA_cd_2010.md
@@ -1,0 +1,25 @@
+# 2010 California Congressional Districts
+
+## Redistricting requirements
+In California, according to the [California Constitution Article XXI](https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?lawCode=CONS&division=&title=&part=&chapter=&article=XXI), districts must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve city, county, neighborhood, and community of interest boundaries as much as possible
+5. not favor or discriminate against incumbents, candidates, or parties
+6. comply with the federal Voting Rights Act
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 California enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/california/?cycle=2010&level=Congress&startdate=2012-01-17).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for California.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In California, according to the [California Constitution Article XXI](https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?lawCode=CONS&division=&title=&part=&chapter=&article=XXI), districts must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve city, county, neighborhood, and community of interest boundaries as much as possible
5. not favor or discriminate against incumbents, candidates, or parties
6. comply with the federal Voting Rights Act


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to limit the county and municipality splits. We add VRA constraints encouraging Hispanic VAP and Asian VAP majorities in districts.

## Data Sources
Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/). Data for the 2010 California enacted congressional map comes from [All About Redistricting](https://redistricting.lls.edu/state/california/?cycle=2010&level=Congress&startdate=2012-01-17). 

## Pre-processing Notes
Islands were connected to their nearest point within county on the mainland.

## Simulation Notes
We sample 25,000 districting plans in each cluster across 2 independent runs of the SMC algorithm.
We next sample 50,000 districting plans for California across 2 independent runs of the SMC algorithm for the remainder.
We then thin the sample to down to 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint. These are counties are Alameda County, Contra Costa County, Fresno County, Kern County, Los Angeles County, Orange County, Riverside County, Sacramento County, San Bernardino County, San Diego County, San Francisco County, San Joaquin County, San Mateo County, Santa Clara County, and Ventura County, which are larger than a congressional district in population.
A small population tempering value was used for each cluster to avoid losing diversity at the final step based on initial runs.

### 1. Clustering Procedure
First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:
- South: Los Angeles, San Bernardino, Orange, Riverside, San Diego, and Imperial
- Bay: Alameda, Contra Costa, Fresno, Kings, Madera, Madera, Merced, Monterey, Sacramento, San Benito, San Francisco, San Joaquin, San Mateo, Santa Clara, Santa Cruz, Solano, Stanislaus, Tulare, and Yolo

We sample in each of these regions with a population deviation of 0.5%. We sample 28 districts in the southern region and 14 districts in the Bay Area. Because each cluster will have leftover population, we apply an additional constraint that
incentivizes leaving any unassigned areas on the edge of these clusters to
avoid discontiguities. For each cluster, we add VRA constraints encouraging Hispanic VAP and Asian VAP concentrations in districts, in line with the enacted plan.

### 2. Combination Procedure

Then, these partial map simulations are combined to run statewide simulations. We sample 11 districts in the remainder.

## Validation

![image](https://user-images.githubusercontent.com/55368740/224191375-a4a0c864-ae23-4ed9-8b9c-aef430240174.png)

```
SMC: 5,000 sampled plans of 53 districts on 8,057 units
`adapt_k_thresh`=0.985 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.37 to 0.87

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white      pop_black       pop_hisp 
     1.0112949      1.0017279      1.0105925      1.0094340      1.0061159      1.0040006      1.0077048      1.0029096 
      pop_aian      pop_asian       pop_nhpi      pop_other        pop_two      vap_white      vap_black       vap_hisp 
     1.0078262      1.0033341      1.0021208      1.0062393      1.0028283      1.0027007      1.0065199      1.0032184 
      vap_aian      vap_asian       vap_nhpi      vap_other        vap_two pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid 
     1.0078660      1.0038106      1.0042237      1.0063968      1.0064388      1.0086911      1.0019121      1.0169725 
pre_20_rep_tru         adv_16         adv_20         arv_16         arv_20  county_splits    muni_splits            ndv 
     1.0023822      1.0086911      1.0169725      1.0019121      1.0023822      1.0048133      1.0015119      1.0083052 
           nrv        ndshare          e_dvs         pr_dem          e_dem          pbias           egap 
     1.0023354      1.0037358      1.0037829      1.0001130      1.0000814      1.0220220      0.9998909 

Sampling diagnostics for SMC run 1 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    22,185 (88.7%)     11.0%        0.43 15,806 (100%)      5 
Split 2    21,778 (87.1%)     12.8%        0.55 15,222 ( 96%)      4 
Split 3    21,593 (86.4%)     11.7%        0.58 15,046 ( 95%)      4 
Split 4    21,262 (85.0%)     14.1%        0.62 14,759 ( 93%)      3 
Split 5    21,090 (84.4%)     13.0%        0.64 14,572 ( 92%)      3 
Split 6    20,654 (82.6%)      7.1%        0.67 14,219 ( 90%)      5 
Split 7    19,667 (78.7%)      7.5%        0.71 13,899 ( 88%)      4 
Split 8    19,095 (76.4%)      8.3%        0.79 13,349 ( 84%)      3 
Split 9    19,656 (78.6%)      4.8%        0.78 12,905 ( 82%)      4 
Split 10   19,173 (76.7%)      2.4%        0.78 11,913 ( 75%)      3 
Resample    9,253 (37.0%)       NA%        0.78 13,005 ( 82%)     NA 

Sampling diagnostics for SMC run 2 of 2 (25,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1    22,155 (88.6%)     11.2%        0.43 15,788 (100%)      5 
Split 2    21,676 (86.7%)     10.2%        0.55 15,141 ( 96%)      5 
Split 3    21,496 (86.0%)     11.6%        0.58 15,041 ( 95%)      4 
Split 4    21,260 (85.0%)      8.6%        0.62 14,837 ( 94%)      5 
Split 5    21,138 (84.6%)      9.8%        0.63 14,492 ( 92%)      4 
Split 6    20,543 (82.2%)     11.6%        0.68 14,354 ( 91%)      3 
Split 7    19,969 (79.9%)      7.5%        0.73 13,907 ( 88%)      4 
Split 8    19,754 (79.0%)      8.0%        0.75 13,533 ( 86%)      3 
Split 9    19,649 (78.6%)      8.9%        0.76 13,046 ( 83%)      2 
Split 10   19,649 (78.6%)      3.3%        0.76 12,041 ( 76%)      2 
Resample   10,549 (42.2%)       NA%        0.76 13,074 ( 83%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3
or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Histograms:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/55368740/224191816-5fb2881f-b078-4ca5-abe1-95b930f14dd0.png">

Dot plots:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/55368740/224191870-712e1913-e585-4750-8435-484a9ca4d96a.png">


@CoryMcCartan
@christopherkenny
