### PR TITLE
Thin NV, NH, and WI, save thinned plans in NY, and update HI numbering

### DIFF
--- a/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
@@ -29,7 +29,8 @@ plans <- redist_plans(
 
 plans <- plans %>%
     mutate(chain = rep(1:2, each = 5000), .after = draw) %>%
-    add_reference(ref_plan = map$cd_2010, "cd_2010")
+    add_reference(ref_plan = map$cd_2010, "cd_2010") %>%
+    match_numbers("cd_2010")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")

--- a/analyses/NH_cd_2010/03_sim_NH_cd_2010.R
+++ b/analyses/NH_cd_2010/03_sim_NH_cd_2010.R
@@ -15,6 +15,9 @@ plans <- redist_smc(map %>% mutate(state = "NH") %>% merge_by(mcd),
     counties = county) %>%
     pullback() %>%
     structure(prec_pop = map$pop) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup() %>%
     match_numbers("cd_2010")
 
 cli_process_done()

--- a/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
+++ b/analyses/NV_cd_2010/03_sim_NV_cd_2010.R
@@ -11,6 +11,9 @@ plans <- redist_smc(map,
     nsims = 5e3,
     runs = 2L,
     counties = pseudo_county) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup() %>%
     match_numbers("cd_2010")
 
 cli_process_done()

--- a/analyses/NY_cd_2010/03_sim_NY_cd_2010.R
+++ b/analyses/NY_cd_2010/03_sim_NY_cd_2010.R
@@ -24,7 +24,7 @@ cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 # Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/NY_2010/NY_cd_2010_plans.rds"), compress = "xz")
+write_rds(thinned_plans, here("data-out/NY_2010/NY_cd_2010_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
@@ -34,6 +34,6 @@ plans <- add_summary_stats(plans, map)
 thinned_plans <- add_summary_stats(thinned_plans, map)
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/NY_2010/NY_cd_2010_stats.csv")
+save_summary_stats(thinned_plans, "data-out/NY_2010/NY_cd_2010_stats.csv")
 
 cli_process_done()

--- a/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
+++ b/analyses/WI_cd_2010/03_sim_WI_cd_2010.R
@@ -10,6 +10,9 @@ set.seed(2010)
 plans <- redist_smc(map, nsims = 5e3,
     counties = pseudo_county,
     runs = 2L, verbose = TRUE, ncores = 16) %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 2500) %>% # thin samples
+    ungroup() %>%
     match_numbers("cd_2010")
 
 cli_process_done()


### PR DESCRIPTION
Updated Nevada, New Hampshire, and Wisconsin to thin existing plans (generated 5,000 over 2 runs for 10,000 total) to 5,000 for all.

Updated New York to ensure the thinned plans are saved.

Updated Hawaii to match district numbering to the reference enacted plan.

@christopherkenny 