### PR TITLE
2020 Oregon Congressional Districts (removes split tracts)

### DIFF
--- a/analyses/OR_cd_2020/01_prep_OR_cd_2020.R
+++ b/analyses/OR_cd_2020/01_prep_OR_cd_2020.R
@@ -21,15 +21,11 @@ url <- "https://raw.githubusercontent.com/alarm-redist/census-2020/main/census-v
 path_data <- "data-raw/OR/or_2020_block.csv"
 download(url, here(path_data))
 
-# updated link: manual download from https://geo.maps.arcgis.com/home/item.html?id=b43a1bf5997d4863a45023bfe7a047b1
-# url <- "https://oregon-redistricting.esriemcs.com/portal/sharing/rest/content/items/4ebcfc87b06c4e79b65685135329513c/data"
-# path_enacted <- "data-raw/OR/or_enacted.zip"
-# download(url, here(path_enacted))
-# zip_files <- unzip(here(path_enacted), list = TRUE)
-# enacted_baf <- zip_files$Name[str_detect(zip_files$Name, "\\.txt$")]
-# unzip(here(path_enacted), files = enacted_baf, exdir = dirname(here(path_enacted)))
+# Manually download the zip file from
+# https://geo.maps.arcgis.com/home/item.html?id=b43a1bf5997d4863a45023bfe7a047b1
+# Extract to 'data-raw/OR/'. Congress block assignment file is:
+# "Congress SB 881A (Block Assignment File).txt"
 path_baf <- "data-raw/OR/Congress SB 881A (Block Assignment File).txt"
-# file.rename(here(dirname(path_enacted), enacted_baf), here(path_baf))
 
 cli_process_done()
 

--- a/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
+++ b/analyses/OR_cd_2020/03_sim_OR_cd_2020.R
@@ -35,5 +35,5 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    plot(map, adj = T, centroid = F)
+    plot(map, adj = TRUE, centroid = FALSE)
 }

--- a/analyses/OR_cd_2020/doc_OR_cd_2020.md
+++ b/analyses/OR_cd_2020/doc_OR_cd_2020.md
@@ -21,7 +21,7 @@ Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](h
 
 ## Pre-processing Notes
 Oregon does not submit precinct boundaries to the Census Bureau.
-The base shapefile consists of tracts, but where tracts are split by the enacted congressional districts, we create separate sub-tracts.
+The base shapefile consists of tracts.
 As described above, counties not linked by a state or federal highway were manually disconnected.
 The full list of these counties can be found in the `01_prep_OR_cd_2020.R` file.
 


### PR DESCRIPTION
## Redistricting requirements
In Oregon, districts must, under Or. Rev. Stat. § 188.010:

1. be contiguous
1. be of equal population
1. utilize existing geographic or political boundaries
1. not divide communities of common interest
1. be connected by transportation links

Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.
To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway.

## Data Sources
Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Oregon does not submit precinct boundaries to the Census Bureau.
The base shapefile consists of tracts.
As described above, counties not linked by a state or federal highway were manually disconnected.
The full list of these counties can be found in the `01_prep_OR_cd_2020.R` file.

## Simulation Notes
We sample 6,000 districting plans for Oregon across two independent runs of the SMC algorithm.
To balance county and municipality splits, we create pseudocounties for use in the county constraint.
These are counties, outside of Multnomah county. Within Multnomah county, each municipality is its own pseudocounty as well.
Multnomah county were chosen since it is necessarily split by congressional districts.

## Validation

![validation_20240515_2156](https://github.com/alarm-redist/fifty-states/assets/28026893/4e0d5be9-076c-44ec-be90-948de5b894ef)

```
SMC: 5,000 sampled plans of 6 districts on 1,001 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.39 to 0.71

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white        pop_two      pop_asian 
         1.014          1.011          1.003          1.000          1.014          1.015          1.011          1.014 
      pop_aian      pop_other       pop_nhpi       pop_hisp      pop_black        vap_two      vap_other       vap_nhpi 
         1.005          1.003          1.008          1.021          1.000          1.010          1.004          1.003 
      vap_hisp      vap_black      vap_asian      vap_white       vap_aian uss_16_rep_cal pre_16_dem_cli uss_16_dem_wyd 
         1.022          1.002          1.015          1.016          1.005          1.005          1.006          1.004 
sos_16_rep_ric gov_16_dem_bro uss_20_dem_mer gov_16_rep_pie atg_16_dem_ros pre_16_rep_tru atg_20_dem_ros atg_16_rep_cro 
         1.005          1.009          1.003          1.006          1.008          1.001          1.003          1.004 
sos_16_dem_ava gov_18_dem_bro gov_18_rep_bue sos_20_rep_tha pre_20_dem_bid pre_20_rep_tru uss_20_rep_per atg_20_rep_cro 
         1.010          1.005          1.011          1.004          1.003          1.002          1.002          1.004 
sos_20_dem_fag         arv_16         adv_16         arv_18         adv_18         arv_20         adv_20  county_splits 
         1.003          1.003          1.007          1.011          1.005          1.003          1.003          1.004 
   muni_splits            ndv            nrv        ndshare          e_dvs         pr_dem          e_dem          pbias 
         1.004          1.005          1.004          1.002          1.003          1.000          1.001          1.002 
          egap 
         1.001 

Sampling diagnostics for SMC run 1 of 2 (3,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,937 (97.9%)      9.6%        0.29 1,876 ( 99%)      5 
Split 2     2,715 (90.5%)     11.8%        0.50 1,853 ( 98%)      4 
Split 3     2,494 (83.1%)     15.1%        0.72 1,736 ( 92%)      3 
Split 4     2,473 (82.4%)     14.2%        0.79 1,705 ( 90%)      3 
Split 5     2,585 (86.2%)      6.4%        0.72 1,564 ( 82%)      2 
Resample    1,573 (52.4%)       NA%        0.72 2,082 (110%)     NA 

Sampling diagnostics for SMC run 2 of 2 (3,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,937 (97.9%)     10.2%        0.28 1,896 (100%)      5 
Split 2     2,730 (91.0%)     11.7%        0.49 1,834 ( 97%)      4 
Split 3     2,502 (83.4%)     15.1%        0.70 1,753 ( 92%)      3 
Split 4     2,468 (82.3%)     14.0%        0.80 1,707 ( 90%)      3 
Split 5     2,631 (87.7%)      2.7%        0.70 1,580 ( 83%)      5 
Resample    1,710 (57.0%)       NA%        0.70 2,129 (112%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more
than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
