### PR TITLE
2000 Oregon Congressional Districts

### DIFF
--- a/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
@@ -38,15 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = or_shp,
                                perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%

--- a/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
@@ -40,13 +40,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = or_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/01_prep_2000_OR_cd_2000.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Download and prepare data for `OR_cd_2000` analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OR_cd_2000}")
+
+path_data <- download_redistricting_file("OR", "data-raw/OR", year = 2000, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OR_2000/shp_vtd.rds"
+perim_path <- "data-out/OR_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong OR} shapefile")
+    # read in redistricting data
+    or_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$OR)
+
+    or_shp <- or_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = or_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    or_shp$adj <- redist.adjacency(or_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    or_shp <- or_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(or_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    or_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong OR} shapefile")
+}

--- a/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
@@ -4,14 +4,9 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(or_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = or_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
@@ -10,7 +10,7 @@ map <- redist_map(or_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `OR_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(or_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = or_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OR_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OR_2000/OR_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -48,7 +48,6 @@ save_summary_stats(plans, "data-out/OR_2000/OR_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)
@@ -62,7 +61,7 @@ if (interactive()) {
                            color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
                            size = 0.5, alpha = 0.5) +
       scale_y_continuous("Percent Black by VAP") +
-      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      labs(title = "Oregon Proposed Plan versus Simulations") +
       scale_color_manual(values = c(cd_2020_prop = "black")) +
       theme_bw()
 
@@ -72,7 +71,7 @@ if (interactive()) {
                            color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
                            size = 0.5, alpha = 0.5) +
       scale_y_continuous("Minority Percentage by VAP") +
-      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      labs(title = "Oregon Proposed Plan versus Simulations") +
       scale_color_manual(values = c(cd_2020_prop = "black")) +
       theme_bw()
 
@@ -124,8 +123,8 @@ if (interactive()) {
       mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
     majminavgs <- avg_by_prec(plans, majmin, draws = NA)
     redist.plot.map(
-      sc_shp,
-      adj = redist.adjacency(sc_shp, plan),
+      or_shp,
+      adj = redist.adjacency(or_shp, plan),
       plan = NULL,
       fill = majminavgs,
       fill_label = "",
@@ -138,8 +137,8 @@ if (interactive()) {
       mutate(bvappct = vap_black/total_vap)
     blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
     redist.plot.map(
-      sc_shp,
-      adj = redist.adjacency(sc_shp, plan),
+      or_shp,
+      adj = redist.adjacency(or_shp, plan),
       plan = NULL,
       fill = blackavgs,
       fill_label = "",

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -6,17 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
 plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -18,7 +18,7 @@ cli_process_start("Running simulations for {.pkg OR_cd_2000}")
 #  if that's the problem.
 #  - Ask for help!
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -46,93 +46,93 @@ if (interactive()) {
 
     # Black VAP Performance Plot
     redist.plot.distr_qtys(plans, vap_black/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
-      scale_y_continuous("Percent Black by VAP") +
-      labs(title = "Oregon Proposed Plan versus Simulations") +
-      scale_color_manual(values = c(cd_2020_prop = "black")) +
-      theme_bw()
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Oregon Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
 
     # Minority VAP Performance Plot
     redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-                           color_thresh = NULL,
-                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                           size = 0.5, alpha = 0.5) +
-      scale_y_continuous("Minority Percentage by VAP") +
-      labs(title = "Oregon Proposed Plan versus Simulations") +
-      scale_color_manual(values = c(cd_2020_prop = "black")) +
-      theme_bw()
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Minority Percentage by VAP") +
+        labs(title = "Oregon Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2020_prop = "black")) +
+        theme_bw()
 
     # Dem seats by BVAP rank -- numeric
     plans %>%
-      group_by(draw) %>%
-      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
-      subset_sampled() %>%
-      select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
-      mutate(dem = ndv > nrv) %>%
-      group_by(bvap_rank) %>%
-      summarize(dem = mean(dem))
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
 
     # Dem seats by Minority VAP rank -- numeric
     plans %>%
-      group_by(draw) %>%
-      mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
-      subset_sampled() %>%
-      select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
-      mutate(dem = ndv > nrv) %>%
-      group_by(tmvap_rank) %>%
-      summarize(dem = mean(dem))
+        group_by(draw) %>%
+        mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(tmvap_rank) %>%
+        summarize(dem = mean(dem))
 
     # Total Black districts that are performing
     plans %>%
-      subset_sampled() %>%
-      group_by(draw) %>%
-      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
-      count(n_black_perf)
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
+        count(n_black_perf)
 
     # Total Minority districts that are performing
     plans %>%
-      subset_sampled() %>%
-      group_by(draw) %>%
-      summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
-      count(n_minority_perf)
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
+        count(n_minority_perf)
 
     # democratic vote
     plans <- plans %>%
-      mutate(Compactness = distr_compactness(map),
-             `Population deviation` = plan_parity(map),
-             `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
+        mutate(Compactness = distr_compactness(map),
+            `Population deviation` = plan_parity(map),
+            `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
     plot(plans, `Democratic vote`, size = 0.5, color_thresh = 0.5) +
-      scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
-      labs(title = "Democratic vote share by district")
+        scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
+        labs(title = "Democratic vote share by district")
 
     # majority minority districts
     plans <- plans %>%
-      mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
+        mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
     majminavgs <- avg_by_prec(plans, majmin, draws = NA)
     redist.plot.map(
-      or_shp,
-      adj = redist.adjacency(or_shp, plan),
-      plan = NULL,
-      fill = majminavgs,
-      fill_label = "",
-      zoom_to = NULL,
-      title = ""
+        or_shp,
+        adj = redist.adjacency(or_shp, plan),
+        plan = NULL,
+        fill = majminavgs,
+        fill_label = "",
+        zoom_to = NULL,
+        title = ""
     )
 
     # majority black districts
     plans <- plans %>%
-      mutate(bvappct = vap_black/total_vap)
+        mutate(bvappct = vap_black/total_vap)
     blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
     redist.plot.map(
-      or_shp,
-      adj = redist.adjacency(or_shp, plan),
-      plan = NULL,
-      fill = blackavgs,
-      fill_label = "",
-      zoom_to = NULL,
-      title = ""
+        or_shp,
+        adj = redist.adjacency(or_shp, plan),
+        plan = NULL,
+        fill = blackavgs,
+        fill_label = "",
+        zoom_to = NULL,
+        title = ""
     )
 
     # this section does not work
@@ -140,19 +140,19 @@ if (interactive()) {
 
     pal <- scales::viridis_pal()(5)[-1]
     redist.plot.scatter(plans, pct_min, pct_dem,
-                        color = pal[subset_sampled(plans)$district]) +
-      scale_color_manual(values = "black")
+        color = pal[subset_sampled(plans)$district]) +
+        scale_color_manual(values = "black")
 
     avg_by_prec(plans, x, draws = NA)
     show(plans)
 
     redist.plot.distr_qtys(
-      plans,
-      qty = total_vap,
-      sort = "asc",
-      geom = "jitter",
-      color_thresh = NULL,
-      size = 0.1,
-      ref_label = total_vap
+        plans,
+        qty = total_vap,
+        sort = "asc",
+        geom = "jitter",
+        color_thresh = NULL,
+        size = 0.1,
+        ref_label = total_vap
     )
 }

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -1,0 +1,170 @@
+###############################################################################
+# Simulate plans for `OR_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OR_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OR_2000/OR_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OR_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OR_2000/OR_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+
+    # Black VAP Performance Plot
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+      scale_y_continuous("Percent Black by VAP") +
+      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      scale_color_manual(values = c(cd_2020_prop = "black")) +
+      theme_bw()
+
+    # Minority VAP Performance Plot
+    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+      scale_y_continuous("Minority Percentage by VAP") +
+      labs(title = "Tennessee Proposed Plan versus Simulations") +
+      scale_color_manual(values = c(cd_2020_prop = "black")) +
+      theme_bw()
+
+    # Dem seats by BVAP rank -- numeric
+    plans %>%
+      group_by(draw) %>%
+      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+      subset_sampled() %>%
+      select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+      mutate(dem = ndv > nrv) %>%
+      group_by(bvap_rank) %>%
+      summarize(dem = mean(dem))
+
+    # Dem seats by Minority VAP rank -- numeric
+    plans %>%
+      group_by(draw) %>%
+      mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
+      subset_sampled() %>%
+      select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
+      mutate(dem = ndv > nrv) %>%
+      group_by(tmvap_rank) %>%
+      summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans %>%
+      subset_sampled() %>%
+      group_by(draw) %>%
+      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
+      count(n_black_perf)
+
+    # Total Minority districts that are performing
+    plans %>%
+      subset_sampled() %>%
+      group_by(draw) %>%
+      summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
+      count(n_minority_perf)
+
+    # democratic vote
+    plans <- plans %>%
+      mutate(Compactness = distr_compactness(map),
+             `Population deviation` = plan_parity(map),
+             `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
+    plot(plans, `Democratic vote`, size = 0.5, color_thresh = 0.5) +
+      scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
+      labs(title = "Democratic vote share by district")
+
+    # majority minority districts
+    plans <- plans %>%
+      mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
+    majminavgs <- avg_by_prec(plans, majmin, draws = NA)
+    redist.plot.map(
+      sc_shp,
+      adj = redist.adjacency(sc_shp, plan),
+      plan = NULL,
+      fill = majminavgs,
+      fill_label = "",
+      zoom_to = NULL,
+      title = ""
+    )
+
+    # majority black districts
+    plans <- plans %>%
+      mutate(bvappct = vap_black/total_vap)
+    blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
+    redist.plot.map(
+      sc_shp,
+      adj = redist.adjacency(sc_shp, plan),
+      plan = NULL,
+      fill = blackavgs,
+      fill_label = "",
+      zoom_to = NULL,
+      title = ""
+    )
+
+    # this section does not work
+    plot(plans, (total_vap - vap_white)/total_vap, sort = FALSE, size = 0.5)
+
+    pal <- scales::viridis_pal()(5)[-1]
+    redist.plot.scatter(plans, pct_min, pct_dem,
+                        color = pal[subset_sampled(plans)$district]) +
+      scale_color_manual(values = "black")
+
+    avg_by_prec(plans, x, draws = NA)
+    show(plans)
+
+    redist.plot.distr_qtys(
+      plans,
+      qty = total_vap,
+      sort = "asc",
+      geom = "jitter",
+      color_thresh = NULL,
+      size = 0.1,
+      ref_label = total_vap
+    )
+}

--- a/analyses/OR_cd_2000/doc_OR_cd_2000.md
+++ b/analyses/OR_cd_2000/doc_OR_cd_2000.md
@@ -1,12 +1,14 @@
 # 2000 Oregon Congressional Districts
 
 ## Redistricting requirements
-In ``STATE NAME `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+In ``Oregon `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
 
 1. be contiguous
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. not favor any political party or incumbent legislator or individual
+1. not dilute the voting strength of any linguistic or ethnic minority group
 
 
 ### Algorithmic Constraints

--- a/analyses/OR_cd_2000/doc_OR_cd_2000.md
+++ b/analyses/OR_cd_2000/doc_OR_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Oregon Congressional Districts
+
+## Redistricting requirements
+In ``STATE NAME `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Oregon comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Oregon across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In ``Oregon `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not favor any political party or incumbent legislator or individual
1. not dilute the voting strength of any linguistic or ethnic minority group


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Oregon comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for Oregon across 10 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/24907240-b348-43aa-aec6-ef7fdaa1b13d" />

```
SMC: 10,000 sampled plans of 5 districts on 755 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Downloading files for OR_cd_2000
Plan diversity 80% range: 0.35 to 0.76
ℹ Downloading files for OR_cd_2000
R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby      pop_aian 
        1.002         1.003         1.003         1.004         1.003         1.005 
      pop_two     pop_white      pop_hisp     pop_asian      pop_nhpi     pop_other 
        1.003         1.003         1.002         1.002         1.002         1.002 
    pop_black      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.003         1.002         1.004         1.002         1.002         1.002 
    vap_other       vap_two      vap_nhpi county_splits   muni_splits           ndv 
        1.002         1.003         1.001         1.004         1.004         1.001 
          nrv       ndshare 
        1.001         1.001 

Sampling diagnostics for SMC run 1 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,947 (97.4%)     11.2%        0.31 1,249 ( 99%)      5 
Split 2     1,916 (95.8%)     11.2%        0.38 1,212 ( 96%)      4 
Split 3     1,860 (93.0%)     12.2%        0.47 1,219 ( 96%)      3 
Split 4     1,826 (91.3%)      5.9%        0.54 1,087 ( 86%)      2 
Resample    1,261 (63.1%)       NA%        0.53 1,525 (121%)     NA 

Sampling diagnostics for SMC run 2 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,949 (97.4%)      9.2%        0.31 1,260 (100%)      6 
Split 2     1,892 (94.6%)     10.8%        0.41 1,225 ( 97%)      4 
Split 3     1,846 (92.3%)      8.9%        0.50 1,221 ( 97%)      4 
Split 4     1,840 (92.0%)      2.8%        0.55 1,090 ( 86%)      4 
Resample    1,352 (67.6%)       NA%        0.53 1,551 (123%)     NA 

Sampling diagnostics for SMC run 3 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,948 (97.4%)      9.3%        0.31 1,266 (100%)      6 
Split 2     1,903 (95.1%)     11.2%        0.41 1,231 ( 97%)      4 
Split 3     1,876 (93.8%)     11.9%        0.47 1,211 ( 96%)      3 
Split 4     1,857 (92.8%)      5.8%        0.53 1,092 ( 86%)      2 
Resample    1,446 (72.3%)       NA%        0.51 1,558 (123%)     NA 

Sampling diagnostics for SMC run 4 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)      9.3%        0.30 1,273 (101%)      6 
Split 2     1,920 (96.0%)     11.0%        0.37 1,239 ( 98%)      4 
Split 3     1,844 (92.2%)     11.7%        0.50 1,180 ( 93%)      3 
Split 4     1,819 (90.9%)      5.8%        0.57 1,063 ( 84%)      2 
Resample    1,262 (63.1%)       NA%        0.55 1,516 (120%)     NA 

Sampling diagnostics for SMC run 5 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,951 (97.6%)      9.5%        0.30 1,266 (100%)      6 
Split 2     1,909 (95.4%)     10.9%        0.41 1,225 ( 97%)      4 
Split 3     1,882 (94.1%)     11.6%        0.46 1,174 ( 93%)      3 
Split 4     1,856 (92.8%)      6.0%        0.52 1,092 ( 86%)      2 
Resample    1,415 (70.8%)       NA%        0.50 1,581 (125%)     NA 

Sampling diagnostics for SMC run 6 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,947 (97.4%)     11.3%        0.31 1,294 (102%)      5 
Split 2     1,895 (94.7%)     10.9%        0.42 1,197 ( 95%)      4 
Split 3     1,877 (93.9%)     11.2%        0.46 1,198 ( 95%)      3 
Split 4     1,848 (92.4%)      5.6%        0.50 1,119 ( 89%)      2 
Resample    1,355 (67.8%)       NA%        0.51 1,577 (125%)     NA 

Sampling diagnostics for SMC run 7 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)      9.2%        0.30 1,263 (100%)      6 
Split 2     1,905 (95.3%)     11.2%        0.41 1,246 ( 99%)      4 
Split 3     1,869 (93.5%)     11.8%        0.48 1,192 ( 94%)      3 
Split 4     1,853 (92.7%)      5.7%        0.56 1,081 ( 86%)      2 
Resample    1,436 (71.8%)       NA%        0.52 1,550 (123%)     NA 

Sampling diagnostics for SMC run 8 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,951 (97.6%)      8.9%        0.30 1,276 (101%)      6 
Split 2     1,910 (95.5%)     11.0%        0.39 1,198 ( 95%)      4 
Split 3     1,862 (93.1%)     11.8%        0.48 1,216 ( 96%)      3 
Split 4     1,832 (91.6%)      4.0%        0.55 1,069 ( 85%)      3 
Resample    1,317 (65.9%)       NA%        0.53 1,533 (121%)     NA 

Sampling diagnostics for SMC run 9 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)      9.2%        0.31 1,262 (100%)      6 
Split 2     1,916 (95.8%)      8.3%        0.39 1,213 ( 96%)      5 
Split 3     1,870 (93.5%)     11.7%        0.47 1,195 ( 95%)      3 
Split 4     1,837 (91.9%)      5.9%        0.54 1,084 ( 86%)      2 
Resample    1,353 (67.7%)       NA%        0.53 1,522 (120%)     NA 

Sampling diagnostics for SMC run 10 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,951 (97.5%)      8.0%        0.30 1,278 (101%)      7 
Split 2     1,919 (95.9%)      8.8%        0.38 1,217 ( 96%)      5 
Split 3     1,881 (94.0%)     11.7%        0.46 1,213 ( 96%)      3 
Split 4     1,863 (93.2%)      5.7%        0.52 1,092 ( 86%)      2 
Resample    1,460 (73.0%)       NA%        0.50 1,580 (125%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny