### PR TITLE
2000 Kentucky Congressional Districts

### DIFF
--- a/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Download and prepare data for `KY_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg KY_cd_2000}")
+
+path_data <- download_redistricting_file("KY", "data-raw/KY", year = 2000, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/KY_2000/shp_vtd.rds"
+perim_path <- "data-out/KY_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong KY} shapefile")
+    # read in redistricting data
+    ky_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$KY)
+
+    ky_shp <- ky_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ky_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ky_shp$adj <- redist.adjacency(ky_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ky_shp <- ky_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ky_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ky_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong KY} shapefile")
+}

--- a/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
@@ -38,15 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ky_shp,
                                perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -55,8 +52,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     ky_shp$adj <- redist.adjacency(ky_shp)
-
-    # TODO any custom adjacency graph edits here
 
     ky_shp <- ky_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/01_prep_2000_KY_cd_2000.R
@@ -40,13 +40,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ky_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ky_shp <- rmapshaper::ms_simplify(ky_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `KY_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg KY_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ky_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = ky_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "KY_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/KY_2000/KY_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
@@ -10,7 +10,7 @@ map <- redist_map(ky_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KY_2000"

--- a/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
@@ -12,6 +12,16 @@ map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
         pop_muni = get_target(map)))
 
+# add cores
+map <- mutate(map,
+              core_id = redist.identify.cores(map$adj, map$cd_2000, boundary = 2),
+              core_id_lump = forcats::fct_lump_n(as.character(core_id), max(cd_2000)), # lump all non-core precincts in to "Other"
+              core_id = if_else(as.logical(is_county_split(core_id_lump, county)), # break off counties which are split by core border
+                                str_c(county, "_", core_id),
+                                as.character(core_id))) %>%
+  select(-core_id_lump)
+map_cores <- merge_by(map, core_id)
+
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KY_2000"
 

--- a/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/02_setup_KY_cd_2000.R
@@ -4,20 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg KY_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ky_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = ky_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KY_2000"

--- a/analyses/KY_cd_2000/03_sim_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/03_sim_KY_cd_2000.R
@@ -6,17 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg KY_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
 plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
@@ -30,8 +19,6 @@ plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/KY_2000/KY_cd_2000_plans.rds"), compress = "xz")
@@ -48,7 +35,6 @@ save_summary_stats(plans, "data-out/KY_2000/KY_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/KY_cd_2000/03_sim_KY_cd_2000.R
+++ b/analyses/KY_cd_2000/03_sim_KY_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `KY_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg KY_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/KY_2000/KY_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg KY_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/KY_2000/KY_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/KY_cd_2000/doc_KY_cd_2000.md
+++ b/analyses/KY_cd_2000/doc_KY_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Kentucky Congressional Districts
+
+## Redistricting requirements
+In Kentucky, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Kentucky comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Kentucky across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/KY_cd_2000/doc_KY_cd_2000.md
+++ b/analyses/KY_cd_2000/doc_KY_cd_2000.md
@@ -7,6 +7,9 @@ In Kentucky, according to [NCSL Redistricting Law 2000](https://web.archive.org/
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. meet the requirements of Section 2 of the Voting Rights Act
+1. preserve communities of interest
+1. preserve cores of existing districts
 
 
 ### Algorithmic Constraints

--- a/analyses/KY_cd_2000/doc_KY_cd_2000.md
+++ b/analyses/KY_cd_2000/doc_KY_cd_2000.md
@@ -13,13 +13,13 @@ In Kentucky, according to [NCSL Redistricting Law 2000](https://web.archive.org/
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Kentucky comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 1990 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Kentucky across 5 independent runs of the SMC algorithm.


### PR DESCRIPTION
## Redistricting requirements
In Kentucky, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. meet the requirements of Section 2 of the Voting Rights Act
1. preserve communities of interest
1. preserve cores of existing districts


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Kentucky comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 1990 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.

## Simulation Notes
We sample 10,000 districting plans for Kentucky across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.


## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/99cf1815-0063-4ee4-91b0-5764433d515a" />

```
SMC: 5,000 sampled plans of 6 districts on 994 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.50 to 0.76

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby      pop_aian 
        1.008         1.002         1.003         1.009         1.007         1.008 
      pop_two     pop_white     pop_black      pop_hisp     pop_asian      pop_nhpi 
        1.007         1.004         1.004         1.003         1.006         1.006 
    pop_other      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.004         1.003         1.008         1.006         1.005         1.004 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits 
        1.008         1.004         1.008         1.002         1.002 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,913 (95.7%)     11.9%        0.43 1,253 ( 99%)      6 
Split 2     1,900 (95.0%)     11.9%        0.41 1,275 (101%)      5 
Split 3     1,901 (95.0%)     16.4%        0.46 1,235 ( 98%)      3 
Split 4     1,862 (93.1%)     14.0%        0.54 1,211 ( 96%)      3 
Split 5     1,840 (92.0%)      6.8%        0.57 1,096 ( 87%)      2 
Resample    1,386 (69.3%)       NA%        0.55 1,533 (121%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,910 (95.5%)     10.3%        0.44 1,271 (101%)      7 
Split 2     1,896 (94.8%)     14.1%        0.41 1,273 (101%)      4 
Split 3     1,910 (95.5%)     16.7%        0.43 1,232 ( 97%)      3 
Split 4     1,850 (92.5%)      9.8%        0.55 1,212 ( 96%)      4 
Split 5     1,864 (93.2%)      4.6%        0.55 1,112 ( 88%)      3 
Resample    1,489 (74.4%)       NA%        0.51 1,598 (126%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,914 (95.7%)     12.3%        0.43 1,224 ( 97%)      6 
Split 2     1,894 (94.7%)     11.6%        0.43 1,243 ( 98%)      5 
Split 3     1,897 (94.8%)     16.0%        0.45 1,243 ( 98%)      3 
Split 4     1,849 (92.4%)     10.0%        0.55 1,193 ( 94%)      4 
Split 5     1,823 (91.1%)      4.3%        0.58 1,119 ( 89%)      3 
Resample    1,323 (66.2%)       NA%        0.57 1,529 (121%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,914 (95.7%)     10.5%        0.43 1,254 ( 99%)      7 
Split 2     1,900 (95.0%)     11.7%        0.41 1,254 ( 99%)      5 
Split 3     1,904 (95.2%)     12.4%        0.44 1,255 ( 99%)      4 
Split 4     1,888 (94.4%)     12.9%        0.50 1,227 ( 97%)      3 
Split 5     1,873 (93.7%)      4.7%        0.53 1,094 ( 87%)      3 
Resample    1,526 (76.3%)       NA%        0.50 1,602 (127%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,917 (95.8%)     10.4%        0.42 1,260 (100%)      7 
Split 2     1,896 (94.8%)     11.9%        0.41 1,262 (100%)      5 
Split 3     1,906 (95.3%)     16.8%        0.43 1,231 ( 97%)      3 
Split 4     1,886 (94.3%)     18.9%        0.49 1,195 ( 95%)      2 
Split 5     1,854 (92.7%)      6.5%        0.55 1,117 ( 88%)      2 
Resample    1,426 (71.3%)       NA%        0.52 1,570 (124%)     NA 
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny