### PR TITLE
2010 Hawaii Congressional Districts (use VTD not tract)

### DIFF
--- a/analyses/HI_cd_2010/01_prep_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/01_prep_HI_cd_2010.R
@@ -19,14 +19,6 @@ cli_process_start("Downloading files for {.pkg HI_cd_2010}")
 
 path_data <- download_redistricting_file("HI", "data-raw/HI", year = 2010, type = "block", overwrite = TRUE)
 
-# download the enacted plan.
-url <- "https://redistricting.lls.edu/wp-content/uploads/hi_2010_congress_2011-09-26_2021-12-31.zip"
-path_enacted <- "data-raw/HI/HI_enacted.zip"
-download(url, here(path_enacted))
-unzip(here(path_enacted), exdir = here(dirname(path_enacted), "HI_enacted"))
-file.remove(path_enacted)
-path_enacted <- "data-raw/HI/HI_enacted/congress11.shp"
-
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -46,34 +38,33 @@ if (!file.exists(here(shp_path))) {
     # add municipalities
     d_muni <- get_baf_10("HI", "INCPLACE_CDP")[[1]] %>%
         rename(GEOID = BLOCKID, muni = PLACEFP)
+    # add cd
     d_cd <- get_baf_10("HI", "CD")[[1]] %>%
         rename(GEOID = BLOCKID, cd_2000 = DISTRICT)
-    hi_shp <- left_join(hi_shp, d_muni, by = "GEOID") %>%
-        left_join(d_cd, by = "GEOID") %>%
-        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
-        relocate(muni, county_muni, cd_2000, .after = county)
-
-    # add the enacted plan by geomatching Honolulu County
-    # (the rest of the state is in District 2)
-    cd_shp <- st_read(here(path_enacted))
-    honolulu <- hi_shp %>% filter(county == "003") %>%
-        mutate(cd_2010 = as.integer(cd_shp$USDist)[
-            geo_match(honolulu, cd_shp, method = "area")],
-        .after = cd_2000)
-    rest_shp <- hi_shp %>%
-        filter(county != "003") %>%
-        mutate(cd_2010 = 2, .after = cd_2000)
-    hi_shp <- rbind(rest_shp, honolulu)
-
-    # group from block-level to tract-level
 
     hi_shp <- hi_shp %>%
-        mutate(tract = str_sub(GEOID, 1, 11)) %>%
-        group_by(tract) %>%
-        summarize(cd_2000 = Mode(cd_2000),
+        left_join(d_muni, by = "GEOID") %>%
+        left_join(d_cd, by = "GEOID") %>%
+        left_join(read_baf_cd113("HI") %>% rename(GEOID = BLOCKID), by = "GEOID") %>%
+        #left_join(d_vtd, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_2000, cd_2010, .after = county)
+
+    # group from block-level to tract-level
+    hi_shp <- hi_shp %>%
+        mutate(
+            vtd = paste0(
+                str_sub(GEOID, 1, 2),
+                COUNTYFP,
+                str_pad(vtd, 6, side = "left", pad = "0")
+            )
+        ) %>%
+        group_by(vtd) %>%
+        summarize(
+            cd_2000 = Mode(cd_2000),
             cd_2010 = Mode(cd_2010),
             muni = Mode(muni),
-            state = unique(state),
+            state = censable::match_abb(unique(state)),
             county = unique(county),
             across(where(is.numeric), sum)
         )
@@ -97,20 +88,16 @@ if (!file.exists(here(shp_path))) {
 
     island_codes <- tribble(
         ~v1, ~v2,
-        "15001021800", "15009030100",
-        "15009030303", "15003980000",
-        "15009031503", "15009031601",
-        "15009031601", "15009031700",
-        "15009031801", "15003000110",
-        "15003009904", "15007040500",
-        "15007040900", "15007041200",
-        "15007041200", "15003981200"
+        "15001ZZZZZZ", "15003ZZZZZZ",
+        "15007ZZZZZZ", "15003ZZZZZZ",
+        "15009ZZZZZZ", "15003ZZZZZZ"
     )
 
-    island_codes$v1 <- which(hi_shp$tract %in% island_codes$v1)[order(na.omit(match(hi_shp$tract, island_codes$v1)))]
-    island_codes$v2 <- which(hi_shp$tract %in% island_codes$v2)[order(na.omit(match(hi_shp$tract, island_codes$v2)))]
+    island_codes$v1 <- match(island_codes$v1, hi_shp$vtd)
+    island_codes$v2 <- match(island_codes$v2, hi_shp$vtd)
 
-    hi_shp$adj <- hi_shp$adj %>% add_edge(island_codes$v1, island_codes$v2, zero = TRUE)
+    hi_shp$adj <- hi_shp$adj %>%
+        add_edge(island_codes$v1, island_codes$v2, zero = TRUE)
 
     hi_shp <- hi_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/HI_cd_2010/01_prep_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/01_prep_HI_cd_2010.R
@@ -46,7 +46,7 @@ if (!file.exists(here(shp_path))) {
         left_join(d_muni, by = "GEOID") %>%
         left_join(d_cd, by = "GEOID") %>%
         left_join(read_baf_cd113("HI") %>% rename(GEOID = BLOCKID), by = "GEOID") %>%
-        #left_join(d_vtd, by = "GEOID") %>%
+        # left_join(d_vtd, by = "GEOID") %>%
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_2000, cd_2010, .after = county)
 

--- a/analyses/HI_cd_2010/02_setup_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/02_setup_HI_cd_2010.R
@@ -7,9 +7,8 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg HI_cd_2010}")
 map <- redist_map(hi_shp, pop_tol = 0.005,
     existing_plan = cd_2010, adj = hi_shp$adj)
 
-# Create sub-map for Honolulu County (excluding its Northwestern Hawaiian Islands)
+# Create sub-map for Honolulu County
 map_honolulu <- map %>%
-    slice(-291) %>%
     filter(county == "003") %>%
     `attr<-`("pop_bounds", attr(map, "pop_bounds"))
 

--- a/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
@@ -16,7 +16,7 @@ plans_honolulu <- redist_smc(
 )
 
 plans <- matrix(data = 0, nrow = nrow(map), ncol = 5001)
-plans[map$tract %in% map_honolulu$tract, ] <- get_plans_matrix(plans_honolulu)
+plans[map$vtd %in% map_honolulu$vtd, ] <- get_plans_matrix(plans_honolulu)
 plans[plans == 0] <- 2
 
 plans <- redist_plans(

--- a/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
+++ b/analyses/HI_cd_2010/03_sim_HI_cd_2010.R
@@ -16,7 +16,7 @@ plans_honolulu <- redist_smc(
 )
 
 plans <- matrix(data = 0, nrow = nrow(map), ncol = 5001)
-plans[map$vtd %in% map_honolulu$vtd, ] <- get_plans_matrix(plans_honolulu)
+plans[map$GEOID %in% map_honolulu$GEOID, ] <- get_plans_matrix(plans_honolulu)
 plans[plans == 0] <- 2
 
 plans <- redist_plans(

--- a/analyses/HI_cd_2010/doc_HI_cd_2010.md
+++ b/analyses/HI_cd_2010/doc_HI_cd_2010.md
@@ -1,7 +1,7 @@
 # 2010 Hawaii Congressional Districts
 
 ## Redistricting requirements
-Per Hawaii Revised Statutes 25-2(b)(1)-(4) and (6), [as in force for the 2010 cycle](https://www.ncsl.org/Portals/1/Documents/Redistricting/Redistricting_2010.pdf), districts must:
+Per Hawaii Revised Statutes 25-2(b)(1)-(4) and (6), [as in force for the 2010 cycle](https://law.justia.com/codes/hawaii/2011/division1/title3/chapter25/25-2/), districts must:
 
 1\. not unduly favor any person or party;
 


### PR DESCRIPTION
## Redistricting requirements
Per Hawaii Revised Statutes 25-2(b)(1)-(4) and (6), [as in force for the 2010 cycle](https://www.ncsl.org/Portals/1/Documents/Redistricting/Redistricting_2010.pdf), districts must:

1\. not unduly favor any person or party;

2\. be contiguous, except when encompassing more than one island;

3\. be compact;

4\. where possible, follow geographical and recognized features and coincide with tract boundaries;

6\. where practicable, avoid mixing regions with different socioeconomic interests.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use Census tracts in line with 25-2(b)(4). In absence of regional knowledge about features and socioeconomic interests, we use municipalities to attempt to enforce 25-2(b)(4) and (6).

## Data Sources
Data for Hawaii comes from the ALARM Project's [2010 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Islands are manually connected in the adjacency graph, but this has no bearing on the simulation.

## Simulation Notes
We sample 5,000 districting plans for Hawaii over 2 independent runs of the SMC algorithm. We use partial SMC to draw one district in the contiguous portion of Honolulu County and assign the remainder to district 2.

## Validation

![validation_20240515_2244](https://github.com/alarm-redist/fifty-states/assets/28026893/078de7a3-f961-459c-a0be-c37baf630ab1)

```
SMC: 5,000 sampled plans of 2 districts on 344 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.23 to 0.67
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
   pop_overlap      total_vap       plan_dev      comp_edge    comp_polsby      pop_white 
         1.000          1.000          1.001          1.000          1.000          1.000 
      pop_aian      pop_other       pop_nhpi        pop_two      pop_black       pop_hisp 
         1.000          1.002          1.001          1.000          1.000          1.000 
     pop_asian        vap_two      vap_other       vap_nhpi      vap_asian       vap_hisp 
         1.001          1.001          1.002          1.001          1.000          1.000 
     vap_black      vap_white       vap_aian pre_20_dem_bid pre_16_dem_cli gov_18_rep_tup 
         1.000          1.001          1.000          1.000          1.000          1.000 
uss_16_dem_sch uss_16_rep_car gov_18_dem_ige pre_20_rep_tru uss_18_rep_cur pre_16_rep_tru 
         1.000          1.000          1.000          1.000          1.000          1.000 
uss_18_dem_hir         arv_20         adv_16         adv_18         arv_18         adv_20 
         1.000          1.000          1.000          1.000          1.000          1.000 
        arv_16    muni_splits            ndv            nrv        ndshare          e_dvs 
         1.000          1.001          1.000          1.000          1.000          1.000 
          egap 
         1.000 

Sampling diagnostics for SMC run 1 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,460 (98.4%)      9.6%        0.25 1,556 ( 98%)      5 
Resample    2,344 (93.8%)       NA%        0.25 2,242 (142%)     NA 

Sampling diagnostics for SMC run 2 of 2 (2,500 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,462 (98.5%)      8.4%        0.25 1,597 (101%)      6 
Resample    2,351 (94.0%)       NA%        0.25 2,224 (141%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std.
devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for
summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the
diversity plot with `hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing
constraints, or increasing the population tolerance. If the acceptance rate drops quickly in the
final splits, try increasing `pop_temper` by 0.01.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan

# Additional notes

- Low # of districts and precincts + keeping main island together results in low diversity
