### PR TITLE
2000 West Virginia Congressional Districts

### DIFF
--- a/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
@@ -1,0 +1,100 @@
+###############################################################################
+# Download and prepare data for WV_cd_2000 analysis
+# © ALARM Project, July 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  library(tinytiger)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WV_cd_2000}")
+path_data <- download_redistricting_file("WV", "data-raw/WV", year = 2000)
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WV_2000/shp_vtd.rds"
+perim_path <- "data-out/WV_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong WV} shapefile")
+  # read in redistricting data
+  wv_df <- read_csv(here(path_data), col_types = cols(GEOID = "c"))
+  if (!"county" %in% names(wv_df)) {
+    wv_df <- wv_df %>% mutate(county = str_sub(GEOID, 3, 5))
+  }
+  
+  # Aggregate once, keeping cd_1990 and cd_2000. Pick up the first value of cd_1990 and cd_2000 because two counties are split between multiple districts in the enacted plan.
+  wv_df_cnty <- wv_df %>%
+    group_by(county) %>%
+    summarise(
+      across(where(is.numeric) & !matches("^cd_1990$|^cd_2000$"),
+             ~ sum(.x, na.rm = TRUE)),
+      cd_1990 = first(cd_1990),
+      cd_2000 = first(cd_2000),
+      .groups = "drop"
+    )
+  
+  cnty_sf <- tt_counties("WV", year = 2000) %>%
+    st_transform(EPSG$WV) %>%
+    transmute(county = COUNTYFP00, geometry)
+  
+  wv_shp <- cnty_sf %>% left_join(wv_df_cnty, by = "county")
+
+  # Prepare lists of column types
+  col_names <- as.vector(colnames(wv_shp))
+  mergeable_col_names <- c("state", "county", "cd_2000", "cd_1990")
+  sf_col_names <- c("muni", "county_muni", "GEOID", "geometry", "vtd")
+  summable_col_names <- col_names[!col_names %in% c(mergeable_col_names, sf_col_names)]
+  
+  # Extract mergeable columns (non-summed)
+  data_without_sf <- st_drop_geometry(wv_shp)
+  cols_to_merge <- select(
+    data_without_sf[!duplicated(data_without_sf$county), ],
+    any_of(mergeable_col_names)
+  )
+  
+  # Sum numeric columns by county
+  merged_county_sf <- wv_shp %>%
+    group_by(county) %>%
+    summarize(across(any_of(summable_col_names), sum), .groups = "drop")
+  
+  # Merge numeric and non-numeric data
+  wv_shp <- merge(merged_county_sf, cols_to_merge, by = "county")
+  
+  # Drop unwanted columns if present
+  wv_shp <- wv_shp %>% select(-any_of(c("mcd", "shd", "ssd")))
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = wv_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    wv_shp <- rmapshaper::ms_simplify(wv_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  wv_shp$adj <- redist.adjacency(wv_shp)
+  
+  wv_shp <- wv_shp %>% fix_geo_assignment(county)
+  
+  write_rds(wv_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  wv_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong WV} shapefile")
+}

--- a/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
@@ -33,7 +33,7 @@ if (!file.exists(here(shp_path))) {
     wv_df <- wv_df %>% mutate(county = str_sub(GEOID, 3, 5))
   }
   
-  # Aggregate once, keeping cd_1990 and cd_2000. Pick up the first value of cd_1990 and cd_2000 because two counties are split between multiple districts in the enacted plan.
+  # Aggregate once, keeping cd_1990 and cd_2000. 
   wv_df_cnty <- wv_df %>%
     group_by(county) %>%
     summarise(

--- a/analyses/WV_cd_2000/02_setup_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/02_setup_WV_cd_2000.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `WV_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WV_cd_2000}")
+
+map <- redist_map(wv_shp, pop_tol = 0.005,
+                  existing_plan = cd_2000, adj = wv_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WV_2000"
+
+map$state <- "WV"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WV_2000/WV_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WV_cd_2000/03_sim_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/03_sim_WV_cd_2000.R
@@ -1,0 +1,32 @@
+###############################################################################
+# Simulate plans for `WV_cd_2000`
+# © ALARM Project, July 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WV_cd_2000}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WV_2000/WV_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WV_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WV_2000/WV_cd_2000_stats.csv")
+
+cli_process_done()

--- a/analyses/WV_cd_2000/doc_WV_cd_2000.md
+++ b/analyses/WV_cd_2000/doc_WV_cd_2000.md
@@ -1,0 +1,23 @@
+# 2000 West Virginia Congressional Districts
+
+## Redistricting requirements
+In ``West Virginia``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be made of contiguous counties
+1. have equal populations
+1. be geographically compact
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+We also merge VTDs into counties and run the simulation at the county level.
+
+## Data Sources
+Data for ``West Virginia`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for ``West Virginia`` across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/WV_cd_2000/doc_WV_cd_2000.md
+++ b/analyses/WV_cd_2000/doc_WV_cd_2000.md
@@ -1,7 +1,7 @@
 # 2000 West Virginia Congressional Districts
 
 ## Redistricting requirements
-In ``West Virginia``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+In ``West Virginia``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts shall:
 
 1. be made of contiguous counties
 1. have equal populations

--- a/analyses/WV_cd_2000/doc_WV_cd_2000.md
+++ b/analyses/WV_cd_2000/doc_WV_cd_2000.md
@@ -20,4 +20,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 10,000 districting plans for ``West Virginia`` across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
-Although we analyze ``West Virginia`` at the county level, Barbour and Braxton County are split by the enacted plan. To assign a single district to each county, we determine which cd_2000 value occurs most frequently among that county’s VTDs, and assign that district code to the county.
+Although we analyze ``West Virginia`` at the county level, Barbour and Braxton counties are split by the enacted plan. To assign a single district to each county, we determine which cd_2000 value occurs most frequently among that county’s VTDs, and assign that district code to the county.

--- a/analyses/WV_cd_2000/doc_WV_cd_2000.md
+++ b/analyses/WV_cd_2000/doc_WV_cd_2000.md
@@ -20,4 +20,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 10,000 districting plans for ``West Virginia`` across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
-Although we analyze ``West Virginia`` at the county level, Barbour and Braxton counties are split by the enacted plan. To assign a single district to each county, we determine which cd_2000 value occurs most frequently among that county’s VTDs, and assign that district code to the county.
+Although we analyze ``West Virginia`` at the county level, Barbour and Braxton counties are split by the enacted plan. To assign a single district to each county, we identify the district number that appears most often among its VTDs in the enacted plan and assign that district code to the county.

--- a/analyses/WV_cd_2000/doc_WV_cd_2000.md
+++ b/analyses/WV_cd_2000/doc_WV_cd_2000.md
@@ -20,4 +20,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 10,000 districting plans for ``West Virginia`` across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
-No special techniques were needed to produce the sample.
+Although we analyze ``West Virginia`` at the county level, Barbour and Braxton County are split by the enacted plan. To assign a single district to each county, we determine which cd_2000 value occurs most frequently among that county’s VTDs, and assign that district code to the county.


### PR DESCRIPTION
## Redistricting requirements
In ``West Virginia``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts shall:

1. be made of contiguous counties
1. have equal populations
1. be geographically compact

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We also merge VTDs into counties and run the simulation at the county level.

## Data Sources
Data for ``West Virginia`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for ``West Virginia`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
Although we analyze ``West Virginia`` at the county level, Barbour and Braxton counties are split by the enacted plan. To assign a single district to each county, we identify the district number that appears most often among its VTDs in the enacted plan and assign that district code to the county.

## Validation
<img width="3000" height="4500" alt="validation_20250807_2316" src="https://github.com/user-attachments/assets/3e6f5080-db31-4358-9117-d0a89d562b7d" />


```
✔ Creating <redist_map> object for WV_cd_2000 ... done
SMC: 5,000 sampled plans of 3 districts on 55 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.38 to 0.81

R-hat values for summary statistics:
pop_overlap   total_vap    plan_dev   comp_edge comp_polsby   pop_white 
      1.003       1.002       1.001       1.001       1.002       1.002 
  pop_black    pop_hisp   pop_asian    pop_nhpi   pop_other     pop_two 
      1.002       1.002       1.002       1.002       1.001       1.002 
   pop_aian   vap_other   vap_asian    vap_hisp    vap_aian   vap_white 
      1.003       1.001       1.002       1.002       1.003       1.001 
    vap_two   vap_black    vap_nhpi         ndv         nrv     ndshare 
      1.003       1.002       1.002       1.002       1.001       1.003 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,971 (98.5%)      2.5%        0.24 1,267 (100%)      3 
Split 2     1,913 (95.6%)      1.3%        0.39 1,042 ( 82%)      2 
Resample    1,643 (82.1%)       NA%        0.39 1,644 (130%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,972 (98.6%)      2.6%        0.24 1,266 (100%)      3 
Split 2     1,939 (96.9%)      1.3%        0.34 1,070 ( 85%)      2 
Resample    1,749 (87.5%)       NA%        0.34 1,719 (136%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,973 (98.6%)      2.6%        0.23 1,270 (100%)      3 
Split 2     1,924 (96.2%)      1.3%        0.37 1,045 ( 83%)      2 
Resample    1,681 (84.0%)       NA%        0.37 1,683 (133%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,971 (98.6%)      2.6%        0.24 1,270 (100%)      3 
Split 2     1,906 (95.3%)      1.3%        0.39 1,032 ( 82%)      2 
Resample    1,580 (79.0%)       NA%        0.39 1,659 (131%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,973 (98.6%)      2.6%        0.23 1,233 ( 98%)      3 
Split 2     1,929 (96.4%)      1.2%        0.36 1,048 ( 83%)      2 
Resample    1,699 (85.0%)       NA%        0.36 1,693 (134%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%),
large std. devs. of the log weights (more than 3 or so), and low numbers of
unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
