### PR TITLE
2000 Pennsylvania Congressional Districts

### DIFF
--- a/analyses/PA_cd_2000/01_prep_PA_cd_2000.R
+++ b/analyses/PA_cd_2000/01_prep_PA_cd_2000.R
@@ -1,0 +1,65 @@
+###############################################################################
+# Download and prepare data for PA_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg PA_cd_2000}")
+path_data <- download_redistricting_file("PA", "data-raw/PA", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/PA_2000/shp_vtd.rds"
+perim_path <- "data-out/PA_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong PA} shapefile")
+  # read in redistricting data
+  pa_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$PA)
+  
+  pa_shp <- pa_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = pa_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    pa_shp <- rmapshaper::ms_simplify(pa_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  pa_shp$adj <- redist.adjacency(pa_shp)
+  
+  pa_shp <- pa_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(pa_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  pa_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong PA} shapefile")
+}

--- a/analyses/PA_cd_2000/02_setup_PA_cd_2000.R
+++ b/analyses/PA_cd_2000/02_setup_PA_cd_2000.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `PA_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg PA_cd_2000}")
+
+map <- redist_map(pa_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = pa_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "PA_2000"
+
+map$state <- "PA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/PA_2000/PA_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/PA_cd_2000/03_sim_PA_cd_2000.R
+++ b/analyses/PA_cd_2000/03_sim_PA_cd_2000.R
@@ -1,0 +1,32 @@
+###############################################################################
+# Simulate plans for `PA_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg PA_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 6e3, runs = 10, counties = county)
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 500) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/PA_2000/PA_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg PA_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/PA_2000/PA_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/PA_cd_2000/doc_PA_cd_2000.md
+++ b/analyses/PA_cd_2000/doc_PA_cd_2000.md
@@ -1,0 +1,18 @@
+# 2000 Pennsylvania Congressional Districts
+
+## Redistricting requirements
+In ``Pennsylvania``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), there are no state law requirements for congressional districts.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for ``Pennsylvania`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 60,000 districting plans for ``Pennsylvania`` across 10 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In ``Pennsylvania``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), there are no state law requirements for congressional districts.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for ``Pennsylvania`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 60,000 districting plans for ``Pennsylvania`` across 10 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="4500" alt="validation_20250804_1555" src="https://github.com/user-attachments/assets/dad2cad1-3982-4eb9-ab7e-a3cfef6d8c78" />

```
SMC: 5,000 sampled plans of 19 districts on 9,407 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.68 to 0.84

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby 
        1.011         1.010         1.017         1.017         1.022 
    pop_other       pop_two      pop_aian     pop_white      pop_hisp 
        1.011         1.013         1.017         1.011         1.011 
    pop_asian      pop_nhpi     pop_black      vap_hisp      vap_aian 
        1.022         1.030         1.014         1.016         1.011 
    vap_asian     vap_white     vap_black      vap_nhpi     vap_other 
        1.021         1.008         1.008         1.032         1.014 
      vap_two county_splits   muni_splits           ndv           nrv 
        1.013         1.021         1.030         1.013         1.020 
      ndshare 
        1.011 

Sampling diagnostics for SMC run 1 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,742 (95.7%)     26.8%        0.42 3,787 (100%)     10 
Split 2     5,724 (95.4%)     31.0%        0.44 3,757 ( 99%)      8 
Split 3     5,677 (94.6%)     37.1%        0.46 3,742 ( 99%)      6 
Split 4     5,658 (94.3%)     40.6%        0.47 3,713 ( 98%)      5 
Split 5     5,595 (93.3%)     29.6%        0.50 3,708 ( 98%)      7 
Split 6     5,486 (91.4%)     35.4%        0.55 3,699 ( 98%)      5 
Split 7     5,315 (88.6%)     39.5%        0.61 3,682 ( 97%)      4 
Split 8     5,188 (86.5%)     36.5%        0.67 3,667 ( 97%)      4 
Split 9     5,149 (85.8%)     21.8%        0.72 3,610 ( 95%)      7 
Split 10    5,032 (83.9%)     26.9%        0.76 3,619 ( 95%)      5 
Split 11    5,042 (84.0%)     29.3%        0.76 3,550 ( 94%)      4 
Split 12    5,178 (86.3%)     33.7%        0.72 3,604 ( 95%)      3 
Split 13    5,115 (85.3%)     38.9%        0.72 3,581 ( 94%)      2 
Split 14    5,147 (85.8%)     36.0%        0.72 3,577 ( 94%)      2 
Split 15    5,131 (85.5%)     31.7%        0.73 3,571 ( 94%)      2 
Split 16    5,186 (86.4%)     26.4%        0.70 3,470 ( 91%)      2 
Split 17    5,206 (86.8%)     16.1%        0.68 3,327 ( 88%)      3 
Split 18    5,363 (89.4%)      7.8%        0.64 2,994 ( 79%)      2 
Resample    3,680 (61.3%)       NA%        0.64 4,430 (117%)     NA 

Sampling diagnostics for SMC run 2 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,747 (95.8%)     20.7%        0.41 3,785 (100%)     13 
Split 2     5,716 (95.3%)     30.3%        0.44 3,700 ( 98%)      8 
Split 3     5,692 (94.9%)     32.9%        0.45 3,751 ( 99%)      7 
Split 4     5,641 (94.0%)     40.7%        0.48 3,687 ( 97%)      5 
Split 5     5,575 (92.9%)     25.9%        0.51 3,732 ( 98%)      8 
Split 6     5,474 (91.2%)     36.4%        0.55 3,696 ( 97%)      5 
Split 7     5,341 (89.0%)     39.5%        0.61 3,702 ( 98%)      4 
Split 8     5,160 (86.0%)     26.7%        0.68 3,656 ( 96%)      6 
Split 9     5,008 (83.5%)     34.0%        0.75 3,628 ( 96%)      4 
Split 10    5,048 (84.1%)     20.6%        0.78 3,607 ( 95%)      7 
Split 11    5,143 (85.7%)     24.9%        0.75 3,575 ( 94%)      5 
Split 12    5,150 (85.8%)     33.1%        0.73 3,592 ( 95%)      3 
Split 13    5,083 (84.7%)     20.4%        0.74 3,580 ( 94%)      5 
Split 14    4,888 (81.5%)     12.2%        0.78 3,527 ( 93%)      8 
Split 15    5,071 (84.5%)     17.2%        0.76 3,459 ( 91%)      5 
Split 16    5,250 (87.5%)     17.6%        0.70 3,463 ( 91%)      4 
Split 17    5,397 (89.9%)     10.1%        0.62 3,337 ( 88%)      6 
Split 18    5,356 (89.3%)      5.4%        0.61 3,165 ( 83%)      4 
Resample    3,342 (55.7%)       NA%        0.61 4,419 (117%)     NA 

Sampling diagnostics for SMC run 3 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,749 (95.8%)     16.8%        0.41 3,810 (100%)     16 
Split 2     5,709 (95.1%)     22.9%        0.45 3,752 ( 99%)     11 
Split 3     5,694 (94.9%)     33.1%        0.45 3,698 ( 98%)      7 
Split 4     5,667 (94.4%)     41.3%        0.47 3,730 ( 98%)      5 
Split 5     5,598 (93.3%)     51.5%        0.50 3,672 ( 97%)      3 
Split 6     5,467 (91.1%)     48.9%        0.55 3,732 ( 98%)      3 
Split 7     5,254 (87.6%)     54.7%        0.63 3,689 ( 97%)      2 
Split 8     5,054 (84.2%)     36.8%        0.72 3,672 ( 97%)      4 
Split 9     4,999 (83.3%)     41.1%        0.77 3,574 ( 94%)      3 
Split 10    5,041 (84.0%)     27.3%        0.79 3,528 ( 93%)      5 
Split 11    5,156 (85.9%)     30.7%        0.75 3,519 ( 93%)      4 
Split 12    5,172 (86.2%)     33.8%        0.73 3,578 ( 94%)      3 
Split 13    5,081 (84.7%)     39.1%        0.74 3,556 ( 94%)      2 
Split 14    5,032 (83.9%)     23.2%        0.76 3,524 ( 93%)      4 
Split 15    5,149 (85.8%)     25.8%        0.74 3,503 ( 92%)      3 
Split 16    5,171 (86.2%)     28.5%        0.71 3,438 ( 91%)      2 
Split 17    5,256 (87.6%)     14.3%        0.67 3,292 ( 87%)      4 
Split 18    5,081 (84.7%)      4.5%        0.70 3,098 ( 82%)      5 
Resample    2,613 (43.5%)       NA%        0.70 4,122 (109%)     NA 

Sampling diagnostics for SMC run 4 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,748 (95.8%)     24.4%        0.41 3,783 (100%)     11 
Split 2     5,712 (95.2%)     31.1%        0.44 3,788 (100%)      8 
Split 3     5,683 (94.7%)     36.9%        0.46 3,727 ( 98%)      6 
Split 4     5,653 (94.2%)     24.4%        0.47 3,768 ( 99%)      9 
Split 5     5,594 (93.2%)     33.3%        0.51 3,744 ( 99%)      6 
Split 6     5,514 (91.9%)     36.0%        0.54 3,704 ( 98%)      5 
Split 7     5,285 (88.1%)     29.4%        0.62 3,702 ( 98%)      6 
Split 8     5,120 (85.3%)     31.6%        0.69 3,684 ( 97%)      5 
Split 9     5,097 (85.0%)     34.4%        0.74 3,637 ( 96%)      4 
Split 10    5,034 (83.9%)     17.7%        0.77 3,530 ( 93%)      8 
Split 11    5,089 (84.8%)     21.4%        0.77 3,553 ( 94%)      6 
Split 12    5,141 (85.7%)     27.1%        0.74 3,577 ( 94%)      4 
Split 13    5,050 (84.2%)     31.0%        0.74 3,593 ( 95%)      3 
Split 14    4,915 (81.9%)     18.9%        0.77 3,491 ( 92%)      5 
Split 15    5,050 (84.2%)     25.7%        0.75 3,464 ( 91%)      3 
Split 16    5,268 (87.8%)     21.3%        0.69 3,418 ( 90%)      3 
Split 17    5,345 (89.1%)     13.4%        0.64 3,310 ( 87%)      4 
Split 18    5,435 (90.6%)      6.3%        0.60 3,091 ( 81%)      3 
Resample    3,886 (64.8%)       NA%        0.60 4,543 (120%)     NA 

Sampling diagnostics for SMC run 5 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,756 (95.9%)     20.5%        0.41 3,784 (100%)     13 
Split 2     5,721 (95.4%)     25.2%        0.44 3,711 ( 98%)     10 
Split 3     5,683 (94.7%)     37.7%        0.46 3,728 ( 98%)      6 
Split 4     5,667 (94.5%)     46.7%        0.47 3,736 ( 99%)      4 
Split 5     5,570 (92.8%)     51.7%        0.51 3,719 ( 98%)      3 
Split 6     5,365 (89.4%)     35.8%        0.57 3,741 ( 99%)      5 
Split 7     5,186 (86.4%)     39.4%        0.64 3,632 ( 96%)      4 
Split 8     5,014 (83.6%)     37.8%        0.73 3,608 ( 95%)      4 
Split 9     5,029 (83.8%)     25.5%        0.78 3,515 ( 93%)      6 
Split 10    5,040 (84.0%)     32.4%        0.78 3,554 ( 94%)      4 
Split 11    5,119 (85.3%)     37.0%        0.76 3,615 ( 95%)      3 
Split 12    5,178 (86.3%)     23.4%        0.73 3,554 ( 94%)      5 
Split 13    5,168 (86.1%)     18.1%        0.70 3,596 ( 95%)      6 
Split 14    5,059 (84.3%)     23.2%        0.74 3,526 ( 93%)      4 
Split 15    5,070 (84.5%)     25.1%        0.73 3,494 ( 92%)      3 
Split 16    5,242 (87.4%)     27.0%        0.70 3,456 ( 91%)      2 
Split 17    5,413 (90.2%)     22.2%        0.62 3,392 ( 89%)      2 
Split 18    5,350 (89.2%)      8.0%        0.62 3,013 ( 79%)      2 
Resample    3,477 (57.9%)       NA%        0.62 4,448 (117%)     NA 

Sampling diagnostics for SMC run 6 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,753 (95.9%)     20.7%        0.41 3,836 (101%)     13 
Split 2     5,721 (95.4%)     27.9%        0.44 3,719 ( 98%)      9 
Split 3     5,680 (94.7%)     37.2%        0.46 3,736 ( 99%)      6 
Split 4     5,604 (93.4%)     47.0%        0.49 3,712 ( 98%)      4 
Split 5     5,523 (92.1%)     44.3%        0.52 3,696 ( 97%)      4 
Split 6     5,380 (89.7%)     24.0%        0.57 3,708 ( 98%)      8 
Split 7     5,257 (87.6%)     33.7%        0.63 3,655 ( 96%)      5 
Split 8     5,122 (85.4%)     37.1%        0.71 3,622 ( 95%)      4 
Split 9     5,034 (83.9%)     40.1%        0.76 3,586 ( 95%)      3 
Split 10    5,040 (84.0%)     47.4%        0.77 3,589 ( 95%)      2 
Split 11    5,052 (84.2%)     45.0%        0.77 3,631 ( 96%)      2 
Split 12    4,988 (83.1%)     27.6%        0.78 3,547 ( 94%)      4 
Split 13    5,040 (84.0%)     17.8%        0.77 3,533 ( 93%)      6 
Split 14    5,088 (84.8%)     23.0%        0.75 3,583 ( 94%)      4 
Split 15    5,131 (85.5%)     17.5%        0.74 3,501 ( 92%)      5 
Split 16    5,296 (88.3%)     22.1%        0.68 3,462 ( 91%)      3 
Split 17    5,250 (87.5%)      8.5%        0.68 3,323 ( 88%)      7 
Split 18    5,395 (89.9%)      3.6%        0.62 3,154 ( 83%)      6 
Resample    3,726 (62.1%)       NA%        0.62 4,476 (118%)     NA 

Sampling diagnostics for SMC run 7 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,748 (95.8%)     20.5%        0.41 3,829 (101%)     13 
Split 2     5,715 (95.3%)     30.9%        0.44 3,757 ( 99%)      8 
Split 3     5,686 (94.8%)     37.1%        0.46 3,753 ( 99%)      6 
Split 4     5,640 (94.0%)     28.1%        0.48 3,755 ( 99%)      8 
Split 5     5,546 (92.4%)     38.5%        0.52 3,710 ( 98%)      5 
Split 6     5,487 (91.4%)     49.3%        0.55 3,729 ( 98%)      3 
Split 7     5,351 (89.2%)     22.5%        0.60 3,668 ( 97%)      8 
Split 8     5,102 (85.0%)     31.1%        0.69 3,646 ( 96%)      5 
Split 9     5,076 (84.6%)     35.1%        0.75 3,609 ( 95%)      4 
Split 10    4,944 (82.4%)     28.0%        0.79 3,589 ( 95%)      5 
Split 11    5,057 (84.3%)     30.2%        0.79 3,570 ( 94%)      4 
Split 12    5,175 (86.3%)     33.6%        0.75 3,527 ( 93%)      3 
Split 13    5,119 (85.3%)     39.1%        0.72 3,601 ( 95%)      2 
Split 14    5,026 (83.8%)     36.1%        0.75 3,593 ( 95%)      2 
Split 15    5,126 (85.4%)     31.9%        0.74 3,482 ( 92%)      2 
Split 16    5,255 (87.6%)     28.2%        0.68 3,451 ( 91%)      2 
Split 17    5,415 (90.3%)     22.3%        0.62 3,363 ( 89%)      2 
Split 18    5,447 (90.8%)      8.4%        0.59 3,046 ( 80%)      2 
Resample    3,885 (64.8%)       NA%        0.59 4,521 (119%)     NA 

Sampling diagnostics for SMC run 8 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,749 (95.8%)     27.3%        0.41 3,812 (101%)     10 
Split 2     5,707 (95.1%)     28.5%        0.45 3,750 ( 99%)      9 
Split 3     5,684 (94.7%)     37.9%        0.46 3,709 ( 98%)      6 
Split 4     5,613 (93.6%)     35.9%        0.49 3,755 ( 99%)      6 
Split 5     5,527 (92.1%)     29.0%        0.52 3,738 ( 99%)      7 
Split 6     5,418 (90.3%)     42.3%        0.56 3,724 ( 98%)      4 
Split 7     5,215 (86.9%)     46.8%        0.64 3,712 ( 98%)      3 
Split 8     5,042 (84.0%)     37.4%        0.72 3,681 ( 97%)      4 
Split 9     4,958 (82.6%)     40.7%        0.78 3,613 ( 95%)      3 
Split 10    4,998 (83.3%)     47.0%        0.80 3,603 ( 95%)      2 
Split 11    5,025 (83.8%)     21.7%        0.78 3,554 ( 94%)      6 
Split 12    5,067 (84.5%)     27.7%        0.74 3,549 ( 94%)      4 
Split 13    5,029 (83.8%)     25.9%        0.74 3,563 ( 94%)      4 
Split 14    4,977 (82.9%)     29.0%        0.77 3,541 ( 93%)      3 
Split 15    5,083 (84.7%)     31.9%        0.76 3,507 ( 92%)      2 
Split 16    5,238 (87.3%)     17.4%        0.71 3,419 ( 90%)      4 
Split 17    5,154 (85.9%)     17.8%        0.68 3,336 ( 88%)      3 
Split 18    5,314 (88.6%)      8.5%        0.65 3,023 ( 80%)      2 
Resample    3,484 (58.1%)       NA%        0.65 4,380 (115%)     NA 

Sampling diagnostics for SMC run 9 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,748 (95.8%)     20.6%        0.41 3,774 (100%)     13 
Split 2     5,703 (95.1%)     25.3%        0.45 3,721 ( 98%)     10 
Split 3     5,693 (94.9%)     33.4%        0.46 3,701 ( 98%)      7 
Split 4     5,647 (94.1%)     39.7%        0.47 3,747 ( 99%)      5 
Split 5     5,548 (92.5%)     38.3%        0.52 3,741 ( 99%)      5 
Split 6     5,468 (91.1%)     41.9%        0.55 3,707 ( 98%)      4 
Split 7     5,272 (87.9%)     28.5%        0.61 3,685 ( 97%)      6 
Split 8     5,123 (85.4%)     37.6%        0.69 3,660 ( 97%)      4 
Split 9     5,071 (84.5%)     41.2%        0.74 3,629 ( 96%)      3 
Split 10    5,031 (83.9%)     38.7%        0.77 3,609 ( 95%)      3 
Split 11    5,048 (84.1%)     21.1%        0.77 3,532 ( 93%)      6 
Split 12    5,115 (85.3%)     27.1%        0.75 3,577 ( 94%)      4 
Split 13    5,068 (84.5%)     30.9%        0.75 3,561 ( 94%)      3 
Split 14    5,008 (83.5%)     15.9%        0.75 3,541 ( 93%)      6 
Split 15    5,056 (84.3%)     20.7%        0.76 3,533 ( 93%)      4 
Split 16    5,163 (86.0%)     22.0%        0.73 3,464 ( 91%)      3 
Split 17    5,219 (87.0%)     13.7%        0.69 3,309 ( 87%)      4 
Split 18    5,436 (90.6%)      6.2%        0.61 3,077 ( 81%)      3 
Resample    3,951 (65.8%)       NA%        0.61 4,523 (119%)     NA 

Sampling diagnostics for SMC run 10 of 10 (6,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     5,749 (95.8%)     24.4%        0.41 3,790 (100%)     11 
Split 2     5,710 (95.2%)     24.9%        0.45 3,787 (100%)     10 
Split 3     5,692 (94.9%)     33.5%        0.45 3,746 ( 99%)      7 
Split 4     5,654 (94.2%)     30.8%        0.47 3,743 ( 99%)      7 
Split 5     5,573 (92.9%)     38.5%        0.51 3,717 ( 98%)      5 
Split 6     5,464 (91.1%)     24.4%        0.55 3,682 ( 97%)      8 
Split 7     5,266 (87.8%)     26.0%        0.62 3,734 ( 98%)      7 
Split 8     5,097 (85.0%)     31.5%        0.70 3,678 ( 97%)      5 
Split 9     5,097 (84.9%)     34.8%        0.75 3,593 ( 95%)      4 
Split 10    5,070 (84.5%)     39.1%        0.77 3,582 ( 94%)      3 
Split 11    5,191 (86.5%)     36.2%        0.73 3,641 ( 96%)      3 
Split 12    5,249 (87.5%)     33.7%        0.70 3,626 ( 96%)      3 
Split 13    5,135 (85.6%)     38.4%        0.71 3,611 ( 95%)      2 
Split 14    5,055 (84.2%)     35.4%        0.72 3,588 ( 95%)      2 
Split 15    5,104 (85.1%)     24.9%        0.73 3,506 ( 92%)      3 
Split 16    5,120 (85.3%)     21.1%        0.72 3,466 ( 91%)      3 
Split 17    5,186 (86.4%)     21.5%        0.71 3,276 ( 86%)      2 
Split 18    5,444 (90.7%)      5.0%        0.60 3,036 ( 80%)      4 
Resample    3,752 (62.5%)       NA%        0.60 4,553 (120%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%),
large std. devs. of the log weights (more than 3 or so), and low numbers of
unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny