### PR TITLE
2000 Nevada Congressional Districts

### DIFF
--- a/analyses/NV_cd_2000/01_prep_2000_NV_cd_2000.R
+++ b/analyses/NV_cd_2000/01_prep_2000_NV_cd_2000.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Download and prepare data for `NV_cd_2000` analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NV_cd_2000}")
+
+path_data <- download_redistricting_file("NV", "data-raw/NV", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NV_2000/shp_vtd.rds"
+perim_path <- "data-out/NV_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NV} shapefile")
+    # read in redistricting data
+    nv_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$NV)
+
+    nv_shp <- nv_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nv_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nv_shp <- rmapshaper::ms_simplify(nv_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nv_shp$adj <- redist.adjacency(nv_shp)
+
+    nv_shp <- nv_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nv_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nv_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NV} shapefile")
+}

--- a/analyses/NV_cd_2000/02_setup_NV_cd_2000.R
+++ b/analyses/NV_cd_2000/02_setup_NV_cd_2000.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `NV_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NV_cd_2000}")
+
+map <- redist_map(nv_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = nv_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NV_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NV_2000/NV_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NV_cd_2000/03_sim_NV_cd_2000.R
+++ b/analyses/NV_cd_2000/03_sim_NV_cd_2000.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `NV_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NV_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NV_2000/NV_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NV_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NV_2000/NV_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/NV_cd_2000/doc_NV_cd_2000.md
+++ b/analyses/NV_cd_2000/doc_NV_cd_2000.md
@@ -1,13 +1,10 @@
 # 2000 Nevada Congressional Districts
 
 ## Redistricting requirements
-In Nevada, districts must:
+In Nevada,according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
 
 1. be contiguous
 1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.

--- a/analyses/NV_cd_2000/doc_NV_cd_2000.md
+++ b/analyses/NV_cd_2000/doc_NV_cd_2000.md
@@ -1,0 +1,23 @@
+# 2000 Nevada Congressional Districts
+
+## Redistricting requirements
+In Nevada, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Nevada comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Nevada.
+No special techniques were needed to produce the sample.

--- a/analyses/NV_cd_2000/doc_NV_cd_2000.md
+++ b/analyses/NV_cd_2000/doc_NV_cd_2000.md
@@ -10,7 +10,7 @@ In Nevada, districts must:
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Nevada comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).


### PR DESCRIPTION
## Redistricting requirements
In Nevada, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Nevada comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Nevada.
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="4500" alt="validation_20250730_2238" src="https://github.com/user-attachments/assets/006365ef-7944-4f1a-9add-448da7d422db" />

```
SMC: 5,000 sampled plans of 3 districts on 1,291 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.42 to 0.61

R-hat values for summary statistics:
pop_overlap   total_vap    plan_dev   comp_edge comp_polsby    pop_hisp   pop_white     pop_two   pop_other    pop_nhpi    pop_aian   pop_asian 
      1.001       1.000       1.002       1.001       1.002       1.000       1.001       1.002       1.002       1.002       1.001       1.001 
  pop_black     vap_two   vap_other    vap_nhpi    vap_hisp   vap_black   vap_asian   vap_white    vap_aian muni_splits         ndv         nrv 
      1.001       1.003       1.002       1.002       1.001       1.001       1.001       1.000       1.001       1.001       1.001       1.001 
    ndshare 
      1.001 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,851 (92.5%)      5.2%        0.52 1,268 (100%)      8 
Split 2     1,784 (89.2%)      3.1%        0.60 1,038 ( 82%)      5 
Resample    1,173 (58.6%)       NA%        0.60 1,455 (115%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,848 (92.4%)      6.9%        0.53 1,268 (100%)      6 
Split 2     1,822 (91.1%)      3.9%        0.56 1,027 ( 81%)      4 
Resample    1,342 (67.1%)       NA%        0.56 1,480 (117%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,848 (92.4%)      6.9%        0.52 1,264 (100%)      6 
Split 2     1,791 (89.6%)      3.7%        0.60 1,012 ( 80%)      4 
Resample    1,208 (60.4%)       NA%        0.60 1,454 (115%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,847 (92.4%)      7.0%        0.53 1,245 ( 98%)      6 
Split 2     1,831 (91.5%)      3.0%        0.56 1,046 ( 83%)      5 
Resample    1,364 (68.2%)       NA%        0.56 1,495 (118%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,844 (92.2%)      5.8%        0.53 1,256 ( 99%)      7 
Split 2     1,781 (89.1%)      3.9%        0.60 1,016 ( 80%)      4 
Resample    1,090 (54.5%)       NA%        0.60 1,467 (116%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko
