### PR TITLE
2000 Missouri Congressional Districts

### DIFF
--- a/analyses/MO_cd_2000/01_prep_2000_MO_cd_2000.R
+++ b/analyses/MO_cd_2000/01_prep_2000_MO_cd_2000.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Download and prepare data for `MO_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MO_cd_2000}")
+
+path_data <- download_redistricting_file("MO", "data-raw/MO", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MO_2000/shp_vtd.rds"
+perim_path <- "data-out/MO_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MO} shapefile")
+    # read in redistricting data
+    mo_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$MO)
+
+    mo_shp <- mo_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mo_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mo_shp <- rmapshaper::ms_simplify(mo_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mo_shp$adj <- redist.adjacency(mo_shp)
+
+    mo_shp <- mo_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(mo_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mo_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MO} shapefile")
+}

--- a/analyses/MO_cd_2000/02_setup_MO_cd_2000.R
+++ b/analyses/MO_cd_2000/02_setup_MO_cd_2000.R
@@ -1,11 +1,11 @@
 ###############################################################################
-# Set up redistricting simulation for `MO_cd_2010`
-# © ALARM Project, December 2022
+# Set up redistricting simulation for `MO_cd_2000`
+# © ALARM Project, August 2025
 ###############################################################################
-cli_process_start("Creating {.cls redist_map} object for {.pkg MO_cd_2010}")
+cli_process_start("Creating {.cls redist_map} object for {.pkg MO_cd_2000}")
 
 map <- redist_map(mo_shp, pop_tol = 0.005,
-    existing_plan = cd_2010, adj = mo_shp$adj)
+    existing_plan = cd_2000, adj = mo_shp$adj)
 
 # add cores
 map <- mutate(map,
@@ -17,10 +17,13 @@ map <- mutate(map,
   select(-core_id_lump)
 map_cores <- merge_by(map, core_id)
 
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+
 # Add an analysis name attribute
-attr(map, "analysis_name") <- "MO_2010"
-map$state <- "MO"
+attr(map, "analysis_name") <- "MO_2000"
 
 # Output the redist_map object. Do not edit this path.
-write_rds(map, "data-out/MO_2010/MO_cd_2010_map.rds", compress = "xz")
+write_rds(map, "data-out/MO_2000/MO_cd_2000_map.rds", compress = "xz")
 cli_process_done()

--- a/analyses/MO_cd_2000/03_sim_MO_cd_2000.R
+++ b/analyses/MO_cd_2000/03_sim_MO_cd_2000.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `MO_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MO_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MO_2000/MO_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MO_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MO_2000/MO_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/MO_cd_2000/doc_MO_cd_2000.md
+++ b/analyses/MO_cd_2000/doc_MO_cd_2000.md
@@ -1,0 +1,26 @@
+# 2000 Missouri Congressional Districts
+
+## Redistricting requirements
+In Missouri, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. not dilute the voting strength of racial or linguistic minority groups
+1. preserve the geographic cores of existing districts
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Missouri across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Missouri, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not dilute the voting strength of racial or linguistic minority groups
1. preserve the geographic cores of existing districts


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Missouri across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/13edff4b-9d3c-4ad1-a24e-4ce30072ae6d" />

```
SMC: 5,000 sampled plans of 9 districts on 3,960 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.61 to 0.85

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two      pop_aian 
        1.010         1.007         1.007         1.014         1.009         1.005         1.007         1.023 
    pop_white      pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp      vap_aian     vap_asian 
        1.009         1.006         1.009         1.014         1.012         1.006         1.022         1.010 
    vap_white     vap_black      vap_nhpi     vap_other       vap_two county_splits   muni_splits           ndv 
        1.004         1.015         1.014         1.009         1.011         1.005         1.009         1.020 
          nrv       ndshare 
        1.004         1.020 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)     13.7%        0.31 1,281 (101%)     10 
Split 2     1,926 (96.3%)     19.7%        0.40 1,250 ( 99%)      6 
Split 3     1,909 (95.4%)     25.3%        0.45 1,246 ( 99%)      4 
Split 4     1,878 (93.9%)     24.2%        0.50 1,235 ( 98%)      4 
Split 5     1,846 (92.3%)     26.5%        0.53 1,249 ( 99%)      3 
Split 6     1,829 (91.5%)     30.1%        0.58 1,202 ( 95%)      2 
Split 7     1,823 (91.1%)     24.2%        0.59 1,184 ( 94%)      2 
Split 8     1,770 (88.5%)      6.3%        0.65 1,072 ( 85%)      3 
Resample    1,026 (51.3%)       NA%        0.61 1,477 (117%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,950 (97.5%)      9.7%        0.31 1,272 (101%)     14 
Split 2     1,933 (96.6%)     15.4%        0.38 1,232 ( 97%)      8 
Split 3     1,914 (95.7%)     21.0%        0.44 1,254 ( 99%)      5 
Split 4     1,858 (92.9%)     29.2%        0.52 1,247 ( 99%)      3 
Split 5     1,836 (91.8%)     33.5%        0.53 1,240 ( 98%)      2 
Split 6     1,816 (90.8%)     29.7%        0.58 1,190 ( 94%)      2 
Split 7     1,803 (90.1%)     15.4%        0.65 1,189 ( 94%)      4 
Split 8     1,804 (90.2%)      6.7%        0.66 1,078 ( 85%)      3 
Resample    1,290 (64.5%)       NA%        0.61 1,484 (117%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,949 (97.5%)     10.3%        0.32 1,251 ( 99%)     13 
Split 2     1,932 (96.6%)     15.8%        0.39 1,249 ( 99%)      8 
Split 3     1,905 (95.3%)     20.7%        0.45 1,229 ( 97%)      5 
Split 4     1,874 (93.7%)     19.4%        0.50 1,222 ( 97%)      5 
Split 5     1,853 (92.7%)     17.6%        0.53 1,223 ( 97%)      5 
Split 6     1,814 (90.7%)     19.9%        0.59 1,221 ( 97%)      4 
Split 7     1,818 (90.9%)      7.9%        0.60 1,158 ( 92%)      8 
Split 8     1,837 (91.9%)      4.3%        0.58 1,059 ( 84%)      5 
Resample    1,391 (69.6%)       NA%        0.56 1,534 (121%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,949 (97.5%)     14.9%        0.32 1,265 (100%)      9 
Split 2     1,926 (96.3%)     15.0%        0.40 1,259 (100%)      8 
Split 3     1,896 (94.8%)     21.3%        0.46 1,243 ( 98%)      5 
Split 4     1,866 (93.3%)     28.6%        0.51 1,241 ( 98%)      3 
Split 5     1,811 (90.6%)     32.8%        0.56 1,243 ( 98%)      2 
Split 6     1,830 (91.5%)     15.6%        0.56 1,204 ( 95%)      5 
Split 7     1,774 (88.7%)     15.5%        0.64 1,134 ( 90%)      4 
Split 8     1,790 (89.5%)      7.0%        0.63 1,073 ( 85%)      3 
Resample    1,069 (53.5%)       NA%        0.59 1,486 (118%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,948 (97.4%)     12.3%        0.32 1,283 (101%)     11 
Split 2     1,922 (96.1%)     17.5%        0.40 1,248 ( 99%)      7 
Split 3     1,914 (95.7%)     21.7%        0.44 1,252 ( 99%)      5 
Split 4     1,883 (94.1%)     19.7%        0.48 1,251 ( 99%)      5 
Split 5     1,824 (91.2%)     26.6%        0.55 1,236 ( 98%)      3 
Split 6     1,806 (90.3%)     20.1%        0.59 1,187 ( 94%)      4 
Split 7     1,826 (91.3%)     18.3%        0.61 1,160 ( 92%)      3 
Split 8     1,817 (90.8%)      8.9%        0.65 1,054 ( 83%)      2 
Resample    1,333 (66.6%)       NA%        0.59 1,502 (119%)     NA 

```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny