### PR TITLE
2000 Georgia Congressional Districts

### DIFF
--- a/analyses/GA_cd_2000/01_prep_2000_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/01_prep_2000_GA_cd_2000.R
@@ -1,0 +1,70 @@
+###############################################################################
+# Download and prepare data for `GA_cd_2000` analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg GA_cd_2000}")
+
+path_data <- download_redistricting_file("GA", "data-raw/GA", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/GA_2000/shp_vtd.rds"
+perim_path <- "data-out/GA_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong GA} shapefile")
+    # read in redistricting data
+    ga_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$GA)
+
+    ga_shp <- ga_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # eliminate empty shapes
+    ga_shp <- ga_shp %>% filter(!st_is_empty(geometry))
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ga_shp,
+                               perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ga_shp$adj <- redist.adjacency(ga_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    ga_shp <- ga_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(ga_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ga_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong GA} shapefile")
+}

--- a/analyses/GA_cd_2000/01_prep_2000_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/01_prep_2000_GA_cd_2000.R
@@ -47,7 +47,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         ga_shp <- rmapshaper::ms_simplify(ga_shp, keep = 0.05,
                                                  keep_shapes = TRUE) %>%
@@ -56,8 +55,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     ga_shp$adj <- redist.adjacency(ga_shp)
-
-    # TODO any custom adjacency graph edits here
 
     ga_shp <- ga_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/GA_cd_2000/02_setup_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/02_setup_GA_cd_2000.R
@@ -4,20 +4,12 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2000}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(ga_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = ga_shp$adj)
-
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map %>%
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "GA_2000"

--- a/analyses/GA_cd_2000/02_setup_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/02_setup_GA_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `GA_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg GA_cd_2000}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(ga_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = ga_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "GA_2000"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/GA_2000/GA_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
@@ -39,4 +39,32 @@ if (interactive()) {
 
     validate_analysis(plans, map)
     summary(plans)
+
+    redist.plot.distr_qtys(
+      plans, vap_black/total_vap,
+      color_thresh = NULL,
+      color = ifelse(
+        subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+        "#3D77BB", "#B25D4C"),
+      size = 0.5, alpha = 0.5) +
+      scale_y_continuous("Percent Black by VAP") +
+      labs(title = "Partisanship of seats by BVAP rank") +
+      scale_color_manual(values = c(cd_2000 = "black"))
+
+    # Dem seats by BVAP rank -- numeric
+    plans %>%
+      group_by(draw) %>%
+      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+      subset_sampled() %>%
+      select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+      mutate(dem = ndv > nrv) %>%
+      group_by(bvap_rank) %>%
+      summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    plans %>%
+      subset_sampled() %>%
+      group_by(draw) %>%
+      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+      count(n_black_perf)
 }

--- a/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
@@ -6,21 +6,8 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg GA_cd_2000}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2000)
 plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans %>%
     group_by(chain) %>%
@@ -30,8 +17,6 @@ plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/GA_2000/GA_cd_2000_plans.rds"), compress = "xz")
@@ -48,7 +33,6 @@ save_summary_stats(plans, "data-out/GA_2000/GA_cd_2000_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
@@ -7,7 +7,7 @@
 cli_process_start("Running simulations for {.pkg GA_cd_2000}")
 
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
 
 plans <- plans %>%
     group_by(chain) %>%

--- a/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
+++ b/analyses/GA_cd_2000/03_sim_GA_cd_2000.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `GA_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg GA_cd_2000}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/GA_2000/GA_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg GA_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/GA_2000/GA_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/GA_cd_2000/doc_GA_cd_2000.md
+++ b/analyses/GA_cd_2000/doc_GA_cd_2000.md
@@ -7,6 +7,9 @@ In Georgia, according to [NCSL Redistricting Law 2000](https://web.archive.org/w
 1. have equal populations
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible
+1. comply with the Voting Rights Act
+1. preserve the cores of existing districts and avoid contests between incumbents
+1. use voting district boundaries as building blocks for districts
 
 
 ### Algorithmic Constraints

--- a/analyses/GA_cd_2000/doc_GA_cd_2000.md
+++ b/analyses/GA_cd_2000/doc_GA_cd_2000.md
@@ -22,6 +22,6 @@ Data for Georgia comes from the [ALARM Project's update](https://dataverse.harva
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Georgia across 5 independent runs of the SMC algorithm.
+We sample 20,000 districting plans for Georgia across 10 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
 No special techniques were needed to produce the sample.

--- a/analyses/GA_cd_2000/doc_GA_cd_2000.md
+++ b/analyses/GA_cd_2000/doc_GA_cd_2000.md
@@ -13,7 +13,7 @@ In Georgia, according to [NCSL Redistricting Law 2000](https://web.archive.org/w
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for Georgia comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

--- a/analyses/GA_cd_2000/doc_GA_cd_2000.md
+++ b/analyses/GA_cd_2000/doc_GA_cd_2000.md
@@ -1,0 +1,24 @@
+# 2000 Georgia Congressional Districts
+
+## Redistricting requirements
+In Georgia, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for Georgia comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Georgia across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Georgia, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. comply with the Voting Rights Act
1. preserve the cores of existing districts and avoid contests between incumbents
1. use voting district boundaries as building blocks for districts


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Georgia comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 20,000 districting plans for Georgia across 10 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.


## Validation

<img width="3000" height="4500" alt="image" src="https://github.com/user-attachments/assets/3897ce00-835f-4a1c-a62e-0df8c6cc0673" />

<img width="1146" height="1090" alt="image" src="https://github.com/user-attachments/assets/94063404-0ddd-4a6f-a26a-cdad3d793525" />

```
# A tibble: 13 × 2
   bvap_rank   dem
       <dbl> <dbl>
 1         1 0.384
 2         2 0.375
 3         3 0.432
 4         4 0.241
 5         5 0.201
 6         6 0.732
 7         7 0.822
 8         8 0.778
 9         9 0.913
10        10 0.946
11        11 0.937
12        12 0.410
13        13 0.615

  n_black_perf    n
1            1    8
2            2   66
3            3  401
4            4 2080
5            5 1404
6            6  185
7            7    5
8           NA 5851
```

```
SMC: 10,000 sampled plans of 13 districts on 2,732 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0
ℹ Preparing GA shapefile
Plan diversity 80% range: 0.61 to 0.84
ℹ Preparing GA shapefile
R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other 
        1.012         1.021         1.016         1.023         1.022         1.012 
      pop_two      pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi 
        1.026         1.020         1.010         1.017         1.010         1.014 
    pop_black      vap_hisp      vap_aian     vap_asian     vap_white     vap_black 
        1.009         1.016         1.015         1.010         1.015         1.010 
     vap_nhpi     vap_other       vap_two county_splits   muni_splits           ndv 
        1.011         1.016         1.012         1.009         1.029         1.018 
          nrv       ndshare 
        1.007         1.014 

Sampling diagnostics for SMC run 1 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,960 (98.0%)     14.0%        0.29 1,257 ( 99%)     10 
Split 2     1,940 (97.0%)     22.4%        0.34 1,270 (100%)      6 
Split 3     1,921 (96.0%)     24.1%        0.41 1,283 (101%)      5 
Split 4     1,895 (94.8%)     21.3%        0.44 1,238 ( 98%)      5 
Split 5     1,852 (92.6%)     24.9%        0.50 1,251 ( 99%)      4 
Split 6     1,845 (92.3%)     28.1%        0.53 1,253 ( 99%)      3 
Split 7     1,840 (92.0%)     20.0%        0.55 1,209 ( 96%)      4 
Split 8     1,809 (90.5%)     23.4%        0.63 1,213 ( 96%)      3 
Split 9     1,787 (89.3%)     21.1%        0.67 1,201 ( 95%)      3 
Split 10    1,766 (88.3%)     24.0%        0.71 1,184 ( 94%)      2 
Split 11    1,792 (89.6%)     19.1%        0.68 1,147 ( 91%)      2 
Split 12    1,833 (91.7%)      6.5%        0.61 1,052 ( 83%)      2 
Resample    1,389 (69.5%)       NA%        0.57 1,527 (121%)     NA 

Sampling diagnostics for SMC run 2 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,962 (98.1%)     16.1%        0.28 1,265 (100%)      9 
Split 2     1,945 (97.3%)     21.5%        0.33 1,238 ( 98%)      6 
Split 3     1,937 (96.8%)     29.5%        0.38 1,250 ( 99%)      4 
Split 4     1,920 (96.0%)     33.3%        0.41 1,251 ( 99%)      3 
Split 5     1,897 (94.9%)     30.1%        0.45 1,244 ( 98%)      3 
Split 6     1,863 (93.2%)     37.9%        0.48 1,238 ( 98%)      2 
Split 7     1,795 (89.8%)     21.2%        0.56 1,217 ( 96%)      4 
Split 8     1,803 (90.1%)     17.6%        0.63 1,208 ( 96%)      4 
Split 9     1,753 (87.6%)     16.6%        0.71 1,190 ( 94%)      4 
Split 10    1,780 (89.0%)     17.7%        0.69 1,164 ( 92%)      3 
Split 11    1,782 (89.1%)     18.7%        0.68 1,133 ( 90%)      2 
Split 12    1,826 (91.3%)      6.8%        0.65 1,047 ( 83%)      2 
Resample    1,374 (68.7%)       NA%        0.58 1,525 (121%)     NA 

Sampling diagnostics for SMC run 3 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,961 (98.0%)     15.7%        0.28 1,256 ( 99%)      9 
Split 2     1,939 (97.0%)     21.2%        0.34 1,275 (101%)      6 
Split 3     1,926 (96.3%)     20.1%        0.39 1,245 ( 98%)      6 
Split 4     1,910 (95.5%)     26.1%        0.43 1,251 ( 99%)      4 
Split 5     1,892 (94.6%)     30.2%        0.46 1,222 ( 97%)      3 
Split 6     1,847 (92.3%)     28.6%        0.51 1,230 ( 97%)      3 
Split 7     1,821 (91.0%)     26.6%        0.57 1,208 ( 96%)      3 
Split 8     1,795 (89.8%)     24.4%        0.62 1,216 ( 96%)      3 
Split 9     1,807 (90.4%)     20.9%        0.66 1,199 ( 95%)      3 
Split 10    1,782 (89.1%)     23.9%        0.68 1,178 ( 93%)      2 
Split 11    1,791 (89.6%)     19.3%        0.68 1,142 ( 90%)      2 
Split 12    1,793 (89.7%)      7.1%        0.68 1,006 ( 80%)      2 
Resample    1,266 (63.3%)       NA%        0.63 1,477 (117%)     NA 

Sampling diagnostics for SMC run 4 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,960 (98.0%)     14.4%        0.29 1,254 ( 99%)     10 
Split 2     1,940 (97.0%)     19.2%        0.34 1,229 ( 97%)      7 
Split 3     1,918 (95.9%)     24.3%        0.40 1,246 ( 99%)      5 
Split 4     1,912 (95.6%)     33.6%        0.44 1,271 (101%)      3 
Split 5     1,897 (94.9%)     30.6%        0.47 1,232 ( 97%)      3 
Split 6     1,872 (93.6%)     37.9%        0.51 1,220 ( 97%)      2 
Split 7     1,861 (93.1%)     16.0%        0.54 1,220 ( 97%)      5 
Split 8     1,835 (91.8%)     18.1%        0.60 1,227 ( 97%)      4 
Split 9     1,796 (89.8%)     21.4%        0.66 1,206 ( 95%)      3 
Split 10    1,780 (89.0%)     24.5%        0.69 1,185 ( 94%)      2 
Split 11    1,763 (88.1%)     13.5%        0.68 1,139 ( 90%)      3 
Split 12    1,802 (90.1%)      6.7%        0.60 1,053 ( 83%)      2 
Resample    1,248 (62.4%)       NA%        0.59 1,495 (118%)     NA 

Sampling diagnostics for SMC run 5 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,960 (98.0%)     16.0%        0.28 1,269 (100%)      9 
Split 2     1,942 (97.1%)     21.2%        0.34 1,247 ( 99%)      6 
Split 3     1,934 (96.7%)     28.9%        0.38 1,255 ( 99%)      4 
Split 4     1,918 (95.9%)     34.6%        0.42 1,233 ( 98%)      3 
Split 5     1,876 (93.8%)     16.6%        0.48 1,267 (100%)      6 
Split 6     1,844 (92.2%)     22.7%        0.52 1,232 ( 97%)      4 
Split 7     1,824 (91.2%)     25.7%        0.57 1,206 ( 95%)      3 
Split 8     1,829 (91.4%)     18.8%        0.58 1,223 ( 97%)      4 
Split 9     1,823 (91.2%)     21.2%        0.63 1,209 ( 96%)      3 
Split 10    1,800 (90.0%)     13.2%        0.67 1,190 ( 94%)      4 
Split 11    1,818 (90.9%)     12.5%        0.64 1,150 ( 91%)      3 
Split 12    1,850 (92.5%)      6.3%        0.60 1,032 ( 82%)      2 
Resample    1,478 (73.9%)       NA%        0.56 1,561 (123%)     NA 

Sampling diagnostics for SMC run 6 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,959 (97.9%)     17.9%        0.29 1,285 (102%)      8 
Split 2     1,940 (97.0%)     21.3%        0.34 1,274 (101%)      6 
Split 3     1,931 (96.5%)     19.8%        0.39 1,247 ( 99%)      6 
Split 4     1,920 (96.0%)     26.5%        0.42 1,253 ( 99%)      4 
Split 5     1,906 (95.3%)     30.7%        0.45 1,251 ( 99%)      3 
Split 6     1,808 (90.4%)     29.2%        0.54 1,236 ( 98%)      3 
Split 7     1,775 (88.8%)     35.5%        0.59 1,212 ( 96%)      2 
Split 8     1,801 (90.0%)     18.7%        0.62 1,164 ( 92%)      4 
Split 9     1,810 (90.5%)     21.1%        0.64 1,197 ( 95%)      3 
Split 10    1,792 (89.6%)     24.4%        0.68 1,211 ( 96%)      2 
Split 11    1,806 (90.3%)     14.3%        0.68 1,099 ( 87%)      3 
Split 12    1,793 (89.7%)      5.2%        0.69 1,039 ( 82%)      3 
Resample    1,312 (65.6%)       NA%        0.65 1,464 (116%)     NA 

Sampling diagnostics for SMC run 7 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,960 (98.0%)     16.1%        0.29 1,267 (100%)      9 
Split 2     1,929 (96.5%)     22.5%        0.35 1,256 ( 99%)      6 
Split 3     1,927 (96.3%)     20.2%        0.40 1,250 ( 99%)      6 
Split 4     1,905 (95.2%)     27.1%        0.45 1,242 ( 98%)      4 
Split 5     1,888 (94.4%)     17.2%        0.47 1,242 ( 98%)      6 
Split 6     1,852 (92.6%)     22.1%        0.52 1,228 ( 97%)      4 
Split 7     1,833 (91.6%)     25.8%        0.57 1,225 ( 97%)      3 
Split 8     1,835 (91.8%)     32.3%        0.59 1,234 ( 98%)      2 
Split 9     1,815 (90.7%)     21.0%        0.64 1,222 ( 97%)      3 
Split 10    1,744 (87.2%)     17.3%        0.65 1,191 ( 94%)      3 
Split 11    1,757 (87.8%)     13.4%        0.72 1,113 ( 88%)      3 
Split 12    1,820 (91.0%)      6.9%        0.63 1,042 ( 82%)      2 
Resample    1,346 (67.3%)       NA%        0.59 1,518 (120%)     NA 

Sampling diagnostics for SMC run 8 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,961 (98.0%)     16.0%        0.28 1,285 (102%)      9 
Split 2     1,942 (97.1%)     19.2%        0.34 1,264 (100%)      7 
Split 3     1,932 (96.6%)     24.0%        0.39 1,254 ( 99%)      5 
Split 4     1,919 (95.9%)     26.6%        0.42 1,269 (100%)      4 
Split 5     1,900 (95.0%)     24.6%        0.45 1,248 ( 99%)      4 
Split 6     1,865 (93.2%)     28.6%        0.51 1,217 ( 96%)      3 
Split 7     1,842 (92.1%)     35.3%        0.57 1,214 ( 96%)      2 
Split 8     1,820 (91.0%)     18.5%        0.62 1,198 ( 95%)      4 
Split 9     1,784 (89.2%)     21.8%        0.67 1,197 ( 95%)      3 
Split 10    1,788 (89.4%)     25.5%        0.70 1,165 ( 92%)      2 
Split 11    1,806 (90.3%)     19.7%        0.67 1,152 ( 91%)      2 
Split 12    1,806 (90.3%)      6.6%        0.66 1,059 ( 84%)      2 
Resample    1,273 (63.6%)       NA%        0.61 1,513 (120%)     NA 

Sampling diagnostics for SMC run 9 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,961 (98.1%)     15.5%        0.28 1,268 (100%)      9 
Split 2     1,942 (97.1%)     22.0%        0.34 1,241 ( 98%)      6 
Split 3     1,933 (96.7%)     29.0%        0.38 1,233 ( 98%)      4 
Split 4     1,916 (95.8%)     15.8%        0.43 1,248 ( 99%)      7 
Split 5     1,906 (95.3%)     17.0%        0.46 1,237 ( 98%)      6 
Split 6     1,881 (94.0%)     22.5%        0.48 1,230 ( 97%)      4 
Split 7     1,839 (92.0%)     26.7%        0.56 1,273 (101%)      3 
Split 8     1,786 (89.3%)     23.5%        0.65 1,221 ( 97%)      3 
Split 9     1,794 (89.7%)     29.5%        0.67 1,202 ( 95%)      2 
Split 10    1,796 (89.8%)     24.7%        0.66 1,198 ( 95%)      2 
Split 11    1,797 (89.9%)     18.8%        0.66 1,135 ( 90%)      2 
Split 12    1,812 (90.6%)      6.4%        0.61 1,009 ( 80%)      2 
Resample    1,285 (64.2%)       NA%        0.59 1,518 (120%)     NA 

Sampling diagnostics for SMC run 10 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,960 (98.0%)     15.3%        0.28 1,266 (100%)      9 
Split 2     1,940 (97.0%)     22.2%        0.34 1,291 (102%)      6 
Split 3     1,927 (96.4%)     28.8%        0.40 1,271 (101%)      4 
Split 4     1,921 (96.0%)     22.0%        0.42 1,251 ( 99%)      5 
Split 5     1,873 (93.7%)     30.8%        0.49 1,217 ( 96%)      3 
Split 6     1,873 (93.7%)     21.7%        0.50 1,240 ( 98%)      4 
Split 7     1,848 (92.4%)     20.2%        0.56 1,208 ( 96%)      4 
Split 8     1,841 (92.0%)     23.7%        0.60 1,245 ( 98%)      3 
Split 9     1,785 (89.3%)     28.9%        0.65 1,186 ( 94%)      2 
Split 10    1,784 (89.2%)     24.6%        0.68 1,207 ( 95%)      2 
Split 11    1,809 (90.5%)     13.6%        0.65 1,165 ( 92%)      3 
Split 12    1,818 (90.9%)      7.0%        0.61 1,026 ( 81%)      2 
Resample    1,356 (67.8%)       NA%        0.60 1,524 (121%)     NA 
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
