### PR TITLE
2000 New York Congressional Districts

### DIFF
--- a/analyses/NY_cd_2000/01_prep_NY_cd_2000.R
+++ b/analyses/NY_cd_2000/01_prep_NY_cd_2000.R
@@ -1,0 +1,66 @@
+###############################################################################
+# Download and prepare data for NY_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NY_cd_2000}")
+
+path_data <- download_redistricting_file("NY", "data-raw/NY", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NY_2000/shp_vtd.rds"
+perim_path <- "data-out/NY_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong NY} shapefile")
+  # read in redistricting data
+  ny_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$NY)
+  
+  ny_shp <- ny_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = ny_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    ny_shp <- rmapshaper::ms_simplify(ny_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  ny_shp$adj <- redist.adjacency(ny_shp)
+  
+  ny_shp <- ny_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(ny_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  ny_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong NY} shapefile")
+}

--- a/analyses/NY_cd_2000/02_setup_NY_cd_2000.R
+++ b/analyses/NY_cd_2000/02_setup_NY_cd_2000.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NY_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NY_cd_2000}")
+
+map <- redist_map(ny_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = ny_shp$adj)
+# Pseudo-county
+map <- map %>%
+  mutate(
+    pseudo_county = pick_county_muni(
+      map,
+      counties = county,   
+      munis    = muni,     
+      pop_muni = get_target(map)
+    )
+  )
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NY_2000"
+
+map$state <- "NY"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NY_2000/NY_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NY_cd_2000/03_sim_NY_cd_2000.R
+++ b/analyses/NY_cd_2000/03_sim_NY_cd_2000.R
@@ -1,0 +1,32 @@
+###############################################################################
+# Simulate plans for `NY_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NY_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 1.2e4, seq_alpha   = 0.95, pop_temper  = 0.001, runs = 5, counties = pseudo_county) 
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NY_2000/NY_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NY_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NY_2000/NY_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/NY_cd_2000/doc_NY_cd_2000.md
+++ b/analyses/NY_cd_2000/doc_NY_cd_2000.md
@@ -1,0 +1,22 @@
+# 2000 New York Congressional Districts
+
+## Redistricting requirements
+In ``New York``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+We use a pseudo-county constraint described below, which attempts to mimic the norms in New York of preserving political subdivisions, communities of interest, and cores of existing districts. This also reflects that districts are generally structured around counties.
+
+## Data Sources
+Data for ``New York`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 60,000 districting plans for ``New York`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+To balance county and municipality splits, we create pseudo-counties for use in the county constraint.


### PR DESCRIPTION
## Redistricting requirements
In ``New York``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We use a pseudo-county constraint described below, which attempts to mimic the norms in New York of preserving political subdivisions, communities of interest, and cores of existing districts. This also reflects that districts are generally structured around counties.

## Data Sources
Data for ``New York`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 60,000 districting plans for ``New York`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
To balance county and municipality splits, we create pseudo-counties for use in the county constraint.

## Validation
<img width="3000" height="4500" alt="validation_20250807_0032" src="https://github.com/user-attachments/assets/7de364f5-99e8-433f-b19a-8676682dcc6d" />

```
SMC: 5,000 sampled plans of 29 districts on 13,374 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.95
`pop_temper`=0.001

Plan diversity 80% range: 0.81 to 0.94

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby 
        1.007       ❌1.081         1.027         1.024         1.029 
    pop_other       pop_two      pop_aian     pop_white      pop_hisp 
      ❌1.061       ❌1.053         1.013         1.033         1.034 
    pop_asian      pop_nhpi     pop_black      vap_hisp      vap_aian 
        1.035         1.031         1.033         1.022         1.030 
    vap_asian     vap_white     vap_black     vap_other       vap_two 
        1.033         1.020         1.046         1.037         1.039 
     vap_nhpi county_splits   muni_splits           ndv           nrv 
        1.017         1.028         1.033         1.039         1.023 
      ndshare 
        1.038 
✖ WARNING: SMC runs have not converged.

Sampling diagnostics for SMC run 1 of 5 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    10,700 (89.2%)     28.7%        0.37 7,572 (100%)     11 
Split 2     9,471 (78.9%)     41.6%        0.44 7,313 ( 96%)      7 
Split 3     8,288 (69.1%)     51.9%        0.49 7,194 ( 95%)      5 
Split 4     5,443 (45.4%)     57.3%        0.53 6,982 ( 92%)      4 
Split 5     5,960 (49.7%)     63.1%        0.56 6,849 ( 90%)      3 
Split 6     6,191 (51.6%)     36.1%        0.59 6,852 ( 90%)      7 
Split 7     4,794 (40.0%)     25.1%        0.62 6,715 ( 89%)     10 
Split 8     6,148 (51.2%)     38.4%        0.64 6,620 ( 87%)      6 
Split 9     5,279 (44.0%)     41.5%        0.66 6,583 ( 87%)      5 
Split 10    4,227 (35.2%)     31.2%        0.70 6,425 ( 85%)      7 
Split 11    4,726 (39.4%)     44.9%        0.76 6,343 ( 84%)      4 
Split 12    3,200 (26.7%)     51.5%        0.80 6,216 ( 82%)      3 
Split 13    4,206 (35.0%)     58.3%        0.76 6,095 ( 80%)      2 
Split 14    4,223 (35.2%)     47.5%        0.71 6,285 ( 83%)      3 
Split 15    7,000 (58.3%)     54.5%        0.65 6,405 ( 84%)      2 
Split 16    4,868 (40.6%)     36.6%        0.63 6,615 ( 87%)      4 
Split 17    4,681 (39.0%)     35.3%        0.62 6,590 ( 87%)      4 
Split 18    5,510 (45.9%)     40.0%        0.62 6,598 ( 87%)      3 
Split 19    5,698 (47.5%)     45.6%        0.60 6,666 ( 88%)      2 
Split 20    6,523 (54.4%)     42.3%        0.60 6,721 ( 89%)      2 
Split 21    6,634 (55.3%)     26.2%        0.60 6,734 ( 89%)      4 
Split 22    6,001 (50.0%)     19.9%        0.60 6,709 ( 88%)      5 
Split 23    5,786 (48.2%)     27.1%        0.62 6,604 ( 87%)      3 
Split 24    5,221 (43.5%)     19.5%        0.64 6,485 ( 85%)      4 
Split 25    6,052 (50.4%)     20.7%        0.63 6,423 ( 85%)      3 
Split 26    4,496 (37.5%)     17.1%        0.63 6,332 ( 83%)      3 
Split 27    6,172 (51.4%)     12.8%        0.63 6,060 ( 80%)      3 
Split 28    6,616 (55.1%)      6.2%        0.60 5,446 ( 72%)      2 
Resample    6,062 (50.5%)       NA%        0.61 8,842 (117%)     NA 

Sampling diagnostics for SMC run 2 of 5 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    10,687 (89.1%)     26.4%        0.38 7,540 ( 99%)     12 
Split 2     9,427 (78.6%)     37.5%        0.43 7,356 ( 97%)      8 
Split 3     8,727 (72.7%)     45.8%        0.48 7,181 ( 95%)      6 
Split 4     5,309 (44.2%)     57.8%        0.53 7,032 ( 93%)      4 
Split 5     7,677 (64.0%)     30.4%        0.56 6,860 ( 90%)      9 
Split 6     6,886 (57.4%)     36.9%        0.59 6,842 ( 90%)      7 
Split 7     6,850 (57.1%)     52.2%        0.61 6,770 ( 89%)      4 
Split 8     6,142 (51.2%)     50.8%        0.63 6,669 ( 88%)      4 
Split 9     3,756 (31.3%)     42.6%        0.67 6,702 ( 88%)      5 
Split 10    4,341 (36.2%)     35.8%        0.72 6,376 ( 84%)      6 
Split 11    4,224 (35.2%)     38.9%        0.78 6,250 ( 82%)      5 
Split 12    4,627 (38.6%)     43.5%        0.80 6,114 ( 81%)      4 
Split 13    5,287 (44.1%)     49.6%        0.76 6,094 ( 80%)      3 
Split 14    2,190 (18.3%)     25.9%        0.71 6,291 ( 83%)      7 
Split 15    2,958 (24.7%)     33.3%        0.67 6,340 ( 84%)      5 
Split 16    6,521 (54.3%)     44.1%        0.64 6,513 ( 86%)      3 
Split 17    6,124 (51.0%)     50.5%        0.62 6,557 ( 86%)      2 
Split 18    6,654 (55.4%)     48.3%        0.61 6,652 ( 88%)      2 
Split 19    5,508 (45.9%)     44.7%        0.62 6,723 ( 89%)      2 
Split 20    6,333 (52.8%)     42.6%        0.61 6,637 ( 87%)      2 
Split 21    4,434 (36.9%)     21.5%        0.61 6,651 ( 88%)      5 
Split 22    2,029 (16.9%)     23.8%        0.65 6,692 ( 88%)      4 
Split 23    2,119 (17.7%)     14.8%        0.64 6,232 ( 82%)      6 
Split 24    3,788 (31.6%)     15.6%        0.62 6,332 ( 83%)      5 
Split 25    3,309 (27.6%)     16.2%        0.64 6,306 ( 83%)      4 
Split 26    4,389 (36.6%)     17.1%        0.64 6,090 ( 80%)      3 
Split 27    5,987 (49.9%)     17.0%        0.66 5,972 ( 79%)      2 
Split 28    7,689 (64.1%)      6.2%        0.59 5,403 ( 71%)      2 
Resample    7,215 (60.1%)       NA%        0.59 9,058 (119%)     NA 

Sampling diagnostics for SMC run 3 of 5 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    10,699 (89.2%)     24.3%        0.37 7,592 (100%)     13 
Split 2     9,320 (77.7%)     33.6%        0.43 7,317 ( 96%)      9 
Split 3     7,709 (64.2%)     40.4%        0.48 7,165 ( 94%)      7 
Split 4     6,976 (58.1%)     50.2%        0.53 6,986 ( 92%)      5 
Split 5     6,828 (56.9%)     48.4%        0.57 6,874 ( 91%)      5 
Split 6     7,260 (60.5%)     53.3%        0.59 6,844 ( 90%)      4 
Split 7     6,358 (53.0%)     59.2%        0.60 6,801 ( 90%)      3 
Split 8     6,140 (51.2%)     50.5%        0.64 6,778 ( 89%)      4 
Split 9     5,768 (48.1%)     48.1%        0.66 6,621 ( 87%)      4 
Split 10    4,623 (38.5%)     30.8%        0.70 6,502 ( 86%)      7 
Split 11    4,329 (36.1%)     44.8%        0.76 6,290 ( 83%)      4 
Split 12    4,548 (37.9%)     50.9%        0.79 6,107 ( 81%)      3 
Split 13    5,785 (48.2%)     57.8%        0.76 6,094 ( 80%)      2 
Split 14    5,530 (46.1%)     47.9%        0.70 6,277 ( 83%)      3 
Split 15    2,768 (23.1%)     46.0%        0.67 6,433 ( 85%)      3 
Split 16    2,916 (24.3%)     37.2%        0.65 6,431 ( 85%)      4 
Split 17    4,636 (38.6%)     17.2%        0.63 6,499 ( 86%)      9 
Split 18    3,217 (26.8%)     23.6%        0.62 6,669 ( 88%)      6 
Split 19    4,249 (35.4%)     30.9%        0.63 6,554 ( 86%)      4 
Split 20    6,279 (52.3%)     28.4%        0.61 6,555 ( 86%)      4 
Split 21    5,239 (43.7%)     26.3%        0.63 6,646 ( 88%)      4 
Split 22    5,564 (46.4%)     14.3%        0.64 6,543 ( 86%)      7 
Split 23    5,050 (42.1%)     21.8%        0.65 6,499 ( 86%)      4 
Split 24    5,387 (44.9%)     24.1%        0.63 6,422 ( 85%)      3 
Split 25    6,304 (52.5%)     26.5%        0.64 6,527 ( 86%)      2 
Split 26    5,353 (44.6%)     22.7%        0.64 6,317 ( 83%)      2 
Split 27    3,617 (30.1%)     10.9%        0.65 6,108 ( 81%)      4 
Split 28    3,429 (28.6%)      5.1%        0.67 5,540 ( 73%)      3 
Resample    2,982 (24.9%)       NA%        0.67 8,114 (107%)     NA 

Sampling diagnostics for SMC run 4 of 5 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    10,694 (89.1%)     21.6%        0.38 7,619 (100%)     15 
Split 2     9,030 (75.3%)     33.6%        0.44 7,352 ( 97%)      9 
Split 3     8,689 (72.4%)     40.9%        0.48 7,121 ( 94%)      7 
Split 4     5,678 (47.3%)     31.6%        0.53 7,030 ( 93%)      9 
Split 5     7,292 (60.8%)     42.4%        0.56 6,812 ( 90%)      6 
Split 6     6,093 (50.8%)     54.7%        0.59 6,887 ( 91%)      4 
Split 7     6,516 (54.3%)     40.0%        0.61 6,723 ( 89%)      6 
Split 8     6,690 (55.8%)     50.5%        0.63 6,802 ( 90%)      4 
Split 9     4,811 (40.1%)     56.5%        0.68 6,656 ( 88%)      3 
Split 10    4,208 (35.1%)     63.3%        0.70 6,484 ( 85%)      2 
Split 11    4,676 (39.0%)     38.4%        0.74 6,400 ( 84%)      5 
Split 12    4,160 (34.7%)     50.7%        0.80 6,217 ( 82%)      3 
Split 13    5,243 (43.7%)     41.4%        0.76 6,110 ( 81%)      4 
Split 14    6,268 (52.2%)     47.3%        0.69 6,371 ( 84%)      3 
Split 15    6,907 (57.6%)     54.2%        0.65 6,543 ( 86%)      2 
Split 16    4,546 (37.9%)     52.3%        0.66 6,650 ( 88%)      2 
Split 17    7,054 (58.8%)     22.3%        0.62 6,570 ( 87%)      7 
Split 18    6,091 (50.8%)     24.0%        0.63 6,735 ( 89%)      6 
Split 19    5,139 (42.8%)     30.8%        0.62 6,714 ( 89%)      4 
Split 20    6,387 (53.2%)     17.5%        0.60 6,563 ( 87%)      7 
Split 21    4,769 (39.7%)     22.4%        0.62 6,710 ( 88%)      5 
Split 22    4,497 (37.5%)     29.7%        0.62 6,647 ( 88%)      3 
Split 23    4,262 (35.5%)     33.7%        0.63 6,589 ( 87%)      2 
Split 24    6,512 (54.3%)     30.4%        0.61 6,461 ( 85%)      2 
Split 25    5,999 (50.0%)     26.4%        0.64 6,559 ( 86%)      2 
Split 26    6,125 (51.0%)     13.8%        0.63 6,296 ( 83%)      4 
Split 27    4,209 (35.1%)     13.7%        0.64 6,156 ( 81%)      3 
Split 28    7,403 (61.7%)      6.8%        0.61 5,487 ( 72%)      2 
Resample    6,957 (58.0%)       NA%        0.61 8,825 (116%)     NA 

Sampling diagnostics for SMC run 5 of 5 (12,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1    10,699 (89.2%)     21.0%        0.37 7,537 ( 99%)     15 
Split 2     9,303 (77.5%)     31.0%        0.44 7,317 ( 96%)     10 
Split 3     4,324 (36.0%)     26.8%        0.48 7,140 ( 94%)     11 
Split 4     7,864 (65.5%)     39.7%        0.52 7,024 ( 93%)      7 
Split 5     6,559 (54.7%)     33.9%        0.57 6,925 ( 91%)      8 
Split 6     6,421 (53.5%)     41.3%        0.59 6,779 ( 89%)      6 
Split 7     4,793 (39.9%)     35.5%        0.63 6,755 ( 89%)      7 
Split 8     6,264 (52.2%)     38.4%        0.64 6,551 ( 86%)      6 
Split 9     5,869 (48.9%)     48.9%        0.66 6,671 ( 88%)      4 
Split 10    4,548 (37.9%)     54.1%        0.70 6,464 ( 85%)      3 
Split 11    4,389 (36.6%)     61.5%        0.75 6,287 ( 83%)      2 
Split 12    5,050 (42.1%)     32.0%        0.76 6,138 ( 81%)      6 
Split 13    4,465 (37.2%)     42.0%        0.78 6,148 ( 81%)      4 
Split 14    5,372 (44.8%)     34.3%        0.71 6,152 ( 81%)      5 
Split 15    4,432 (36.9%)     21.6%        0.68 6,464 ( 85%)      8 
Split 16    6,326 (52.7%)     31.1%        0.64 6,572 ( 87%)      5 
Split 17    6,473 (53.9%)     35.0%        0.63 6,629 ( 87%)      4 
Split 18    5,069 (42.2%)     39.6%        0.62 6,599 ( 87%)      3 
Split 19    4,155 (34.6%)     45.1%        0.62 6,550 ( 86%)      2 
Split 20    6,222 (51.8%)     23.5%        0.60 6,624 ( 87%)      5 
Split 21    6,523 (54.4%)     18.4%        0.60 6,700 ( 88%)      6 
Split 22    4,739 (39.5%)     24.1%        0.62 6,624 ( 87%)      4 
Split 23    5,929 (49.4%)     26.6%        0.64 6,549 ( 86%)      3 
Split 24    4,720 (39.3%)     30.0%        0.63 6,588 ( 87%)      2 
Split 25    5,166 (43.1%)     26.1%        0.65 6,460 ( 85%)      2 
Split 26    3,657 (30.5%)     21.0%        0.64 6,324 ( 83%)      2 
Split 27    2,422 (20.2%)     17.0%        0.65 6,021 ( 79%)      2 
Split 28    6,924 (57.7%)      3.2%        0.60 5,691 ( 75%)      5 
Resample    6,443 (53.7%)       NA%        0.60 8,868 (117%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%),
large std. devs. of the log weights (more than 3 or so), and low numbers of
unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low
plan diversity or bottlenecks as well, address those issues first.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
(Like the 2010 analysis, the SMC does not converge for total_vap, pop_other, and pop_two, but I'm at the limit of my computing power to keep pushing the number of sims up)
