### PR TITLE
2000 Maryland Congressional Districts

### DIFF
--- a/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `MD_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MD_cd_2000}")
+
+map <- redist_map(md_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = wv_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MD_2000"
+
+map$state <- "MD"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MD_2000/MD_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
@@ -1,0 +1,34 @@
+###############################################################################
+# Simulate plans for `MD_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MD_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MD_2000/MD_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MD_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MD_2000/MD_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/MD_cd_2000/doc_MD_cd_2000.md
+++ b/analyses/MD_cd_2000/doc_MD_cd_2000.md
@@ -1,0 +1,25 @@
+# 2000 Maryland Congressional Districts
+
+## Redistricting requirements
+In ``Maryland``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts should:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. not dilute minority voting strengths
+1. give due regard to natural boundaries
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for ``Maryland`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In ``Maryland``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts should:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not dilute minority voting strengths
1. give due regard to natural boundaries

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for ``Maryland`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="4500" alt="validation_20250801_1501" src="https://github.com/user-attachments/assets/b3360b6b-d080-432f-beb0-ad283df9c6ff" />

```
✔ Creating <redist_map> object for MD_cd_2000 ... done
SMC: 5,000 sampled plans of 8 districts on 1,691 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0                     
ℹ Downloading files for WV_cd_2000

Plan diversity 80% range: 0.48 to 0.73
ℹ Downloading files for WV_cd_2000

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two 
        1.004         1.000         1.002         1.001         1.011         1.011         1.007 
     pop_aian     pop_white     pop_black      pop_hisp     pop_asian      pop_nhpi      vap_hisp 
        1.006         1.005         1.005         1.005         1.005         1.003         1.005 
     vap_aian     vap_asian     vap_white     vap_black      vap_nhpi     vap_other       vap_two 
        1.005         1.005         1.005         1.005         1.004         1.009         1.007 
county_splits   muni_splits           ndv           nrv       ndshare 
        1.012         1.002         1.007         1.009         1.009 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)     15.2%        0.30 1,268 (100%)      5 
Split 2     1,929 (96.4%)     13.6%        0.36 1,226 ( 97%)      5 
Split 3     1,905 (95.2%)     12.0%        0.41 1,224 ( 97%)      5 
Split 4     1,853 (92.6%)     17.5%        0.50 1,204 ( 95%)      3 
Split 5     1,789 (89.5%)     14.7%        0.60 1,183 ( 94%)      3 
Split 6     1,772 (88.6%)     11.4%        0.65 1,128 ( 89%)      3 
Split 7     1,776 (88.8%)      5.4%        0.66 1,033 ( 82%)      2 
Resample    1,193 (59.6%)       NA%        0.66 1,463 (116%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,951 (97.5%)     12.8%        0.30 1,266 (100%)      6 
Split 2     1,934 (96.7%)     13.7%        0.35 1,271 (101%)      5 
Split 3     1,903 (95.2%)     14.9%        0.42 1,220 ( 97%)      4 
Split 4     1,868 (93.4%)     17.0%        0.49 1,217 ( 96%)      3 
Split 5     1,833 (91.7%)     11.3%        0.53 1,195 ( 95%)      4 
Split 6     1,782 (89.1%)     12.1%        0.63 1,156 ( 91%)      3 
Split 7     1,763 (88.1%)      6.0%        0.68 1,042 ( 82%)      2 
Resample    1,182 (59.1%)       NA%        0.68 1,443 (114%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)     13.4%        0.30 1,263 (100%)      6 
Split 2     1,932 (96.6%)     17.1%        0.35 1,202 ( 95%)      4 
Split 3     1,902 (95.1%)     12.2%        0.42 1,232 ( 97%)      5 
Split 4     1,875 (93.8%)     17.8%        0.47 1,214 ( 96%)      3 
Split 5     1,845 (92.2%)     14.3%        0.53 1,194 ( 94%)      3 
Split 6     1,791 (89.6%)     17.2%        0.63 1,163 ( 92%)      2 
Split 7     1,790 (89.5%)      3.7%        0.65 1,041 ( 82%)      3 
Resample    1,281 (64.1%)       NA%        0.65 1,484 (117%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,948 (97.4%)     12.9%        0.30 1,256 ( 99%)      6 
Split 2     1,929 (96.4%)     12.9%        0.36 1,234 ( 98%)      5 
Split 3     1,908 (95.4%)     14.7%        0.41 1,219 ( 96%)      4 
Split 4     1,884 (94.2%)     17.5%        0.46 1,220 ( 97%)      3 
Split 5     1,818 (90.9%)     11.2%        0.53 1,220 ( 97%)      4 
Split 6     1,782 (89.1%)     11.3%        0.63 1,178 ( 93%)      3 
Split 7     1,751 (87.5%)      4.0%        0.69 1,018 ( 81%)      3 
Resample    1,133 (56.7%)       NA%        0.69 1,409 (111%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)     11.1%        0.30 1,290 (102%)      7 
Split 2     1,932 (96.6%)     13.4%        0.35 1,251 ( 99%)      5 
Split 3     1,912 (95.6%)     12.0%        0.40 1,233 ( 98%)      5 
Split 4     1,885 (94.3%)     13.7%        0.46 1,220 ( 97%)      4 
Split 5     1,835 (91.8%)     14.6%        0.54 1,197 ( 95%)      3 
Split 6     1,824 (91.2%)     16.9%        0.58 1,177 ( 93%)      2 
Split 7     1,803 (90.1%)      5.4%        0.63 1,072 ( 85%)      2 
Resample    1,321 (66.1%)       NA%        0.63 1,473 (117%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny