### PR TITLE
2000 Oklahoma Congressional Districts

### DIFF
--- a/analyses/OK_cd_2000/01_prep_OK_cd_2000.R
+++ b/analyses/OK_cd_2000/01_prep_OK_cd_2000.R
@@ -1,0 +1,71 @@
+###############################################################################
+# Download and prepare data for OK_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OK_cd_2000}")
+path_data <- download_redistricting_file("OK", "data-raw/OK", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OK_2000/shp_vtd.rds"
+perim_path <- "data-out/OK_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong OK} shapefile")
+  # read in redistricting data
+  ok_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$OK)
+  
+  ok_shp <- ok_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # any additional columns or data you want to add should go here
+  # add a stronger county constraint
+  
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = ok_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    ok_shp <- rmapshaper::ms_simplify(ok_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  ok_shp$adj <- redist.adjacency(ok_shp)
+  
+  # any custom adjacency graph edits here
+  
+  ok_shp <- ok_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(ok_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  ok_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong OK} shapefile")
+}

--- a/analyses/OK_cd_2000/02_setup_OK_cd_2000.R
+++ b/analyses/OK_cd_2000/02_setup_OK_cd_2000.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `OK_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OK_cd_2000}")
+
+# any pre-computation (usually not necessary)
+
+map <- redist_map(ok_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = ok_shp$adj)
+
+#Pseudo-County
+map <- map %>%
+  mutate(
+    pseudo_county = pick_county_muni(
+      map,
+      counties = county,   
+      munis    = muni,     
+      pop_muni = get_target(map)
+    )
+  )
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OK_2000"
+
+map$state <- "OK"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OK_2000/OK_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OK_cd_2000/03_sim_OK_cd_2000.R
+++ b/analyses/OK_cd_2000/03_sim_OK_cd_2000.R
@@ -1,0 +1,36 @@
+###############################################################################
+# Simulate plans for `OK_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OK_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OK_2000/OK_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OK_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OK_2000/OK_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/OK_cd_2000/doc_OK_cd_2000.md
+++ b/analyses/OK_cd_2000/doc_OK_cd_2000.md
@@ -1,0 +1,18 @@
+# 2000 Oklahoma Congressional Districts
+
+## Redistricting requirements
+In ``Oklahoma `, there are no state law requirements for congressional districts.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for ``Oklahoma`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for ``Oklahoma`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


### PR DESCRIPTION
## Redistricting requirements
In ``Oklahoma `, there are no state law requirements for congressional districts.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for ``Oklahoma`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for ``Oklahoma`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

## Validation

<img width="3000" height="4500" alt="validation_20250731_0228" src="https://github.com/user-attachments/assets/bd7e5d8d-fe07-4311-8443-7383dc9b9184" />


```
✔ Preparing HI shapefile ... done
SMC: 5,000 sampled plans of 5 districts on 2,108 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0           
ℹ Preparing UT shapefile

Plan diversity 80% range: 0.60 to 0.89
ℹ Preparing UT shapefile

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two 
        1.001         1.003         1.001         1.001         1.000         1.002         1.001 
     pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp 
        1.005         1.003         1.006         1.001         1.004         1.004         1.005 
     vap_aian     vap_asian     vap_white     vap_black      vap_nhpi     vap_other       vap_two 
        1.005         1.001         1.004         1.004         1.003         1.002         1.002 
county_splits   muni_splits           ndv           nrv       ndshare 
        1.002         1.002         1.003         1.003         1.002 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,957 (97.9%)      9.2%        0.29 1,259 (100%)     10 
Split 2     1,921 (96.0%)     14.3%        0.37 1,251 ( 99%)      6 
Split 3     1,876 (93.8%)     18.0%        0.46 1,244 ( 98%)      4 
Split 4     1,818 (90.9%)      7.4%        0.56 1,103 ( 87%)      3 
Resample    1,276 (63.8%)       NA%        0.56 1,522 (120%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,957 (97.9%)      7.6%        0.29 1,273 (101%)     12 
Split 2     1,918 (95.9%)     12.0%        0.38 1,266 (100%)      7 
Split 3     1,870 (93.5%)     18.6%        0.46 1,224 ( 97%)      4 
Split 4     1,824 (91.2%)      7.5%        0.55 1,121 ( 89%)      3 
Resample    1,181 (59.1%)       NA%        0.55 1,534 (121%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,958 (97.9%)     13.0%        0.29 1,244 ( 98%)      7 
Split 2     1,923 (96.2%)     16.7%        0.37 1,240 ( 98%)      5 
Split 3     1,869 (93.4%)     22.9%        0.47 1,214 ( 96%)      3 
Split 4     1,828 (91.4%)     10.2%        0.56 1,084 ( 86%)      2 
Resample    1,331 (66.5%)       NA%        0.56 1,538 (122%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,958 (97.9%)     14.1%        0.29 1,279 (101%)      7 
Split 2     1,917 (95.9%)     16.5%        0.38 1,240 ( 98%)      5 
Split 3     1,876 (93.8%)     22.5%        0.46 1,245 ( 98%)      3 
Split 4     1,836 (91.8%)      7.7%        0.54 1,119 ( 89%)      3 
Resample    1,334 (66.7%)       NA%        0.54 1,541 (122%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,957 (97.8%)     13.5%        0.29 1,286 (102%)      7 
Split 2     1,926 (96.3%)     20.1%        0.37 1,232 ( 97%)      4 
Split 3     1,873 (93.6%)     15.1%        0.47 1,224 ( 97%)      5 
Split 4     1,832 (91.6%)      5.9%        0.54 1,150 ( 91%)      4 
Resample    1,309 (65.5%)       NA%        0.54 1,529 (121%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
