### PR TITLE
2000 New Jersey Congressional Districts

### DIFF
--- a/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
@@ -1,0 +1,65 @@
+###############################################################################
+# Download and prepare data for NJ_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NJ_cd_2000}")
+path_data <- download_redistricting_file("NJ", "data-raw/NJ", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NJ_2000/shp_vtd.rds"
+perim_path <- "data-out/NJ_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong NJ} shapefile")
+  # read in redistricting data
+  nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$NJ)
+  
+  nj_shp <- nj_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = nj_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  nj_shp$adj <- redist.adjacency(nj_shp)
+  
+  nj_shp <- nj_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(nj_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  nj_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong NJ} shapefile")
+}

--- a/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
@@ -1,18 +1,18 @@
 ###############################################################################
 # Download and prepare data for NJ_cd_2000 analysis
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 suppressMessages({
-  library(dplyr)
-  library(readr)
-  library(sf)
-  library(redist)
-  library(geomander)
-  library(baf)
-  library(cli)
-  library(here)
-  devtools::load_all() # load utilities
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
 })
 
 # Download necessary files for analysis -----
@@ -26,41 +26,101 @@ shp_path <- "data-out/NJ_2000/shp_vtd.rds"
 perim_path <- "data-out/NJ_2000/perim.rds"
 
 if (!file.exists(here(shp_path))) {
-  cli_process_start("Preparing {.strong NJ} shapefile")
-  # read in redistricting data
-  nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
-    join_vtd_shapefile(year = 2000) %>%
-    st_transform(EPSG$NJ)
-  
-  nj_shp <- nj_shp %>%
-    rename(muni = place) %>%
-    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
-    relocate(muni, county_muni, cd_1990, .after = county)
-  
-  # Create perimeters in case shapes are simplified
-  redistmetrics::prep_perims(shp = nj_shp,
-                             perim_path = here(perim_path)) %>%
-    invisible()
-  
-  # simplifies geometry for faster processing, plotting, and smaller shapefiles
-  if (requireNamespace("rmapshaper", quietly = TRUE)) {
-    nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
-                                      keep_shapes = TRUE) %>%
-      suppressWarnings()
-  }
-  
-  nj_shp <- nj_shp %>%
-    fix_geo_assignment(muni)
-  
-  # compute merge groups
-  nj_shp$merge_group <- contiguity_merges(nj_shp)
-  
-  # create adjacency graph
-  nj_shp$adj <- redist.adjacency(nj_shp)
-  
-  write_rds(nj_shp, here(shp_path), compress = "gz")
-  cli_process_done()
+    cli_process_start("Preparing {.strong NJ} shapefile")
+    # read in redistricting data
+    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$NJ)
+
+    nj_shp <- nj_shp %>%
+        rename(muni = place) %>%
+        mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    nj_shp <- nj_shp %>%
+        fix_geo_assignment(muni)
+
+    # compute merge groups
+    nj_shp$merge_group <- contiguity_merges(nj_shp)
+
+    # create adjacency graph
+    nj_shp$adj <- redist.adjacency(nj_shp)
+
+    ###############################################################################
+    # Logit-shift ndv/nrv to match 2000 MEDSL county results
+    ###############################################################################
+
+    # Use a wider uniroot interval because some counties require a shift beyond [-1, 1]
+    logit_shift_baseline <- function(d_baseline, ndv, nrv,
+                                     target = 0.5,
+                                     tol = sqrt(.Machine$double.eps)) {
+        if (missing(ndv) || missing(nrv)) {
+            cli::cli_abort("Both {.arg ndv} and {.arg nrv} must be provided.")
+        }
+        ndv_q <- rlang::enquo(ndv)
+        nrv_q <- rlang::enquo(nrv)
+
+        ndv_vec <- dplyr::pull(d_baseline, !!ndv_q)
+        nrv_vec <- dplyr::pull(d_baseline, !!nrv_q)
+
+        turn <- ndv_vec + nrv_vec
+
+        if (sum(turn) == 0) {
+            return(d_baseline)
+        }
+
+        ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
+
+        res <- uniroot(function(shift) {
+            stats::weighted.mean(plogis(ldvs + shift), turn) - target
+        }, c(-5, 5), tol = tol)
+
+        ldvs <- ldvs + res$root
+
+        ndv_new <- turn*plogis(ldvs)
+        nrv_new <- turn - ndv_new
+
+        dplyr::mutate(
+            d_baseline,
+            !!rlang::as_name(ndv_q) := ndv_new,
+            !!rlang::as_name(nrv_q) := nrv_new
+        )
+    }
+
+    # Logit shift
+    medsl_cty <- read_csv(
+        here::here("data-raw/baseline_voteshare_medsl_00.csv"),
+        show_col_types = FALSE
+    )
+
+    nj_shp <- nj_shp |>
+        mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
+
+    nj_shp <- nj_shp |>
+        group_by(county_fips) |>
+        group_split() |>
+        lapply(function(x) {
+            meds <- medsl_cty |>
+                filter(county == x$county_fips[1])
+
+            target <- meds$dshare_00[1]
+
+            if (length(target) == 0 || is.na(target)) return(x)
+
+            logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+        }) |>
+        bind_rows()
+
+    write_rds(nj_shp, here(shp_path), compress = "gz")
+    cli_process_done()
 } else {
-  nj_shp <- read_rds(here(shp_path))
-  cli_alert_success("Loaded {.strong NJ} shapefile")
+    nj_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NJ} shapefile")
 }

--- a/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
@@ -57,10 +57,6 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     nj_shp$adj <- redist.adjacency(nj_shp)
 
-    ###############################################################################
-    # Logit-shift ndv/nrv
-    ###############################################################################
-
     # Logit shift
     medsl_cty <- read_csv(
         here::here("data-raw/baseline_voteshare_medsl_00.csv"),

--- a/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
@@ -37,6 +37,10 @@ if (!file.exists(here(shp_path))) {
         mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
+    redistmetrics::prep_perims(shp = nj_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
@@ -54,10 +58,10 @@ if (!file.exists(here(shp_path))) {
     nj_shp$adj <- redist.adjacency(nj_shp)
 
     ###############################################################################
-    # Logit-shift ndv/nrv to match 2000 MEDSL county results
+    # Logit-shift ndv/nrv
     ###############################################################################
 
-    # Use a wider uniroot interval because some counties require a shift beyond [-1, 1]
+    # Use a wider uniroot interval
     logit_shift_baseline <- function(d_baseline, ndv, nrv,
                                      target = 0.5,
                                      tol = sqrt(.Machine$double.eps)) {
@@ -80,7 +84,7 @@ if (!file.exists(here(shp_path))) {
 
         res <- uniroot(function(shift) {
             stats::weighted.mean(plogis(ldvs + shift), turn) - target
-        }, c(-5, 5), tol = tol)
+        }, c(-1.5, 1.5), tol = tol)
 
         ldvs <- ldvs + res$root
 

--- a/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/01_prep_NJ_cd_2000.R
@@ -61,43 +61,6 @@ if (!file.exists(here(shp_path))) {
     # Logit-shift ndv/nrv
     ###############################################################################
 
-    # Use a wider uniroot interval
-    logit_shift_baseline <- function(d_baseline, ndv, nrv,
-                                     target = 0.5,
-                                     tol = sqrt(.Machine$double.eps)) {
-        if (missing(ndv) || missing(nrv)) {
-            cli::cli_abort("Both {.arg ndv} and {.arg nrv} must be provided.")
-        }
-        ndv_q <- rlang::enquo(ndv)
-        nrv_q <- rlang::enquo(nrv)
-
-        ndv_vec <- dplyr::pull(d_baseline, !!ndv_q)
-        nrv_vec <- dplyr::pull(d_baseline, !!nrv_q)
-
-        turn <- ndv_vec + nrv_vec
-
-        if (sum(turn) == 0) {
-            return(d_baseline)
-        }
-
-        ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
-
-        res <- uniroot(function(shift) {
-            stats::weighted.mean(plogis(ldvs + shift), turn) - target
-        }, c(-1.5, 1.5), tol = tol)
-
-        ldvs <- ldvs + res$root
-
-        ndv_new <- turn*plogis(ldvs)
-        nrv_new <- turn - ndv_new
-
-        dplyr::mutate(
-            d_baseline,
-            !!rlang::as_name(ndv_q) := ndv_new,
-            !!rlang::as_name(nrv_q) := nrv_new
-        )
-    }
-
     # Logit shift
     medsl_cty <- read_csv(
         here::here("data-raw/baseline_voteshare_medsl_00.csv"),
@@ -118,7 +81,13 @@ if (!file.exists(here(shp_path))) {
 
             if (length(target) == 0 || is.na(target)) return(x)
 
-            logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+            logit_shift_baseline(
+                x, 
+                ndv = ndv, 
+                nrv = nrv, 
+                target = target,
+                interval = c(-1.5, 1.5)
+            )
         }) |>
         bind_rows()
 

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -7,6 +7,7 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2000}")
 map <- redist_map(nj_shp, pop_tol = 0.005,
                   existing_plan = cd_2000, adj = nj_shp$adj)
 
+# Pseudo-county
 map <- map %>%
   mutate(
     pseudo_county = pick_county_muni(

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -53,14 +53,14 @@ check_valid <- function(pref_n, plans_matrix) {
     if (length(adj_built[[i]]) > 0) {
       adj_adjusted[[i]] <- adj_poly[[i]]
     } else {
-      adj_adjusted[[i]] <- adj_orig[[i]]  # fallback (islands)
+      adj_adjusted[[i]] <- adj_orig[[i]]  
     }
   }
   
   # Identify islands
   is_island <- vapply(adj_adjusted, length, 0L) == 0
   
-  # Contiguity check
+  # Contiguity check (avoid falsely flagging islands as discontiguous)
   checks <- vapply(seq_len(ncol(plans_matrix)), function(k) {
     p <- plans_matrix[, k]
     comp <- geomander::check_contiguity(adj_adjusted, p)$component

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -49,9 +49,7 @@ check_valid <- function(pref_n, plans_matrix) {
   
   for (k in 1:ncol(plans_matrix))
   {
-    # mainland_plan <- plans_matrix[mainland$unit, k]
-    # mainland$temp_plan <- mainland_plan
-    # checks[k] <- max(check_polygon_contiguity(shp=mainland, group=temp_plan)$component) == 1 
+
     checks[k] <- max(check_contiguity(mainland_adj, mainland_plans[, k])$component) == 1
   }
   

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -1,11 +1,13 @@
 ###############################################################################
 # Set up redistricting simulation for `NJ_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, February 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2000}")
 
 map <- redist_map(nj_shp, pop_tol = 0.005,
                   existing_plan = cd_2000, adj = nj_shp$adj)
+
+map <- map %>% merge_by(merge_group, drop_geom = FALSE)
 
 # Pseudo-county
 map <- map %>%
@@ -26,53 +28,3 @@ map$state <- "NJ"
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/NJ_2000/NJ_cd_2000_map.rds", compress = "xz")
 cli_process_done()
-
-# Define helper function before it is called
-check_valid <- function(pref_n, plans_matrix) {
-  # ensure geometries are valid
-  shp <- sf::st_make_valid(sf::st_as_sf(pref_n))
-  
-  # Build hybrid adjacency
-  adj_orig  <- pref_n$adj
-  adj_built <- redist::redist.adjacency(shp)  
-  
-  shp$.__uid <- seq_len(nrow(shp))
-  poly_big <- shp |>
-    sf::st_cast("POLYGON") |>
-    dplyr::mutate(.area = sf::st_area(geometry)) |>
-    dplyr::group_by(.__uid) |>
-    dplyr::slice_max(.area, n = 1, with_ties = FALSE) |>
-    dplyr::ungroup() |>
-    dplyr::select(-.area) |>
-    dplyr::arrange(.__uid)
-  
-  adj_poly <- redist::redist.adjacency(poly_big)
-  
-  adj_adjusted <- adj_built
-  for (i in seq_along(adj_adjusted)) {
-    if (length(adj_built[[i]]) > 0) {
-      adj_adjusted[[i]] <- adj_poly[[i]]
-    } else {
-      adj_adjusted[[i]] <- adj_orig[[i]]  
-    }
-  }
-  
-  # Identify islands
-  is_island <- vapply(adj_adjusted, length, 0L) == 0
-  
-  # Contiguity check (avoid falsely flagging islands as discontiguous)
-  checks <- vapply(seq_len(ncol(plans_matrix)), function(k) {
-    p <- plans_matrix[, k]
-    comp <- geomander::check_contiguity(adj_adjusted, p)$component
-    
-    by_district <- tapply(seq_along(p), p, function(idx) {
-      idx_main <- idx[!is_island[idx]]
-      if (length(idx_main) == 0) TRUE
-      else max(comp[idx_main]) == 1
-    })
-    
-    all(unlist(by_district))
-  }, logical(1))
-  
-  return(list(valid = checks, adj_adjusted = adj_adjusted, is_island = is_island))
-}

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NJ_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2000}")
+
+map <- redist_map(nj_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = nj_shp$adj)
+
+map <- map %>%
+  mutate(
+    pseudo_county = pick_county_muni(
+      map,
+      counties = county,   
+      munis    = muni,     
+      pop_muni = get_target(map)
+    )
+  )
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NJ_2000"
+
+map$state <- "NJ"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NJ_2000/NJ_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -1,24 +1,33 @@
 ###############################################################################
 # Set up redistricting simulation for `NJ_cd_2000`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2000}")
 
 map <- redist_map(nj_shp, pop_tol = 0.005,
-                  existing_plan = cd_2000, adj = nj_shp$adj)
+    existing_plan = cd_2000, adj = nj_shp$adj)
 
 map <- map %>% merge_by(merge_group, drop_geom = FALSE)
 
+# Extract merged geometry as sf
+merged_sf <- sf::st_as_sf(map)
+
+redistmetrics::prep_perims(
+    shp = merged_sf,
+    perim_path = here(perim_path)
+) %>%
+    invisible()
+
 # Pseudo-county
 map <- map %>%
-  mutate(
-    pseudo_county = pick_county_muni(
-      map,
-      counties = county,   
-      munis    = muni,     
-      pop_muni = get_target(map)
+    mutate(
+        pseudo_county = pick_county_muni(
+            map,
+            counties = county,
+            munis    = muni,
+            pop_muni = get_target(map)
+        )
     )
-  )
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NJ_2000"

--- a/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/02_setup_NJ_cd_2000.R
@@ -7,25 +7,18 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_2000}")
 map <- redist_map(nj_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = nj_shp$adj)
 
-map <- map %>% merge_by(merge_group, drop_geom = FALSE)
+# Merged map: use this only for simulation
+map_merged <- map %>%
+  merge_by(merge_group, drop_geom = FALSE)
 
-# Extract merged geometry as sf
-merged_sf <- sf::st_as_sf(map)
-
-redistmetrics::prep_perims(
-    shp = merged_sf,
-    perim_path = here(perim_path)
-) %>%
-    invisible()
-
-# Pseudo-county
-map <- map %>%
+# Pseudo-county on merged simulation map
+map_merged <- map_merged %>%
     mutate(
         pseudo_county = pick_county_muni(
-            map,
+            map_merged,
             counties = county,
             munis    = muni,
-            pop_muni = get_target(map)
+            pop_muni = get_target(map_merged)
         )
     )
 

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -145,6 +145,6 @@ if (interactive()) {
     dplyr::left_join(plan_index, by = "col")
   
   # quick readout
-  tbl <- table(per_plan_summary$all_contiguous)
-  n_false <- ifelse("FALSE" %in% names(tbl), tbl["FALSE"], 0)
-  cat("Number of non-contiguous plans:", n_false, "\n")
+  tbl <- per_plan_summary |>
+  dplyr::count(all_contiguous, name = "n") |>
+  dplyr::mutate(prop = round(n / sum(n), 3))

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -8,8 +8,6 @@ cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
 
 set.seed(2000)
 plans <- redist_smc(map, nsims = 4e3, runs = 10, counties = pseudo_county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans %>%
   group_by(chain) %>%

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -1,99 +1,51 @@
 ###############################################################################
 # Simulate plans for `NJ_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
-# Run the simulation ----- 
-cli_process_start("Running simulations for {.pkg NJ_cd_2000}") 
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
 
-set.seed(2000) 
-plans <- redist_smc(map, nsims = 30000, runs = 10, counties = pseudo_county) 
+set.seed(2000)
+plans <- redist_smc(map, nsims = 6e3, runs = 5, counties = pseudo_county)
 
-plans <- match_numbers(plans, "cd_2000")
+# contiguity validation
+pmat  <- redist::get_plans_matrix(plans)
+ok    <- check_plans_polygon_contiguity(map, pmat)
 
-cli_process_done() 
-
-# Screen for contiguity
-cli_process_start("Screening for contiguity") 
-
-pmat <- redist::get_plans_matrix(plans) 
-res   <- check_valid(pref_n = map, plans_matrix = pmat)
-valid <- res$valid
-adj_adjusted <- res$adj_adjusted
-is_island    <- res$is_island
-
-cli_alert_info("{sum(valid)} of {length(valid)} draws passed contiguity.") 
-
-# Keep only contiguous draws
-keep_draws <- which(valid) 
-n_dropped <- length(valid) - length(keep_draws) 
-
-if (n_dropped > 0) 
-  cli_alert_warning("Dropping {n_dropped} non-contiguous draws.") 
-if (length(keep_draws) == 0) {
-  cli_abort("No draws passed the contiguity screen. Consider revisiting adjacency or constraints.") 
-} 
-
-# Tag each draw with validity
-pairs <- plans %>% 
+# Build a index in the same order as pmat columns
+draw_index <- plans %>%
   dplyr::distinct(chain, draw) %>%
-  dplyr::mutate(valid = valid)
+  dplyr::arrange(chain, as.integer(draw))
 
-# Filter to valid plans only
+# Keep only the pairs that passed contiguity
+keep_pairs <- draw_index[ok, ]
+
+# Filter original plans object
 plans <- plans %>%
-  dplyr::semi_join(dplyr::filter(pairs, valid), by = c("chain", "draw"))
+  dplyr::inner_join(keep_pairs, by = c("chain", "draw"))
 
-# Thin simulation results to 5000.
-burn <- 500
-n_total <- 5000
+# Thin samples
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+  ungroup()
 
-plans <- plans %>% dplyr::arrange(chain, draw)
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
 
-ids <- plans %>%
-  dplyr::distinct(chain, draw) %>%
-  dplyr::group_by(chain) %>%
-  dplyr::mutate(r = dplyr::row_number(),
-                n_in_chain = dplyr::n()) %>%
-  dplyr::filter(r > pmin(burn, n_in_chain)) %>%   
-  dplyr::ungroup()
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NJ_2000/NJ_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
 
-n_runs   <- dplyr::n_distinct(ids$chain)
-keep_each <- min(floor(n_total / n_runs),
-                 ids %>% dplyr::count(chain, name = "m") %>% dplyr::pull(m) %>% min())
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_2000}")
 
-# take a contiguous tail: last keep_each draws per chain
-keep_ids <- ids %>%
-  dplyr::group_by(chain) %>%
-  dplyr::slice_max(order_by = draw, n = keep_each, with_ties = FALSE) %>%
-  dplyr::ungroup() %>%
-  dplyr::select(chain, draw)
+plans <- add_summary_stats(plans, map)
 
-plans <- plans %>% dplyr::semi_join(keep_ids, by = c("chain","draw"))
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv")
 
-cli_alert_success("Burn-in: dropped up to {burn}/chain; kept {keep_each} tail draws per chain (total {keep_each * n_runs}).")
-
-pmat <- redist::get_plans_matrix(plans)
-
-# add the enacted plan as a named reference plan
-plans <- redist::add_reference(plans, ref_plan = map$cd_2000, name = "cd_2000")
-
-# Save the filtered redist_plans object. Do not edit this path. 
-write_rds(plans, here("data-out/NJ_2000/NJ_cd_2000_plans.rds"), compress = "xz") 
-cli_process_done() 
-
-# Compute summary statistics ----- 
-cli_process_start("Computing summary statistics for {.pkg NJ_cd_2000}") 
-
-plans <- add_summary_stats(plans, map) 
-
-plans <- plans %>%
-  dplyr::mutate(
-    pop_overlap = dplyr::if_else(.data$draw == "cd_2000" & is.na(.data$pop_overlap),
-                                 1, .data$pop_overlap)
-  )
-
-# Output the summary statistics. Do not edit this path. 
-save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv") 
 cli_process_done()
 
 # Validation plots
@@ -117,34 +69,3 @@ if (interactive()) {
     group_by(draw) %>%
     summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
     count(n_black_perf)
-
-  # Validation for distontiguous plans.
-  plan_index <- plans |>
-    dplyr::distinct(chain, draw) |>
-    dplyr::arrange(chain, draw)
-  
-  if ("cd_2000" %in% plan_index$draw) {
-    plan_index <- dplyr::filter(plan_index, draw != "cd_2000")
-  }
-  
-  plan_index <- plan_index |>
-    dplyr::mutate(col = dplyr::row_number())
-  
-  per_plan_summary <- data.frame(
-    col = seq_len(ncol(pmat)),
-    all_contiguous = vapply(seq_len(ncol(pmat)), function(j) {
-      p <- pmat[, j]
-      comp <- geomander::check_contiguity(adj_adjusted, p)$component
-      by_district <- tapply(seq_along(p), p, function(idx) {
-        idx_main <- idx[!is_island[idx]]
-        if (length(idx_main) == 0) TRUE else max(comp[idx_main]) == 1
-      })
-      all(unlist(by_district))
-    }, logical(1))
-  ) |>
-    dplyr::left_join(plan_index, by = "col")
-  
-  # quick readout
-  tbl <- per_plan_summary |>
-  dplyr::count(all_contiguous, name = "n") |>
-  dplyr::mutate(prop = round(n / sum(n), 3))

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -148,5 +148,3 @@ if (interactive()) {
   tbl <- table(per_plan_summary$all_contiguous)
   n_false <- ifelse("FALSE" %in% names(tbl), tbl["FALSE"], 0)
   cat("Number of non-contiguous plans:", n_false, "\n")
-  
-}

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -3,30 +3,112 @@
 # © ALARM Project, July 2025
 ###############################################################################
 
-# Run the simulation -----
-cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
+# Run the simulation ----- 
+cli_process_start("Running simulations for {.pkg NJ_cd_2000}") 
 
-set.seed(2000)
-plans <- redist_smc(map, nsims = 4e3, runs = 10, counties = pseudo_county)
+set.seed(2000) 
+plans <- redist_smc(map, nsims = 18000, runs = 10, counties = pseudo_county) 
 
-plans <- plans %>%
-  group_by(chain) %>%
-  filter(as.integer(draw) < min(as.integer(draw)) + 500) %>% # thin samples
-  ungroup()
 plans <- match_numbers(plans, "cd_2000")
 
+cli_process_done() 
+
+# Screen for contiguity
+cli_process_start("Screening for contiguity") 
+
+pmat <- redist::get_plans_matrix(plans) 
+valid <- check_valid(pref_n = map, plans_matrix = pmat) 
+
+cli_alert_info("{sum(valid)} of {length(valid)} draws passed contiguity.") 
+
+# Keep only contiguous draws
+keep_draws <- which(valid) 
+n_dropped <- length(valid) - length(keep_draws) 
+
+if (n_dropped > 0) 
+  cli_alert_warning("Dropping {n_dropped} non-contiguous draws.") 
+if (length(keep_draws) == 0) {
+  cli_abort("No draws passed the contiguity screen. Consider revisiting adjacency or constraints.") 
+} 
+
+# Tag each draw with validity
+pairs <- plans %>% 
+  dplyr::distinct(chain, draw) %>%
+  dplyr::mutate(valid = valid)
+
+# Filter to valid plans only
+plans <- plans %>%
+  dplyr::semi_join(dplyr::filter(pairs, valid), by = c("chain", "draw"))
+
+# Thin simulation results to 5000.
+burn <- 500
+n_total <- 5000
+
+plans <- plans %>% dplyr::arrange(chain, draw)
+
+ids <- plans %>%
+  dplyr::distinct(chain, draw) %>%
+  dplyr::group_by(chain) %>%
+  dplyr::mutate(r = dplyr::row_number(),
+                n_in_chain = dplyr::n()) %>%
+  dplyr::filter(r > pmin(burn, n_in_chain)) %>%   
+  dplyr::ungroup()
+
+n_runs   <- dplyr::n_distinct(ids$chain)
+keep_each <- min(floor(n_total / n_runs),
+                 ids %>% dplyr::count(chain, name = "m") %>% dplyr::pull(m) %>% min())
+
+# take a contiguous tail: last keep_each draws per chain
+keep_ids <- ids %>%
+  dplyr::group_by(chain) %>%
+  dplyr::slice_max(order_by = draw, n = keep_each, with_ties = FALSE) %>%
+  dplyr::ungroup() %>%
+  dplyr::select(chain, draw)
+
+plans <- plans %>% dplyr::semi_join(keep_ids, by = c("chain","draw"))
+
+cli_alert_success("Burn-in: dropped up to {burn}/chain; kept {keep_each} tail draws per chain (total {keep_each * n_runs}).")
+
+# add the enacted plan as a named reference plan
+plans <- redist::add_reference(plans, ref_plan = map$cd_2000, name = "cd_2000")
+
+# Save the filtered redist_plans object. Do not edit this path. 
+write_rds(plans, here("data-out/NJ_2000/NJ_cd_2000_plans.rds"), compress = "xz") 
+cli_process_done() 
+
+# Compute summary statistics ----- 
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_2000}") 
+
+plans <- add_summary_stats(plans, map) 
+
+plans <- plans %>%
+  dplyr::mutate(
+    pop_overlap = dplyr::if_else(.data$draw == "cd_2000" & is.na(.data$pop_overlap),
+                                 1, .data$pop_overlap)
+  )
+
+# Output the summary statistics. Do not edit this path. 
+save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv") 
 cli_process_done()
-cli_process_start("Saving {.cls redist_plans} object")
 
-# Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/NJ_2000/NJ_cd_2000_plans.rds"), compress = "xz")
-cli_process_done()
-
-# Compute summary statistics -----
-cli_process_start("Computing summary statistics for {.pkg NJ_cd_2000}")
-
-plans <- add_summary_stats(plans, map)
-# Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv")
-
-cli_process_done()
+# Validation plots
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  # Black VAP Performance Plot  
+  redist.plot.distr_qtys(plans, vap_black / total_vap,
+                         color_thresh = NULL,
+                         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                         size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Black by VAP") +
+    labs(title = "New Jersey Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    theme_bw()
+  
+  # Total Black districts that are performing
+  plans %>%
+    subset_sampled() %>%
+    group_by(draw) %>%
+    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+    count(n_black_perf)

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -1,0 +1,34 @@
+###############################################################################
+# Simulate plans for `NJ_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 4e3, runs = 10, counties = pseudo_county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 500) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NJ_2000/NJ_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -119,34 +119,34 @@ if (interactive()) {
     count(n_black_perf)
 
   # Validation for distontiguous plans.
-plan_index <- plans |>
-  dplyr::distinct(chain, draw) |>
-  dplyr::arrange(chain, draw)
-
-if ("cd_2000" %in% plan_index$draw) {
-  plan_index <- dplyr::filter(plan_index, draw != "cd_2000")
-}
-
-plan_index <- plan_index |>
-  dplyr::mutate(col = dplyr::row_number())
-
-per_plan_summary <- data.frame(
-  col = seq_len(ncol(pmat)),
-  all_contiguous = vapply(seq_len(ncol(pmat)), function(j) {
-    p <- pmat[, j]
-    comp <- geomander::check_contiguity(adj_adjusted, p)$component
-    by_district <- tapply(seq_along(p), p, function(idx) {
-      idx_main <- idx[!is_island[idx]]
-      if (length(idx_main) == 0) TRUE else max(comp[idx_main]) == 1
-    })
-    all(unlist(by_district))
-  }, logical(1))
-) |>
-  dplyr::left_join(plan_index, by = "col")
-
-# quick readout
-tbl <- table(per_plan_summary$all_contiguous)
-n_false <- ifelse("FALSE" %in% names(tbl), tbl["FALSE"], 0)
-cat("Number of non-contiguous plans:", n_false, "\n")
+  plan_index <- plans |>
+    dplyr::distinct(chain, draw) |>
+    dplyr::arrange(chain, draw)
+  
+  if ("cd_2000" %in% plan_index$draw) {
+    plan_index <- dplyr::filter(plan_index, draw != "cd_2000")
+  }
+  
+  plan_index <- plan_index |>
+    dplyr::mutate(col = dplyr::row_number())
+  
+  per_plan_summary <- data.frame(
+    col = seq_len(ncol(pmat)),
+    all_contiguous = vapply(seq_len(ncol(pmat)), function(j) {
+      p <- pmat[, j]
+      comp <- geomander::check_contiguity(adj_adjusted, p)$component
+      by_district <- tapply(seq_along(p), p, function(idx) {
+        idx_main <- idx[!is_island[idx]]
+        if (length(idx_main) == 0) TRUE else max(comp[idx_main]) == 1
+      })
+      all(unlist(by_district))
+    }, logical(1))
+  ) |>
+    dplyr::left_join(plan_index, by = "col")
+  
+  # quick readout
+  tbl <- table(per_plan_summary$all_contiguous)
+  n_false <- ifelse("FALSE" %in% names(tbl), tbl["FALSE"], 0)
+  cat("Number of non-contiguous plans:", n_false, "\n")
   
 }

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -8,28 +8,32 @@ cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
 
 BVAP_THRESH <- 0.30
 DEM_THRESH  <- 0.50
-ndists <- attr(map, "ndists")
+ndists <- attr(map_merged, "ndists")
 
-constr <- redist_constr(map) |>
-    add_constr_min_group_frac(
-        strength      = -1,
-        group_pops    = list(map$vap_black, map$ndv),
-        total_pops    = list(map$vap, map$nrv + map$ndv),
-        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
-        thresh        = -0.9,
-        only_nregions = ndists
-    )
+constr <- redist_constr(map_merged) |>
+  add_constr_min_group_frac(
+    strength      = -1,
+    group_pops    = list(map_merged$vap_black, map_merged$ndv),
+    total_pops    = list(map_merged$vap, map_merged$nrv + map_merged$ndv),
+    min_fracs     = c(BVAP_THRESH, DEM_THRESH),
+    thresh        = -0.9,
+    only_nregions = ndists
+  )
 
 set.seed(2000)
-plans <- redist_smc(map,
-    nsims = 1e3,
-    runs = 5,
-    counties = pseudo_county,
-    constraints = constr,
-    sampling_space = "spanning_forest",
-    ms_params = list(frequency = 1L, mh_accept_per_smc = 20),
-    split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = T, pop_temper = 0.01)
+plans <- redist_smc(
+  map_merged,
+  nsims = 1e3,
+  runs = 5,
+  counties = pseudo_county,
+  constraints = constr,
+  sampling_space = "spanning_forest",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = 20),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE,
+  pop_temper = 0.01
+) %>%
+  pullback(map)
 
 plans <- plans %>%
     group_by(chain) %>%

--- a/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
+++ b/analyses/NJ_cd_2000/03_sim_NJ_cd_2000.R
@@ -1,35 +1,41 @@
-###############################################################################
+################################################################################
 # Simulate plans for `NJ_cd_2000`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NJ_cd_2000}")
 
+BVAP_THRESH <- 0.30
+DEM_THRESH  <- 0.50
+ndists <- attr(map, "ndists")
+
+constr <- redist_constr(map) |>
+    add_constr_min_group_frac(
+        strength      = -1,
+        group_pops    = list(map$vap_black, map$ndv),
+        total_pops    = list(map$vap, map$nrv + map$ndv),
+        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
+        thresh        = -0.9,
+        only_nregions = ndists
+    )
+
 set.seed(2000)
-plans <- redist_smc(map, nsims = 6e3, runs = 5, counties = pseudo_county)
+plans <- redist_smc(map,
+    nsims = 1e3,
+    runs = 5,
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "spanning_forest",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = 20),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = T, pop_temper = 0.01)
 
-# contiguity validation
-pmat  <- redist::get_plans_matrix(plans)
-ok    <- check_plans_polygon_contiguity(map, pmat)
-
-# Build a index in the same order as pmat columns
-draw_index <- plans %>%
-  dplyr::distinct(chain, draw) %>%
-  dplyr::arrange(chain, as.integer(draw))
-
-# Keep only the pairs that passed contiguity
-keep_pairs <- draw_index[ok, ]
-
-# Filter original plans object
 plans <- plans %>%
-  dplyr::inner_join(keep_pairs, by = c("chain", "draw"))
-
-# Thin samples
-plans <- plans |>
-  group_by(chain) |>
-  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
-  ungroup()
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
@@ -47,25 +53,3 @@ plans <- add_summary_stats(plans, map)
 save_summary_stats(plans, "data-out/NJ_2000/NJ_cd_2000_stats.csv")
 
 cli_process_done()
-
-# Validation plots
-if (interactive()) {
-  library(ggplot2)
-  library(patchwork)
-  
-  # Black VAP Performance Plot  
-  redist.plot.distr_qtys(plans, vap_black / total_vap,
-                         color_thresh = NULL,
-                         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                         size = 0.5, alpha = 0.5) +
-    scale_y_continuous("Percent Black by VAP") +
-    labs(title = "New Jersey Proposed Plan versus Simulations") +
-    scale_color_manual(values = c(cd_2000 = "black")) +
-    theme_bw()
-  
-  # Total Black districts that are performing
-  plans %>%
-    subset_sampled() %>%
-    group_by(draw) %>%
-    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
-    count(n_black_perf)

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -17,5 +17,5 @@ We used a helper function to exclude simulated plans containing discontiguous di
 
 ## Simulation Notes
 We sample 30,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
-After the simulation, we filtered out plans with discontiguous districts and then thinned the remaining sample to 5,000 plans.
+After the simulation, we filtered out plans with discontiguous districts and thinned the remaining sample to 5,000 plans.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -4,6 +4,7 @@
 In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
 
 1. be geographically contiguous
+2. have equal populations
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -7,13 +7,13 @@ In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archiv
 2. have equal populations
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below, which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
 
 ## Data Sources
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-We used a helper function to exclude simulated plans containing discontiguous districts.
+We used a helper function to identify and merge discontiguous precincts.
 
 ## Simulation Notes
 We sample 30,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -13,9 +13,9 @@ We enforce a maximum population deviation of 0.5%. We use a pseudo-county constr
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We used a helper function to exclude simulated plans containing discontiguous districts
 
 ## Simulation Notes
-We sample 40,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
-We then thinned the number of samples to 5,000. 
+We sample 180,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
+After the simulation, we filtered out plans with discontiguous districts and then thinned the remaining sample to 5,000 plans.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -16,6 +16,6 @@ Data for ``New Jersey`` comes from the [ALARM Project's update](https://datavers
 We used a helper function to exclude simulated plans containing discontiguous districts.
 
 ## Simulation Notes
-We sample 180,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
+We sample 300,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
 After the simulation, we filtered out plans with discontiguous districts and then thinned the remaining sample to 5,000 plans.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -16,6 +16,6 @@ Data for ``New Jersey`` comes from the [ALARM Project's update](https://datavers
 We used a helper function to exclude simulated plans containing discontiguous districts.
 
 ## Simulation Notes
-We sample 300,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
+We sample 30,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
 After the simulation, we filtered out plans with discontiguous districts and then thinned the remaining sample to 5,000 plans.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -1,0 +1,20 @@
+# 2000 New Jersey Congressional Districts
+
+## Redistricting requirements
+In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be geographically contiguous
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
+
+## Data Sources
+Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 40,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -13,7 +13,7 @@ We enforce a maximum population deviation of 0.5%. We use a pseudo-county constr
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-We used a helper function to exclude simulated plans containing discontiguous districts
+We used a helper function to exclude simulated plans containing discontiguous districts.
 
 ## Simulation Notes
 We sample 180,000 districting plans for ``New Jersey`` across 10 independent runs of the SMC algorithm.

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -7,14 +7,14 @@ In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archiv
 2. have equal populations
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below, which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below, which attempts to mimic the norms in ``New Jersey`` of generally preserving county and municipal boundaries.
 We add thresholded hard constraints to ensure at least one black performant district.
 
 ## Data Sources
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-Because New Jersey contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
+Because ``New Jersey`` contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
 We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval [-1, 1] was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to [-1.5, 1.5] to accommodate the larger correction.
 
 ## Simulation Notes

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -8,14 +8,17 @@ In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archiv
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below, which attempts to mimic the norms in New Jersey of generally preserving county and municipal boundaries.
+We add thresholded hard constraints to ensure at least one black performant district.
 
 ## Data Sources
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-We used a helper function to identify and merge discontiguous precincts.
+We use a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs), which were merged prior to simulation.
+Because the Essex MCDGRP identifiers are broken and produce a distorted baseline merge, several counties have raw Democratic shares far below the 2000 MEDSL targets. 
+We apply a county-level logit shift to recalibrate ``ndv/nrv`` and widen the ``uniroot()`` search interval from ``[-1,1]`` to ``[-5,5]`` to accommodate the larger correction.
 
 ## Simulation Notes
-We sample 30,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
-After the simulation, we filtered out plans with discontiguous districts and thinned the remaining sample to 5,000 plans.
+We sample 5,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
+We also use the algorithmic mergesplit parameters to improve mixing.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -15,7 +15,7 @@ Data for ``New Jersey`` comes from the [ALARM Project's update](https://datavers
 
 ## Pre-processing Notes
 Because New Jersey contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
-We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval ``[-1, 1]`` was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to ``[-1.5, 1.5]`` to accommodate the larger correction.
+We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval [-1, 1] was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to [-1.5, 1.5] to accommodate the larger correction.
 
 ## Simulation Notes
 We sample 5,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -14,11 +14,10 @@ We add thresholded hard constraints to ensure at least one black performant dist
 Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-We use a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs), which were merged prior to simulation.
-Because the Essex MCDGRP identifiers are broken and produce a distorted baseline merge, several counties have raw Democratic shares far below the 2000 MEDSL targets. 
-We apply a county-level logit shift to recalibrate ``ndv/nrv`` and widen the ``uniroot()`` search interval from ``[-1,1]`` to ``[-5,5]`` to accommodate the larger correction.
+Because New Jersey contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
+We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval ``[-1, 1]`` was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to ``[-1.5, 1.5]`` to accommodate the larger correction.
 
 ## Simulation Notes
 We sample 5,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
-We also use the algorithmic mergesplit parameters to improve mixing.
+To improve mixing, we apply the merge-split procedure at every step of the algorithm and allow up to 20 updates within each step.
 To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 


### PR DESCRIPTION
## Redistricting requirements
In ``New Jersey``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be geographically contiguous
2. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint described below, which attempts to mimic the norms in ``New Jersey`` of generally preserving county and municipal boundaries.
We add thresholded hard constraints to ensure at least one black performant district.

## Data Sources
Data for ``New Jersey`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
Because ``New Jersey`` contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval [-1, 1] was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to [-1.5, 1.5] to accommodate the larger correction.

## Simulation Notes
We sample 5,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.
To improve mixing, we apply the merge-split procedure at every step of the algorithm and allow up to 20 updates within each step.
To balance county and municipality splits, we create pseudo-counties for use in the county constraint. 

## Validation
<img width="3000" height="4500" alt="validation_20260315_1743" src="https://github.com/user-attachments/assets/72acf9cf-1f5e-4b5a-898d-cf0eedb2b3e8" />



```
SMC with Merge-Split MCMC Steps: 5,000 sampled plans of 13 districts on 6,138 units
Plans sampled on Spanning Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.01
Mergesplit Parameters:
• `total_ms_steps` = 12
• `mh_accept_per_smc` = 20
• `pair_rule` = uniform
Plan diversity 80% range: 0.40 to 0.62
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv      plan_dev      pop_aian 
        1.002         1.003         1.001         1.001         1.011         1.012         1.011         1.001         1.016 
    pop_asian     pop_black      pop_hisp      pop_nhpi     pop_other   pop_overlap       pop_two     pop_white     total_vap 
        1.009         1.013         1.019         1.012         1.009         1.016         1.011         1.019         1.006 
     vap_aian     vap_asian     vap_black      vap_hisp      vap_nhpi     vap_other       vap_two     vap_white 
        1.011         1.013         1.015         1.014         1.015         1.008         1.016         1.018 
• R-hat ≤ 1.05: 338
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 338
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       198 (19.8%)     99.5%        1.15   645 (102%) 
Split 2       310 (31.0%)     78.4%        1.02   416 ( 66%) 
Split 3       427 (42.7%)     61.1%        0.86   456 ( 72%) 
Split 4       462 (46.2%)     53.5%        0.73   485 ( 77%) 
Split 5       637 (63.7%)     42.2%        0.65   509 ( 81%) 
Split 6       685 (68.5%)     35.1%        0.59   543 ( 86%) 
Split 7       711 (71.1%)     31.0%        0.55   540 ( 85%) 
Split 8       785 (78.5%)     25.9%        0.48   560 ( 89%) 
Split 9       815 (81.5%)     22.3%        0.45   554 ( 88%) 
Split 10      867 (86.7%)     18.9%        0.39   573 ( 91%) 
Split 11      890 (89.0%)     16.1%        0.34   570 ( 90%) 
Split 12      934 (93.4%)     13.5%        0.28   528 ( 84%) 
Resample      934 (93.4%)       NA%          NA   895 (142%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      41.8%                40
MS Step 2      32.5%                60
MS Step 3      27.7%                80
MS Step 4      25.3%                80
MS Step 5      23.8%                80
MS Step 6      22.4%               100
MS Step 7      22.7%               100
MS Step 8      22.7%               100
MS Step 9      23.1%               100
MS Step 10     23.4%               100
MS Step 11     24.6%               100
MS Step 12     25.4%               100

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Additional Notes
BVAP performance plot:
<img width="893" height="686" alt="ecent Black by VAR" src="https://github.com/user-attachments/assets/25b85d52-f624-46d3-91ea-49f62557cce9" />


Total Black performant districts:
```
  n_black_perf    n
1            1 4986
2            2   14
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny