### PR TITLE
2000 New Mexico Congressional Districts

### DIFF
--- a/analyses/NM_cd_2000/01_prep_2000_NM_cd_2000.R
+++ b/analyses/NM_cd_2000/01_prep_2000_NM_cd_2000.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Download and prepare data for `NM_cd_2000` analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NM_cd_2000}")
+
+path_data <- download_redistricting_file("NM", "data-raw/NM", year = 2000, overwrite=TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NM_2000/shp_vtd.rds"
+perim_path <- "data-out/NM_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NM} shapefile")
+    # read in redistricting data
+    nm_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$NM)
+
+    nm_shp <- nm_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nm_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nm_shp <- rmapshaper::ms_simplify(nm_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nm_shp$adj <- redist.adjacency(nm_shp)
+
+    nm_shp <- nm_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(nm_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nm_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NM} shapefile")
+}

--- a/analyses/NM_cd_2000/02_setup_NM_cd_2000.R
+++ b/analyses/NM_cd_2000/02_setup_NM_cd_2000.R
@@ -1,0 +1,21 @@
+###############################################################################
+# Set up redistricting simulation for `NM_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NM_cd_2000}")
+
+map <- redist_map(nm_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = nm_shp$adj)
+
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NM_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NM_2000/NM_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NM_cd_2000/03_sim_NM_cd_2000.R
+++ b/analyses/NM_cd_2000/03_sim_NM_cd_2000.R
@@ -1,0 +1,44 @@
+###############################################################################
+# Simulate plans for `NM_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NM_cd_2000}")
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2000, runs = 10, compactness=1, counties = county, pop_temper = 0.05, verbose = TRUE)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NM_2000/NM_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NM_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NM_2000/NM_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}
+

--- a/analyses/NM_cd_2000/doc_NM_cd_2000.md
+++ b/analyses/NM_cd_2000/doc_NM_cd_2000.md
@@ -1,0 +1,28 @@
+# 2000 New Mexico Congressional Districts
+
+## Redistricting requirements
+In New Mexico, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+The house of representatives is composed of seventy members to be elected from districts that are contiguous and that are as compact as is practical and possible.
+The senate is composed of forty-two members to be elected from districts that are contiguous and that are as compact as is practical and possible.
+nsims = 2000, runs = 10 (20000 plans total)
+pop_temper=0.05
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for New Mexico comes from the ALARM Project's [2000 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 20000 redistricting plans for New Mexico across 10 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5000.
+We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.


### PR DESCRIPTION
# 2000 New Mexico Congressional Districts

## Redistricting requirements
In New Mexico, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible

Regulations in 2000:
The house of representatives is composed of seventy members to be elected from districts that are contiguous and that are as compact as is practical and possible.
The senate is composed of forty-two members to be elected from districts that are contiguous and that are as compact as is practical and possible.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
nsims = 2000, runs = 10 (20000 plans total)
pop_temper=0.05

## Data Sources
Data for New Mexico comes from the ALARM Project's [2000 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20000 redistricting plans for New Mexico across 10 independent runs of the SMC algorithm.
We then thinned the number of samples to 5000.
We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.

## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/51ef5f6f-8e93-4576-8f8f-20d956108607" />

```
SMC: 10,000 sampled plans of 3 districts on 1,346 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0.05

Plan diversity 80% range: 0.23 to 0.68
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two      pop_aian     pop_white 
        1.001         1.001         1.000         1.001         1.001         1.001         1.001         1.001         1.001 
     pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.000         1.001         1.001         1.002         1.001         1.001         1.001         1.001         1.002 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits 
        1.001         1.001         1.001         1.001         1.000 

Sampling diagnostics for SMC run 1 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,930 (96.5%)     10.3%        0.41 1,279 (101%)      7 
Split 2     1,868 (93.4%)      5.4%        0.53 1,205 ( 95%)      5 
Resample    1,518 (75.9%)       NA%        0.53 1,598 (126%)     NA 

Sampling diagnostics for SMC run 2 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,935 (96.8%)      7.5%        0.39 1,252 ( 99%)     10 
Split 2     1,886 (94.3%)      4.6%        0.51 1,207 ( 95%)      6 
Resample    1,609 (80.4%)       NA%        0.50 1,629 (129%)     NA 

Sampling diagnostics for SMC run 3 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,931 (96.5%)      9.3%        0.41 1,261 (100%)      8 
Split 2     1,884 (94.2%)      5.5%        0.50 1,178 ( 93%)      5 
Resample    1,564 (78.2%)       NA%        0.50 1,634 (129%)     NA 

Sampling diagnostics for SMC run 4 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,934 (96.7%)      8.3%        0.40 1,287 (102%)      9 
Split 2     1,863 (93.1%)      5.6%        0.53 1,185 ( 94%)      5 
Resample    1,450 (72.5%)       NA%        0.53 1,593 (126%)     NA 

Sampling diagnostics for SMC run 5 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,929 (96.4%)      9.4%        0.41 1,264 (100%)      8 
Split 2     1,867 (93.3%)      5.3%        0.53 1,186 ( 94%)      5 
Resample    1,501 (75.1%)       NA%        0.53 1,613 (128%)     NA 

Sampling diagnostics for SMC run 6 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,933 (96.7%)      9.1%        0.40 1,253 ( 99%)      8 
Split 2     1,881 (94.0%)      5.5%        0.51 1,169 ( 92%)      5 
Resample    1,586 (79.3%)       NA%        0.51 1,624 (128%)     NA 

Sampling diagnostics for SMC run 7 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,933 (96.7%)      8.0%        0.40 1,275 (101%)      9 
Split 2     1,869 (93.5%)      5.5%        0.53 1,183 ( 94%)      5 
Resample    1,519 (76.0%)       NA%        0.53 1,595 (126%)     NA 

Sampling diagnostics for SMC run 8 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,929 (96.4%)     13.8%        0.41 1,275 (101%)      5 
Split 2     1,862 (93.1%)      8.7%        0.53 1,223 ( 97%)      3 
Resample    1,472 (73.6%)       NA%        0.53 1,589 (126%)     NA 

Sampling diagnostics for SMC run 9 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,930 (96.5%)      7.3%        0.41 1,278 (101%)     10 
Split 2     1,858 (92.9%)      4.0%        0.53 1,191 ( 94%)      7 
Resample    1,421 (71.1%)       NA%        0.53 1,595 (126%)     NA 

Sampling diagnostics for SMC run 10 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,930 (96.5%)      9.1%        0.41 1,261 (100%)      8 
Split 2     1,877 (93.8%)      5.1%        0.52 1,190 ( 94%)      5 
Resample    1,565 (78.3%)       NA%        0.52 1,614 (128%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with
`hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing constraints, or increasing the population tolerance. If the
acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
```



## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
