### PR TITLE
2000 Kansas Congressional Districts

### DIFF
--- a/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
@@ -38,15 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ks_shp,
                                perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -54,9 +51,9 @@ if (!file.exists(here(shp_path))) {
     }
 
     # create adjacency graph
-    ks_shp$adj <- redist.adjacency(ks_shp)
-
-    # TODO any custom adjacency graph edits here
+    ks_shp$adj <- redist.adjacency(ks_shp) %>%
+      add_edge(2452, 2451, zero = TRUE) %>%
+      add_edge(2451, 2452, zero = TRUE)
 
     ks_shp <- ks_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
@@ -40,20 +40,20 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = ks_shp,
-                               perim_path = here(perim_path)) %>%
+        perim_path = here(perim_path)) %>%
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) %>%
+            keep_shapes = TRUE) %>%
             suppressWarnings()
     }
 
     # create adjacency graph
     ks_shp$adj <- redist.adjacency(ks_shp) %>%
-      add_edge(2452, 2451, zero = TRUE) %>%
-      add_edge(2451, 2452, zero = TRUE)
+        add_edge(2452, 2451, zero = TRUE) %>%
+        add_edge(2451, 2452, zero = TRUE)
 
     ks_shp <- ks_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/01_prep_2000_KS_cd_2000.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Download and prepare data for `KS_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg KS_cd_2000}")
+
+path_data <- download_redistricting_file("KS", "data-raw/KS", year = 2000, overwrite = TRUE)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/KS_2000/shp_vtd.rds"
+perim_path <- "data-out/KS_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong KS} shapefile")
+    # read in redistricting data
+    ks_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$KS)
+
+    ks_shp <- ks_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ks_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ks_shp <- rmapshaper::ms_simplify(ks_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ks_shp$adj <- redist.adjacency(ks_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ks_shp <- ks_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ks_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ks_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong KS} shapefile")
+}

--- a/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
@@ -4,20 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg KS_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ks_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = ks_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KS_2000"

--- a/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
@@ -10,7 +10,7 @@ map <- redist_map(ks_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "KS_2000"

--- a/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/02_setup_KS_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `KS_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg KS_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ks_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = ks_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "KS_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/KS_2000/KS_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/KS_cd_2000/03_sim_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/03_sim_KS_cd_2000.R
@@ -6,21 +6,8 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg KS_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
 plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans %>%
     group_by(chain) %>%
@@ -30,8 +17,6 @@ plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/KS_2000/KS_cd_2000_plans.rds"), compress = "xz")
@@ -48,7 +33,6 @@ save_summary_stats(plans, "data-out/KS_2000/KS_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/KS_cd_2000/03_sim_KS_cd_2000.R
+++ b/analyses/KS_cd_2000/03_sim_KS_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `KS_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg KS_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/KS_2000/KS_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg KS_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/KS_2000/KS_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/KS_cd_2000/doc_KS_cd_2000.md
+++ b/analyses/KS_cd_2000/doc_KS_cd_2000.md
@@ -12,7 +12,7 @@ In Kansas, according to [NCSL Redistricting Law 2000](https://web.archive.org/we
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Kansas comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

--- a/analyses/KS_cd_2000/doc_KS_cd_2000.md
+++ b/analyses/KS_cd_2000/doc_KS_cd_2000.md
@@ -7,6 +7,8 @@ In Kansas, according to [NCSL Redistricting Law 2000](https://web.archive.org/we
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. preserve communities of interest
+1. not be drawn to dilute minority voting strength or protect or defeat an incumbent
 
 
 ### Algorithmic Constraints

--- a/analyses/KS_cd_2000/doc_KS_cd_2000.md
+++ b/analyses/KS_cd_2000/doc_KS_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Kansas Congressional Districts
+
+## Redistricting requirements
+In Kansas, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Kansas comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Kansas across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Kansas, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. preserve communities of interest
1. not be drawn to dilute minority voting strength or protect or defeat an incumbent


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Kansas comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Kansas across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.


## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/f68ea4c6-24ed-42ad-a659-948d8fd63496" />

```
✔ Running simulations for KS_cd_2000 ... done
SMC: 5,000 sampled plans of 4 districts on 3,730 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0  
ℹ Running simulations for KS_cd_2010
Plan diversity 80% range: 0.35 to 0.75
ℹ Running simulations for KS_cd_2010
R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other 
        1.001         1.001         1.002         1.000         1.003         1.000 
      pop_two      pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi 
        1.000         1.001         1.000         1.000         1.001         1.001 
    pop_black      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.000         1.000         1.001         1.001         1.000         1.000 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits           ndv 
        1.000         1.000         1.000         1.000         1.000         1.001 
          nrv       ndshare 
        1.001         1.000 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,868 (93.4%)      8.4%        0.51 1,267 (100%)     12 
Split 2     1,899 (95.0%)     13.2%        0.43 1,220 ( 97%)      8 
Split 3     1,872 (93.6%)      6.6%        0.51 1,141 ( 90%)      5 
Resample    1,541 (77.0%)       NA%        0.51 1,599 (126%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,873 (93.6%)     10.1%        0.49 1,280 (101%)     10 
Split 2     1,893 (94.6%)     11.3%        0.44 1,267 (100%)     10 
Split 3     1,850 (92.5%)      5.3%        0.54 1,151 ( 91%)      6 
Resample    1,448 (72.4%)       NA%        0.55 1,554 (123%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,872 (93.6%)     10.1%        0.50 1,269 (100%)     10 
Split 2     1,889 (94.4%)     13.8%        0.44 1,246 ( 99%)      8 
Split 3     1,865 (93.3%)      6.5%        0.52 1,129 ( 89%)      5 
Resample    1,514 (75.7%)       NA%        0.53 1,595 (126%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,871 (93.6%)      9.3%        0.50 1,278 (101%)     11 
Split 2     1,901 (95.0%)     13.9%        0.42 1,236 ( 98%)      8 
Split 3     1,883 (94.2%)      6.3%        0.49 1,143 ( 90%)      5 
Resample    1,591 (79.5%)       NA%        0.50 1,597 (126%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,865 (93.3%)     10.6%        0.51 1,255 ( 99%)     10 
Split 2     1,886 (94.3%)     18.0%        0.45 1,217 ( 96%)      6 
Split 3     1,880 (94.0%)      7.6%        0.51 1,136 ( 90%)      4 
Resample    1,587 (79.4%)       NA%        0.51 1,600 (127%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny