### PR TITLE
2000 Colorado Congressional Districts

### DIFF
--- a/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
@@ -38,15 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = co_shp,
                                perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -55,8 +52,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     co_shp$adj <- redist.adjacency(co_shp)
-
-    # TODO any custom adjacency graph edits here
 
     co_shp <- co_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Download and prepare data for `CO_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CO_cd_2000}")
+
+path_data <- download_redistricting_file("CO", "data-raw/CO", year = 2000, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CO_2000/shp_vtd.rds"
+perim_path <- "data-out/CO_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CO} shapefile")
+    # read in redistricting data
+    co_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$CO)
+
+    co_shp <- co_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = co_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    co_shp$adj <- redist.adjacency(co_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    co_shp <- co_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(co_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    co_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CO} shapefile")
+}

--- a/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/01_prep_2000_CO_cd_2000.R
@@ -40,13 +40,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = co_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
@@ -9,15 +9,9 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg CO_cd_2000}")
 map <- redist_map(co_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = co_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CO_2000"

--- a/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
@@ -4,8 +4,6 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg CO_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(co_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = co_shp$adj)
 

--- a/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
@@ -9,7 +9,7 @@ map <- redist_map(co_shp, pop_tol = 0.005,
 
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "CO_2000"

--- a/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/02_setup_CO_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `CO_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CO_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(co_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = co_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CO_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CO_2000/CO_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
@@ -6,21 +6,8 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CO_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county, ncores = 15)
 
 plans <- plans %>%
     group_by(chain) %>%
@@ -30,8 +17,6 @@ plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/CO_2000/CO_cd_2000_plans.rds"), compress = "xz")

--- a/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
@@ -33,7 +33,6 @@ save_summary_stats(plans, "data-out/CO_2000/CO_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
+++ b/analyses/CO_cd_2000/03_sim_CO_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `CO_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CO_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CO_2000/CO_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CO_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CO_2000/CO_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/CO_cd_2000/doc_CO_cd_2000.md
+++ b/analyses/CO_cd_2000/doc_CO_cd_2000.md
@@ -7,10 +7,11 @@ In Colorado, according to [NCSL Redistricting Law 2000](https://web.archive.org/
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. follow the Voting Rights Act
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Colorado comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
@@ -21,4 +22,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 10,000 districting plans for Colorado across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
-No special techniques were needed to produce the sample.
+We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.

--- a/analyses/CO_cd_2000/doc_CO_cd_2000.md
+++ b/analyses/CO_cd_2000/doc_CO_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Colorado Congressional Districts
+
+## Redistricting requirements
+In Colorado, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Colorado comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Colorado across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Colorado, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. follow the Voting Rights Act


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Colorado comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Colorado across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.


## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/23d7bacf-6ce1-4f12-919b-c7903eebc6a0" />

```
SMC: 5,000 sampled plans of 7 districts on 1,062 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.44 to 0.81

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby      pop_aian 
        1.020         1.004         1.009         1.002         1.007         1.002 
      pop_two     pop_white     pop_black      pop_hisp     pop_asian      pop_nhpi 
        1.006         1.004         1.018         1.003         1.008         1.008 
    pop_other      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.005         1.003         1.003         1.008         1.005         1.018 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits           ndv 
        1.008         1.012         1.005         1.006         1.022         1.002 
          nrv       ndshare 
        1.010         1.003 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,937 (96.9%)     10.7%        0.35 1,256 ( 99%)      5 
Split 2     1,908 (95.4%)     13.2%        0.42 1,239 ( 98%)      4 
Split 3     1,886 (94.3%)     15.9%        0.47 1,240 ( 98%)      3 
Split 4     1,853 (92.6%)     20.8%        0.51 1,210 ( 96%)      2 
Split 5     1,817 (90.9%)     16.7%        0.54 1,158 ( 92%)      2 
Split 6     1,817 (90.9%)      6.1%        0.56 1,066 ( 84%)      2 
Resample    1,251 (62.5%)       NA%        0.55 1,515 (120%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,937 (96.8%)      7.8%        0.35 1,277 (101%)      7 
Split 2     1,913 (95.7%)     10.4%        0.42 1,222 ( 97%)      5 
Split 3     1,897 (94.8%)     15.2%        0.45 1,247 ( 99%)      3 
Split 4     1,867 (93.4%)     20.4%        0.49 1,215 ( 96%)      2 
Split 5     1,803 (90.1%)     12.0%        0.57 1,172 ( 93%)      3 
Split 6     1,831 (91.6%)      4.1%        0.55 1,030 ( 81%)      3 
Resample    1,332 (66.6%)       NA%        0.54 1,539 (122%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,933 (96.6%)      6.7%        0.36 1,266 (100%)      8 
Split 2     1,906 (95.3%)     10.1%        0.43 1,246 ( 99%)      5 
Split 3     1,895 (94.7%)     16.0%        0.46 1,212 ( 96%)      3 
Split 4     1,881 (94.0%)     21.1%        0.49 1,218 ( 96%)      2 
Split 5     1,871 (93.5%)     17.9%        0.51 1,149 ( 91%)      2 
Split 6     1,544 (77.2%)      6.0%        0.63 1,072 ( 85%)      2 
Resample      277 (13.8%)       NA%        0.62 1,326 (105%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,937 (96.8%)     10.7%        0.35 1,257 ( 99%)      5 
Split 2     1,900 (95.0%)     12.4%        0.44 1,252 ( 99%)      4 
Split 3     1,890 (94.5%)     15.8%        0.47 1,217 ( 96%)      3 
Split 4     1,861 (93.1%)     20.8%        0.49 1,214 ( 96%)      2 
Split 5     1,812 (90.6%)     16.8%        0.57 1,161 ( 92%)      2 
Split 6     1,823 (91.1%)      5.7%        0.57 1,045 ( 83%)      2 
Resample    1,324 (66.2%)       NA%        0.56 1,513 (120%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,937 (96.8%)      9.0%        0.35 1,260 (100%)      6 
Split 2     1,909 (95.5%)     13.0%        0.41 1,231 ( 97%)      4 
Split 3     1,902 (95.1%)     11.8%        0.45 1,231 ( 97%)      4 
Split 4     1,885 (94.2%)     14.8%        0.48 1,228 ( 97%)      3 
Split 5     1,830 (91.5%)     12.5%        0.55 1,149 ( 91%)      3 
Split 6     1,729 (86.5%)      6.3%        0.61 1,034 ( 82%)      2 
Resample      719 (35.9%)       NA%        0.60 1,442 (114%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny