### PR TITLE
2000 Tennessee Congressional Districts

### DIFF
--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -59,8 +59,8 @@ if (!file.exists(here(shp_path))) {
 
     # TODO any custom adjacency graph edits here
 
-    tn_shp <- tn_shp %>%
-        fix_geo_assignment(muni)
+    #tn_shp <- tn_shp %>%
+    #    fix_geo_assignment(muni)
 
     write_rds(tn_shp, here(shp_path), compress = "gz")
     cli_process_done()

--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -1,0 +1,70 @@
+###############################################################################
+# Download and prepare data for `TN_cd_2000` analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg TN_cd_2000}")
+
+path_data <- download_redistricting_file("TN", "data-raw/TN", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/TN_2000/shp_vtd.rds"
+perim_path <- "data-out/TN_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong TN} shapefile")
+    # read in redistricting data
+    tn_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        # TODO: If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$TN)
+
+    tn_shp <- tn_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = tn_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    tn_shp$adj <- redist.adjacency(tn_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    tn_shp <- tn_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(tn_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    tn_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong TN} shapefile")
+}

--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -18,7 +18,7 @@ suppressMessages({
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg TN_cd_2000}")
 
-path_data <- download_redistricting_file("TN", "data-raw/TN", year = 2000)
+path_data <- download_redistricting_file("TN", "data-raw/TN", year = 2000, overwrite = TRUE)
 
 cli_process_done()
 
@@ -59,8 +59,8 @@ if (!file.exists(here(shp_path))) {
 
     # TODO any custom adjacency graph edits here
 
-    # tn_shp <- tn_shp %>%
-    #    fix_geo_assignment(muni)
+    tn_shp <- tn_shp %>%
+        fix_geo_assignment(muni)
 
     write_rds(tn_shp, here(shp_path), compress = "gz")
     cli_process_done()

--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -30,7 +30,6 @@ if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong TN} shapefile")
     # read in redistricting data
     tn_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
-        # TODO: If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
         join_vtd_shapefile(year = 2000) %>%
         st_transform(EPSG$TN)
 

--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -43,14 +43,14 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = tn_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
@@ -59,7 +59,7 @@ if (!file.exists(here(shp_path))) {
 
     # TODO any custom adjacency graph edits here
 
-    #tn_shp <- tn_shp %>%
+    # tn_shp <- tn_shp %>%
     #    fix_geo_assignment(muni)
 
     write_rds(tn_shp, here(shp_path), compress = "gz")

--- a/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_2000_TN_cd_2000.R
@@ -39,15 +39,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = tn_shp,
         perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
             keep_shapes = TRUE) %>%
@@ -56,8 +53,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     tn_shp$adj <- redist.adjacency(tn_shp)
-
-    # TODO any custom adjacency graph edits here
 
     tn_shp <- tn_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
@@ -15,7 +15,7 @@ map <- redist_map(tn_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
@@ -4,14 +4,10 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(tn_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = tn_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `TN_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(tn_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = tn_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "TN_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/TN_2000/TN_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
@@ -49,4 +49,116 @@ if (interactive()) {
 
     validate_analysis(plans, map)
     summary(plans)
+
+    # Black VAP Performance Plot
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+      scale_y_continuous("Percent Black by VAP") +
+      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      scale_color_manual(values = c(cd_2020_prop = "black")) +
+      theme_bw()
+
+    # Minority VAP Performance Plot
+    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+      scale_y_continuous("Minority Percentage by VAP") +
+      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      scale_color_manual(values = c(cd_2020_prop = "black")) +
+      theme_bw()
+
+    # Dem seats by BVAP rank -- numeric
+    plans %>%
+      group_by(draw) %>%
+      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+      subset_sampled() %>%
+      select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+      mutate(dem = ndv > nrv) %>%
+      group_by(bvap_rank) %>%
+      summarize(dem = mean(dem))
+
+    # Dem seats by Minority VAP rank -- numeric
+    plans %>%
+      group_by(draw) %>%
+      mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
+      subset_sampled() %>%
+      select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
+      mutate(dem = ndv > nrv) %>%
+      group_by(tmvap_rank) %>%
+      summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans %>%
+      subset_sampled() %>%
+      group_by(draw) %>%
+      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
+      count(n_black_perf)
+
+    # Total Minority districts that are performing
+    plans %>%
+      subset_sampled() %>%
+      group_by(draw) %>%
+      summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
+      count(n_minority_perf)
+
+    # democratic vote
+    plans <- plans %>%
+      mutate(Compactness = distr_compactness(map),
+             `Population deviation` = plan_parity(map),
+             `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
+    plot(plans, `Democratic vote`, size = 0.5, color_thresh = 0.5) +
+      scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
+      labs(title = "Democratic vote share by district")
+
+    # majority minority districts
+    plans <- plans %>%
+      mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
+    majminavgs <- avg_by_prec(plans, majmin, draws = NA)
+    redist.plot.map(
+      tn_shp,
+      adj = redist.adjacency(tn_shp, plan),
+      plan = NULL,
+      fill = majminavgs,
+      fill_label = "",
+      zoom_to = NULL,
+      title = ""
+    )
+
+    # majority black districts
+    plans <- plans %>%
+      mutate(bvappct = vap_black/total_vap)
+    blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
+    redist.plot.map(
+      tn_shp,
+      adj = redist.adjacency(tn_shp, plan),
+      plan = NULL,
+      fill = blackavgs,
+      fill_label = "",
+      zoom_to = NULL,
+      title = ""
+    )
+
+    # this section does not work
+    plot(plans, (total_vap - vap_white)/total_vap, sort = FALSE, size = 0.5)
+
+    pal <- scales::viridis_pal()(5)[-1]
+    redist.plot.scatter(plans, pct_min, pct_dem,
+                        color = pal[subset_sampled(plans)$district]) +
+      scale_color_manual(values = "black")
+
+    avg_by_prec(plans, x, draws = NA)
+    show(plans)
+
+    redist.plot.distr_qtys(
+      plans,
+      qty = total_vap,
+      sort = "asc",
+      geom = "jitter",
+      color_thresh = NULL,
+      size = 0.1,
+      ref_label = total_vap
+    )
 }

--- a/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `TN_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg TN_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/TN_2000/TN_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg TN_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/TN_2000/TN_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
@@ -6,9 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg TN_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
 #  `pop_temper=0.01` and nudging upward from there. Monitor the output for
 #  efficiency!
@@ -31,8 +28,6 @@ plans <- match_numbers(plans, "cd_2000")
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/TN_2000/TN_cd_2000_plans.rds"), compress = "xz")
 cli_process_done()
@@ -48,7 +43,6 @@ save_summary_stats(plans, "data-out/TN_2000/TN_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
@@ -52,93 +52,93 @@ if (interactive()) {
 
     # Black VAP Performance Plot
     redist.plot.distr_qtys(plans, vap_black/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
-      scale_y_continuous("Percent Black by VAP") +
-      labs(title = "Tennessee Proposed Plan versus Simulations") +
-      scale_color_manual(values = c(cd_2020_prop = "black")) +
-      theme_bw()
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Tennessee Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
 
     # Minority VAP Performance Plot
     redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
-      scale_y_continuous("Minority Percentage by VAP") +
-      labs(title = "Tennessee Proposed Plan versus Simulations") +
-      scale_color_manual(values = c(cd_2020_prop = "black")) +
-      theme_bw()
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Minority Percentage by VAP") +
+        labs(title = "Tennessee Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
 
     # Dem seats by BVAP rank -- numeric
     plans %>%
-      group_by(draw) %>%
-      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
-      subset_sampled() %>%
-      select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
-      mutate(dem = ndv > nrv) %>%
-      group_by(bvap_rank) %>%
-      summarize(dem = mean(dem))
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
 
     # Dem seats by Minority VAP rank -- numeric
     plans %>%
-      group_by(draw) %>%
-      mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
-      subset_sampled() %>%
-      select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
-      mutate(dem = ndv > nrv) %>%
-      group_by(tmvap_rank) %>%
-      summarize(dem = mean(dem))
+        group_by(draw) %>%
+        mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(tmvap_rank) %>%
+        summarize(dem = mean(dem))
 
     # Total Black districts that are performing
     plans %>%
-      subset_sampled() %>%
-      group_by(draw) %>%
-      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
-      count(n_black_perf)
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
+        count(n_black_perf)
 
     # Total Minority districts that are performing
     plans %>%
-      subset_sampled() %>%
-      group_by(draw) %>%
-      summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
-      count(n_minority_perf)
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
+        count(n_minority_perf)
 
     # democratic vote
     plans <- plans %>%
-      mutate(Compactness = distr_compactness(map),
-             `Population deviation` = plan_parity(map),
-             `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
+        mutate(Compactness = distr_compactness(map),
+            `Population deviation` = plan_parity(map),
+            `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
     plot(plans, `Democratic vote`, size = 0.5, color_thresh = 0.5) +
-      scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
-      labs(title = "Democratic vote share by district")
+        scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
+        labs(title = "Democratic vote share by district")
 
     # majority minority districts
     plans <- plans %>%
-      mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
+        mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
     majminavgs <- avg_by_prec(plans, majmin, draws = NA)
     redist.plot.map(
-      tn_shp,
-      adj = redist.adjacency(tn_shp, plan),
-      plan = NULL,
-      fill = majminavgs,
-      fill_label = "",
-      zoom_to = NULL,
-      title = ""
+        tn_shp,
+        adj = redist.adjacency(tn_shp, plan),
+        plan = NULL,
+        fill = majminavgs,
+        fill_label = "",
+        zoom_to = NULL,
+        title = ""
     )
 
     # majority black districts
     plans <- plans %>%
-      mutate(bvappct = vap_black/total_vap)
+        mutate(bvappct = vap_black/total_vap)
     blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
     redist.plot.map(
-      tn_shp,
-      adj = redist.adjacency(tn_shp, plan),
-      plan = NULL,
-      fill = blackavgs,
-      fill_label = "",
-      zoom_to = NULL,
-      title = ""
+        tn_shp,
+        adj = redist.adjacency(tn_shp, plan),
+        plan = NULL,
+        fill = blackavgs,
+        fill_label = "",
+        zoom_to = NULL,
+        title = ""
     )
 
     # this section does not work
@@ -146,19 +146,19 @@ if (interactive()) {
 
     pal <- scales::viridis_pal()(5)[-1]
     redist.plot.scatter(plans, pct_min, pct_dem,
-                        color = pal[subset_sampled(plans)$district]) +
-      scale_color_manual(values = "black")
+        color = pal[subset_sampled(plans)$district]) +
+        scale_color_manual(values = "black")
 
     avg_by_prec(plans, x, draws = NA)
     show(plans)
 
     redist.plot.distr_qtys(
-      plans,
-      qty = total_vap,
-      sort = "asc",
-      geom = "jitter",
-      color_thresh = NULL,
-      size = 0.1,
-      ref_label = total_vap
+        plans,
+        qty = total_vap,
+        sort = "asc",
+        geom = "jitter",
+        color_thresh = NULL,
+        size = 0.1,
+        ref_label = total_vap
     )
 }

--- a/analyses/TN_cd_2000/doc_TN_cd_2000.md
+++ b/analyses/TN_cd_2000/doc_TN_cd_2000.md
@@ -10,7 +10,7 @@ In Tennessee, districts must:
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.05%.
 
 ## Data Sources
 Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/TN_cd_2000/doc_TN_cd_2000.md
+++ b/analyses/TN_cd_2000/doc_TN_cd_2000.md
@@ -1,0 +1,23 @@
+# 2000 Tennessee Congressional Districts
+
+## Redistricting requirements
+In Tennessee, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 5,000 districting plans for Tennessee.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Tennessee, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.05%.

## Data Sources
Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 5,000 districting plans for Tennessee.
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/9ce6544b-efde-4774-8b2f-6ef42d2ab886" />

```
SMC: 5,000 sampled plans of 9 districts on 2,407 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing TN shapefile
Plan diversity 80% range: 0.57 to 0.81
ℹ Preparing TN shapefile
R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby 
        1.006         1.016         1.010         1.004         1.004 
    pop_other       pop_two      pop_aian     pop_white      pop_hisp 
        1.012         1.021         1.003         1.012         1.014 
    pop_asian      pop_nhpi     pop_black      vap_hisp      vap_aian 
        1.011         1.008         1.022         1.014         1.004 
    vap_asian     vap_white     vap_black     vap_other       vap_two 
        1.010         1.015         1.022         1.012         1.022 
     vap_nhpi county_splits   muni_splits           ndv           nrv 
        1.014         1.014         1.006         1.018         1.020 
      ndshare 
        1.013 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,903 (95.1%)     10.9%        0.45 1,280 (101%)     10 
Split 2     1,889 (94.5%)     14.2%        0.51 1,278 (101%)      7 
Split 3     1,882 (94.1%)     18.3%        0.51 1,253 ( 99%)      5 
Split 4     1,860 (93.0%)     20.5%        0.54 1,226 ( 97%)      4 
Split 5     1,814 (90.7%)     22.7%        0.60 1,214 ( 96%)      3 
Split 6     1,783 (89.2%)     20.5%        0.70 1,248 ( 99%)      3 
Split 7     1,775 (88.7%)     12.5%        0.80 1,162 ( 92%)      4 
Split 8     1,770 (88.5%)      5.2%        0.81 1,056 ( 84%)      3 
Resample    1,224 (61.2%)       NA%        0.68 1,454 (115%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,905 (95.2%)     13.8%        0.45 1,247 ( 99%)      8 
Split 2     1,886 (94.3%)     16.7%        0.51 1,256 ( 99%)      6 
Split 3     1,874 (93.7%)     18.5%        0.52 1,231 ( 97%)      5 
Split 4     1,845 (92.2%)     20.3%        0.55 1,221 ( 97%)      4 
Split 5     1,840 (92.0%)     23.8%        0.59 1,207 ( 95%)      3 
Split 6     1,828 (91.4%)     21.3%        0.69 1,228 ( 97%)      3 
Split 7     1,799 (89.9%)     21.0%        0.79 1,182 ( 93%)      2 
Split 8     1,808 (90.4%)      6.9%        0.78 1,074 ( 85%)      2 
Resample    1,334 (66.7%)       NA%        0.62 1,493 (118%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,904 (95.2%)     12.0%        0.45 1,267 (100%)      9 
Split 2     1,895 (94.7%)     14.7%        0.50 1,272 (101%)      7 
Split 3     1,868 (93.4%)     13.2%        0.54 1,227 ( 97%)      7 
Split 4     1,848 (92.4%)     20.3%        0.54 1,225 ( 97%)      4 
Split 5     1,817 (90.9%)     17.8%        0.61 1,231 ( 97%)      4 
Split 6     1,781 (89.1%)     20.6%        0.69 1,189 ( 94%)      3 
Split 7     1,768 (88.4%)     16.6%        0.81 1,173 ( 93%)      3 
Split 8     1,808 (90.4%)      7.2%        0.79 1,033 ( 82%)      2 
Resample    1,375 (68.7%)       NA%        0.64 1,468 (116%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,899 (95.0%)     10.7%        0.46 1,267 (100%)     10 
Split 2     1,896 (94.8%)     14.5%        0.49 1,229 ( 97%)      7 
Split 3     1,875 (93.7%)     21.9%        0.51 1,241 ( 98%)      4 
Split 4     1,860 (93.0%)     20.7%        0.54 1,242 ( 98%)      4 
Split 5     1,845 (92.2%)     23.3%        0.60 1,228 ( 97%)      3 
Split 6     1,823 (91.1%)     26.9%        0.68 1,233 ( 98%)      2 
Split 7     1,813 (90.6%)     15.3%        0.78 1,178 ( 93%)      3 
Split 8     1,800 (90.0%)      6.8%        0.80 1,042 ( 82%)      2 
Resample    1,323 (66.1%)       NA%        0.64 1,492 (118%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,906 (95.3%)     11.9%        0.45 1,249 ( 99%)      9 
Split 2     1,900 (95.0%)     16.2%        0.49 1,247 ( 99%)      6 
Split 3     1,869 (93.5%)     14.7%        0.52 1,234 ( 98%)      6 
Split 4     1,836 (91.8%)     20.4%        0.54 1,217 ( 96%)      4 
Split 5     1,840 (92.0%)     18.6%        0.59 1,208 ( 96%)      4 
Split 6     1,820 (91.0%)     16.1%        0.69 1,228 ( 97%)      4 
Split 7     1,779 (88.9%)     16.2%        0.81 1,173 ( 93%)      3 
Split 8     1,796 (89.8%)      7.6%        0.82 1,065 ( 84%)      2 
Resample    1,226 (61.3%)       NA%        0.63 1,492 (118%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
