### PR TITLE
2000 Louisiana Congressional Districts

### DIFF
--- a/analyses/LA_cd_2000/01_prep_LA_cd_2000.R
+++ b/analyses/LA_cd_2000/01_prep_LA_cd_2000.R
@@ -1,0 +1,65 @@
+###############################################################################
+# Download and prepare data for LA_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg LA_cd_2000}")
+path_data <- download_redistricting_file("LA", "data-raw/LA", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/LA_2000/shp_vtd.rds"
+perim_path <- "data-out/LA_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong LA} shapefile")
+  # read in redistricting data
+  la_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$LA)
+  
+  la_shp <- la_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = la_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  la_shp$adj <- redist.adjacency(la_shp)
+  
+  la_shp <- la_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(la_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  la_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong LA} shapefile")
+}

--- a/analyses/LA_cd_2000/02_setup_LA_cd_2000.R
+++ b/analyses/LA_cd_2000/02_setup_LA_cd_2000.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `LA_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_2000}")
+
+map <- redist_map(la_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = la_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "LA_2000"
+
+map$state <- "LA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/LA_2000/LA_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/LA_cd_2000/03_sim_LA_cd_2000.R
+++ b/analyses/LA_cd_2000/03_sim_LA_cd_2000.R
@@ -1,0 +1,39 @@
+###############################################################################
+# Simulate plans for `LA_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_cd_2000}")
+
+constr <- redist_constr(map) %>%
+  add_constr_grp_hinge(30, vap - vap_white, vap, 0.50) %>%
+  add_constr_grp_hinge(-25, vap - vap_white, vap, 0.41) %>%
+  add_constr_grp_inv_hinge(10, vap - vap_white, vap, 0.55)
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county, constraints = constr)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_2000/LA_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_2000/LA_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/LA_cd_2000/doc_LA_cd_2000.md
+++ b/analyses/LA_cd_2000/doc_LA_cd_2000.md
@@ -1,0 +1,18 @@
+# 2000 Louisiana Congressional Districts
+
+## Redistricting requirements
+In ``Louisiana``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), there are no state law requirements for congressional districts.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.
+
+## Data Sources
+Data for ``Louisiana`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for ``Louisiana`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In ``Louisiana``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), there are no state law requirements for congressional districts.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting the same number of majority-minority districts as the enacted plan. We also apply a hinge Gibbs constraint to discourage packing of minority voters.

## Data Sources
Data for ``Louisiana`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for ``Louisiana`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="4500" alt="validation_20250801_0154" src="https://github.com/user-attachments/assets/12230848-b8bf-4a58-b687-fffd25e19d92" />


```
✔ Running simulations for LA_cd_2000 ... done
SMC: 5,000 sampled plans of 7 districts on 3,521 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0           
ℹ Preparing LA shapefile

Plan diversity 80% range: 0.47 to 0.79
ℹ Preparing LA shapefile

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two 
        1.019         1.008         1.006         1.017         1.021         1.021         1.012 
     pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp 
        1.005         1.015         1.012         1.026         1.009         1.019         1.008 
     vap_aian     vap_asian     vap_white     vap_black      vap_nhpi     vap_other       vap_two 
        1.005         1.019         1.015         1.014         1.007         1.020         1.012 
county_splits   muni_splits 
        1.020         1.006 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,489 (74.5%)     10.6%        0.27 1,267 (100%)      9 
Split 2     1,486 (74.3%)     15.2%        0.87 1,090 ( 86%)      7 
Split 3     1,531 (76.5%)     21.8%        0.79 1,194 ( 94%)      4 
Split 4     1,604 (80.2%)     16.1%        0.77 1,189 ( 94%)      5 
Split 5     1,580 (79.0%)     11.5%        0.73 1,139 ( 90%)      6 
Split 6     1,437 (71.9%)      5.1%        0.68 1,047 ( 83%)      4 
Resample      372 (18.6%)       NA%        1.20 1,201 ( 95%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,492 (74.6%)     11.1%        0.27 1,265 (100%)      9 
Split 2     1,440 (72.0%)     17.5%        0.87 1,101 ( 87%)      6 
Split 3     1,528 (76.4%)     21.4%        0.79 1,158 ( 92%)      4 
Split 4     1,552 (77.6%)     12.0%        0.75 1,171 ( 93%)      7 
Split 5     1,452 (72.6%)     13.6%        0.79 1,124 ( 89%)      5 
Split 6     1,307 (65.3%)      6.5%        0.74 1,002 ( 79%)      3 
Resample      304 (15.2%)       NA%        1.32 1,075 ( 85%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,504 (75.2%)     10.6%        0.27 1,246 ( 99%)      9 
Split 2     1,370 (68.5%)     17.0%        0.88 1,089 ( 86%)      6 
Split 3     1,516 (75.8%)     22.0%        0.81 1,146 ( 91%)      4 
Split 4     1,579 (78.9%)     13.1%        0.76 1,173 ( 93%)      6 
Split 5     1,562 (78.1%)     10.1%        0.76 1,143 ( 90%)      7 
Split 6     1,394 (69.7%)      5.1%        0.69 1,066 ( 84%)      4 
Resample      311 (15.5%)       NA%        1.22 1,179 ( 93%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,488 (74.4%)     10.9%        0.28 1,246 ( 99%)      9 
Split 2     1,370 (68.5%)     11.9%        0.89 1,089 ( 86%)      9 
Split 3     1,516 (75.8%)     15.1%        0.80 1,168 ( 92%)      6 
Split 4     1,679 (83.9%)     19.0%        0.75 1,167 ( 92%)      4 
Split 5     1,700 (85.0%)     16.8%        0.68 1,149 ( 91%)      4 
Split 6     1,436 (71.8%)      5.2%        0.63 1,067 ( 84%)      4 
Resample      486 (24.3%)       NA%        1.20 1,172 ( 93%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,487 (74.4%)     11.6%        0.28 1,254 ( 99%)      8 
Split 2     1,411 (70.5%)     20.4%        0.88 1,091 ( 86%)      5 
Split 3     1,575 (78.8%)      9.9%        0.77 1,162 ( 92%)      9 
Split 4     1,624 (81.2%)     13.4%        0.74 1,197 ( 95%)      6 
Split 5     1,570 (78.5%)     15.8%        0.72 1,153 ( 91%)      4 
Split 6     1,391 (69.6%)      6.6%        0.71 1,035 ( 82%)      3 
Resample      512 (25.6%)       NA%        1.32 1,136 ( 90%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
