### PR TITLE
2000 Minnesota Congressional Districts

### DIFF
--- a/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
@@ -38,15 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = mn_shp,
                                perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -55,8 +52,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     mn_shp$adj <- redist.adjacency(mn_shp)
-
-    # TODO any custom adjacency graph edits here
 
     mn_shp <- mn_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Download and prepare data for `MN_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MN_cd_2000}")
+
+path_data <- download_redistricting_file("MN", "data-raw/MN", year = 2000, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MN_2000/shp_vtd.rds"
+perim_path <- "data-out/MN_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MN} shapefile")
+    # read in redistricting data
+    mn_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$MN)
+
+    mn_shp <- mn_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mn_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mn_shp$adj <- redist.adjacency(mn_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    mn_shp <- mn_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(mn_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mn_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MN} shapefile")
+}

--- a/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/01_prep_2000_MN_cd_2000.R
@@ -40,13 +40,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = mn_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 

--- a/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `MN_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MN_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(mn_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = mn_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MN_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MN_2000/MN_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
@@ -10,7 +10,7 @@ map <- redist_map(mn_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MN_2000"
 

--- a/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/02_setup_MN_cd_2000.R
@@ -4,21 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg MN_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(mn_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = mn_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MN_2000"
 

--- a/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
@@ -18,7 +18,7 @@ cli_process_start("Running simulations for {.pkg MN_cd_2000}")
 #  if that's the problem.
 #  - Ask for help!
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 

--- a/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
@@ -6,17 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MN_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
 plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
@@ -30,8 +19,6 @@ plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/MN_2000/MN_cd_2000_plans.rds"), compress = "xz")
@@ -48,7 +35,6 @@ save_summary_stats(plans, "data-out/MN_2000/MN_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
+++ b/analyses/MN_cd_2000/03_sim_MN_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `MN_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MN_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MN_2000/MN_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MN_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MN_2000/MN_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/MN_cd_2000/doc_MN_cd_2000.md
+++ b/analyses/MN_cd_2000/doc_MN_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Minnesota Congressional Districts
+
+## Redistricting requirements
+In Minnesota, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Minnesota across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/MN_cd_2000/doc_MN_cd_2000.md
+++ b/analyses/MN_cd_2000/doc_MN_cd_2000.md
@@ -7,10 +7,11 @@ In Minnesota, according to [NCSL Redistricting Law 2000](https://web.archive.org
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. not dilute the voting strength of racial or language minority groups
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

--- a/analyses/MN_cd_2000/doc_MN_cd_2000.md
+++ b/analyses/MN_cd_2000/doc_MN_cd_2000.md
@@ -20,6 +20,6 @@ Data for Minnesota comes from the [ALARM Project's update](https://dataverse.har
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Minnesota across 5 independent runs of the SMC algorithm.
+We sample 20,000 districting plans for Minnesota across 10 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Minnesota, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not dilute the voting strength of racial or language minority groups


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for Minnesota across 10 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.


## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/0438e1c6-10d9-4ecd-8e98-dcb69997f997" />

```
SMC: 10,000 sampled plans of 8 districts on 4,094 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.71 to 0.92

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other 
        1.009         1.004         1.007         1.005         1.007         1.006 
      pop_two      pop_aian     pop_white     pop_black      pop_hisp     pop_asian 
        1.004         1.008         1.003         1.004         1.011         1.009 
     pop_nhpi      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.005         1.010         1.008         1.008         1.005         1.004 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits           ndv 
        1.003         1.006         1.004         1.008         1.002         1.002 
          nrv       ndshare 
        1.008         1.006 

Sampling diagnostics for SMC run 1 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,969 (98.4%)     11.0%        0.25 1,245 ( 98%)     12 
Split 2     1,932 (96.6%)     13.6%        0.36 1,236 ( 98%)      8 
Split 3     1,885 (94.2%)     17.5%        0.47 1,232 ( 97%)      5 
Split 4     1,889 (94.5%)     12.6%        0.48 1,249 ( 99%)      6 
Split 5     1,845 (92.3%)     14.8%        0.54 1,252 ( 99%)      4 
Split 6     1,838 (91.9%)     15.5%        0.55 1,169 ( 92%)      3 
Split 7     1,835 (91.7%)      7.1%        0.54 1,071 ( 85%)      2 
Resample    1,316 (65.8%)       NA%        0.53 1,544 (122%)     NA 

Sampling diagnostics for SMC run 2 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,968 (98.4%)     10.8%        0.25 1,257 ( 99%)     12 
Split 2     1,908 (95.4%)     14.9%        0.38 1,257 ( 99%)      7 
Split 3     1,887 (94.4%)     10.3%        0.46 1,232 ( 97%)      9 
Split 4     1,813 (90.6%)     13.0%        0.55 1,240 ( 98%)      6 
Split 5     1,721 (86.1%)     15.7%        0.63 1,221 ( 97%)      4 
Split 6     1,821 (91.1%)     15.2%        0.59 1,182 ( 93%)      3 
Split 7     1,809 (90.5%)      7.2%        0.56 1,072 ( 85%)      2 
Resample    1,191 (59.6%)       NA%        0.55 1,522 (120%)     NA 

Sampling diagnostics for SMC run 3 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,967 (98.3%)      8.9%        0.26 1,249 ( 99%)     14 
Split 2     1,935 (96.7%)     13.6%        0.35 1,268 (100%)      8 
Split 3     1,897 (94.8%)     14.7%        0.44 1,264 (100%)      6 
Split 4     1,866 (93.3%)     18.2%        0.50 1,244 ( 98%)      4 
Split 5     1,846 (92.3%)     15.5%        0.53 1,222 ( 97%)      4 
Split 6     1,834 (91.7%)     16.0%        0.55 1,212 ( 96%)      3 
Split 7     1,815 (90.8%)      5.3%        0.55 1,092 ( 86%)      3 
Resample    1,159 (58.0%)       NA%        0.53 1,544 (122%)     NA 

Sampling diagnostics for SMC run 4 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,970 (98.5%)     12.6%        0.25 1,278 (101%)     10 
Split 2     1,928 (96.4%)     17.6%        0.36 1,255 ( 99%)      6 
Split 3     1,895 (94.8%)     20.4%        0.45 1,240 ( 98%)      4 
Split 4     1,870 (93.5%)     23.3%        0.51 1,240 ( 98%)      3 
Split 5     1,872 (93.6%)     19.3%        0.53 1,236 ( 98%)      3 
Split 6     1,862 (93.1%)     21.9%        0.54 1,189 ( 94%)      2 
Split 7     1,844 (92.2%)      7.0%        0.55 1,087 ( 86%)      2 
Resample    1,345 (67.2%)       NA%        0.52 1,562 (124%)     NA 

Sampling diagnostics for SMC run 5 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,970 (98.5%)      9.3%        0.25 1,257 ( 99%)     14 
Split 2     1,929 (96.4%)     11.7%        0.36 1,236 ( 98%)      9 
Split 3     1,892 (94.6%)     17.8%        0.46 1,237 ( 98%)      5 
Split 4     1,878 (93.9%)     10.7%        0.50 1,216 ( 96%)      7 
Split 5     1,863 (93.2%)     15.1%        0.53 1,247 ( 99%)      4 
Split 6     1,829 (91.5%)     15.6%        0.58 1,171 ( 93%)      3 
Split 7     1,833 (91.6%)      2.0%        0.56 1,085 ( 86%)      8 
Resample    1,311 (65.5%)       NA%        0.53 1,549 (123%)     NA 

Sampling diagnostics for SMC run 6 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,970 (98.5%)      9.4%        0.25 1,253 ( 99%)     13 
Split 2     1,909 (95.5%)     13.3%        0.36 1,239 ( 98%)      8 
Split 3     1,875 (93.8%)     17.6%        0.45 1,234 ( 98%)      5 
Split 4     1,841 (92.1%)     22.7%        0.52 1,235 ( 98%)      3 
Split 5     1,823 (91.1%)     26.4%        0.56 1,224 ( 97%)      2 
Split 6     1,857 (92.9%)      9.6%        0.55 1,156 ( 91%)      5 
Split 7     1,824 (91.2%)      4.1%        0.57 1,067 ( 84%)      4 
Resample    1,248 (62.4%)       NA%        0.55 1,556 (123%)     NA 

Sampling diagnostics for SMC run 7 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,969 (98.4%)      8.5%        0.25 1,262 (100%)     15 
Split 2     1,926 (96.3%)     12.0%        0.36 1,277 (101%)      9 
Split 3     1,913 (95.7%)     14.8%        0.44 1,238 ( 98%)      6 
Split 4     1,882 (94.1%)     18.9%        0.49 1,243 ( 98%)      4 
Split 5     1,878 (93.9%)     19.7%        0.51 1,234 ( 98%)      3 
Split 6     1,847 (92.4%)     12.0%        0.56 1,196 ( 95%)      4 
Split 7     1,875 (93.7%)      5.9%        0.51 1,060 ( 84%)      3 
Resample    1,492 (74.6%)       NA%        0.48 1,589 (126%)     NA 

Sampling diagnostics for SMC run 8 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,970 (98.5%)     11.4%        0.25 1,258 (100%)     11 
Split 2     1,925 (96.3%)     14.8%        0.36 1,255 ( 99%)      7 
Split 3     1,899 (95.0%)     17.3%        0.45 1,252 ( 99%)      5 
Split 4     1,868 (93.4%)     23.0%        0.51 1,241 ( 98%)      3 
Split 5     1,847 (92.3%)     20.3%        0.54 1,212 ( 96%)      3 
Split 6     1,827 (91.4%)     21.5%        0.58 1,173 ( 93%)      2 
Split 7     1,812 (90.6%)      7.4%        0.58 1,095 ( 87%)      2 
Resample    1,173 (58.7%)       NA%        0.54 1,515 (120%)     NA 

Sampling diagnostics for SMC run 9 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,969 (98.4%)     12.6%        0.26 1,257 ( 99%)     10 
Split 2     1,929 (96.4%)     17.8%        0.35 1,246 ( 99%)      6 
Split 3     1,906 (95.3%)     21.2%        0.43 1,237 ( 98%)      4 
Split 4     1,890 (94.5%)     17.7%        0.48 1,238 ( 98%)      4 
Split 5     1,869 (93.5%)     19.9%        0.52 1,228 ( 97%)      3 
Split 6     1,806 (90.3%)     12.9%        0.59 1,189 ( 94%)      4 
Split 7     1,788 (89.4%)      3.4%        0.63 1,085 ( 86%)      5 
Resample    1,116 (55.8%)       NA%        0.59 1,481 (117%)     NA 

Sampling diagnostics for SMC run 10 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,968 (98.4%)      9.5%        0.26 1,287 (102%)     13 
Split 2     1,944 (97.2%)     13.5%        0.32 1,258 (100%)      8 
Split 3     1,901 (95.0%)     17.8%        0.43 1,264 (100%)      5 
Split 4     1,878 (93.9%)     22.8%        0.49 1,254 ( 99%)      3 
Split 5     1,826 (91.3%)     28.0%        0.55 1,253 ( 99%)      2 
Split 6     1,752 (87.6%)     15.5%        0.63 1,157 ( 92%)      3 
Split 7     1,836 (91.8%)      3.4%        0.58 1,085 ( 86%)      5 
Resample    1,360 (68.0%)       NA%        0.54 1,541 (122%)     NA 

```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny