### PR TITLE
2000 Indiana Congressional Districts

### DIFF
--- a/analyses/IN_cd_2000/01_prep_IN_cd_2000.R
+++ b/analyses/IN_cd_2000/01_prep_IN_cd_2000.R
@@ -1,0 +1,71 @@
+###############################################################################
+# Download and prepare data for IN_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg IN_cd_2000}")
+path_data <- download_redistricting_file("IN", "data-raw/IN", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/IN_2000/shp_vtd.rds"
+perim_path <- "data-out/IN_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong IN} shapefile")
+  # read in redistricting data
+  in_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$IN)
+  
+  in_shp <- in_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # any additional columns or data you want to add should go here
+  # add a stronger county constraint
+  
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = in_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # TODO feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    in_shp <- rmapshaper::ms_simplify(in_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  in_shp$adj <- redist.adjacency(in_shp)
+  
+  # any custom adjacency graph edits here
+  
+  in_shp <- in_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(in_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  in_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong IN} shapefile")
+}

--- a/analyses/IN_cd_2000/02_setup_IN_cd_2000.R
+++ b/analyses/IN_cd_2000/02_setup_IN_cd_2000.R
@@ -1,0 +1,19 @@
+###############################################################################
+# Set up redistricting simulation for `IN_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg IN_cd_2000}")
+
+# any pre-computation (usually not necessary)
+
+map <- redist_map(in_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = in_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "IN_2000"
+
+map$state <- "IN"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/IN_2000/IN_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/IN_cd_2000/03_sim_IN_cd_2000.R
+++ b/analyses/IN_cd_2000/03_sim_IN_cd_2000.R
@@ -1,0 +1,36 @@
+###############################################################################
+# Simulate plans for `IN_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg IN_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/IN_2000/IN_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg IN_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/IN_2000/IN_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/IN_cd_2000/doc_IN_cd_2000.md
+++ b/analyses/IN_cd_2000/doc_IN_cd_2000.md
@@ -1,0 +1,18 @@
+# 2000 Indiana Congressional Districts
+
+## Redistricting requirements
+In ``Indiana `, there are no state law requirements for congressional districts.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for ``STATE NAME`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for ``Indiana`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In ``Indiana `, there are no state law requirements for congressional districts.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for ``Indiana`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for ``Indiana`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="4500" alt="validation_20250731_0204" src="https://github.com/user-attachments/assets/eada353b-cf32-4ced-b8a0-baf98b535450" />


```
✔ Preparing IN shapefile ... done
SMC: 5,000 sampled plans of 9 districts on 5,034 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0           
ℹ Preparing IN shapefile

Plan diversity 80% range: 0.61 to 0.83
ℹ Preparing IN shapefile

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two 
        1.013         1.017         1.007         1.010         1.003         1.012         1.011 
     pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp 
        1.010         1.008         1.006         1.001         1.012         1.006         1.005 
     vap_aian     vap_asian     vap_white     vap_black      vap_nhpi     vap_other       vap_two 
        1.009         1.002         1.008         1.006         1.010         1.003         1.013 
county_splits           ndv           nrv       ndshare 
        1.003         1.011         1.008         1.006 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,858 (92.9%)     15.0%        0.56 1,263 (100%)     12 
Split 2     1,834 (91.7%)     19.1%        0.59 1,245 ( 98%)      8 
Split 3     1,761 (88.1%)     27.5%        0.68 1,235 ( 98%)      5 
Split 4     1,743 (87.2%)     28.6%        0.70 1,220 ( 97%)      4 
Split 5     1,728 (86.4%)     21.4%        0.73 1,195 ( 95%)      5 
Split 6     1,701 (85.0%)     26.7%        0.74 1,189 ( 94%)      3 
Split 7     1,740 (87.0%)     18.1%        0.71 1,157 ( 92%)      4 
Split 8     1,683 (84.2%)      7.9%        0.77 1,052 ( 83%)      3 
Resample      951 (47.6%)       NA%        0.77 1,356 (107%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,857 (92.9%)     18.0%        0.56 1,283 (101%)     10 
Split 2     1,817 (90.8%)     25.7%        0.61 1,235 ( 98%)      6 
Split 3     1,746 (87.3%)     32.6%        0.68 1,212 ( 96%)      4 
Split 4     1,737 (86.9%)     28.7%        0.70 1,212 ( 96%)      4 
Split 5     1,748 (87.4%)     18.3%        0.72 1,227 ( 97%)      6 
Split 6     1,711 (85.6%)     21.8%        0.71 1,202 ( 95%)      4 
Split 7     1,749 (87.5%)     20.6%        0.70 1,167 ( 92%)      3 
Split 8     1,724 (86.2%)      8.9%        0.72 1,037 ( 82%)      2 
Resample    1,015 (50.7%)       NA%        0.72 1,406 (111%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,866 (93.3%)     14.8%        0.55 1,238 ( 98%)     12 
Split 2     1,842 (92.1%)     17.1%        0.58 1,238 ( 98%)      9 
Split 3     1,760 (88.0%)     22.9%        0.67 1,228 ( 97%)      6 
Split 4     1,682 (84.1%)     24.9%        0.74 1,210 ( 96%)      5 
Split 5     1,668 (83.4%)     25.8%        0.75 1,212 ( 96%)      4 
Split 6     1,716 (85.8%)     21.9%        0.73 1,198 ( 95%)      4 
Split 7     1,749 (87.4%)     20.6%        0.72 1,133 ( 90%)      3 
Split 8     1,692 (84.6%)      7.2%        0.74 1,024 ( 81%)      3 
Resample      962 (48.1%)       NA%        0.74 1,345 (106%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,860 (93.0%)     17.9%        0.57 1,262 (100%)     10 
Split 2     1,837 (91.9%)     20.3%        0.59 1,243 ( 98%)      8 
Split 3     1,777 (88.8%)     27.4%        0.66 1,221 ( 97%)      5 
Split 4     1,745 (87.2%)     28.3%        0.70 1,203 ( 95%)      4 
Split 5     1,758 (87.9%)     15.6%        0.70 1,199 ( 95%)      7 
Split 6     1,751 (87.5%)     13.7%        0.70 1,174 ( 93%)      7 
Split 7     1,744 (87.2%)     14.1%        0.72 1,137 ( 90%)      5 
Split 8     1,688 (84.4%)      5.9%        0.76 1,037 ( 82%)      4 
Resample      925 (46.2%)       NA%        0.76 1,346 (106%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,859 (92.9%)     16.9%        0.56 1,264 (100%)     11 
Split 2     1,848 (92.4%)     20.0%        0.58 1,210 ( 96%)      8 
Split 3     1,758 (87.9%)     19.8%        0.68 1,232 ( 97%)      7 
Split 4     1,752 (87.6%)     28.2%        0.70 1,204 ( 95%)      4 
Split 5     1,787 (89.3%)     25.1%        0.67 1,204 ( 95%)      4 
Split 6     1,767 (88.3%)     26.1%        0.68 1,211 ( 96%)      3 
Split 7     1,712 (85.6%)     25.4%        0.74 1,172 ( 93%)      2 
Split 8     1,600 (80.0%)      3.5%        0.87 1,012 ( 80%)      7 
Resample      844 (42.2%)       NA%        0.87 1,227 ( 97%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
