### PR TITLE
2000 Tennessee Congressional Districts Update

### DIFF
--- a/analyses/TN_cd_2000/01_prep_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/01_prep_TN_cd_2000.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Download and prepare data for TN_cd_2000 analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg TN_cd_2000}")
+path_data <- download_redistricting_file("TN", "data-raw/TN", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/TN_2000/shp_vtd.rds"
+perim_path <- "data-out/TN_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong TN} shapefile")
+  # read in redistricting data
+  tn_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$TN)
+  
+  tn_shp <- tn_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = tn_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    tn_shp <- rmapshaper::ms_simplify(tn_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  tn_shp$adj <- redist.adjacency(tn_shp)
+  
+  tn_shp <- tn_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(tn_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  tn_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong TN} shapefile")
+}

--- a/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/02_setup_TN_cd_2000.R
@@ -1,20 +1,26 @@
 ###############################################################################
 # Set up redistricting simulation for `TN_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, August 2025
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg TN_cd_2000}")
 
 map <- redist_map(tn_shp, pop_tol = 0.005,
-    existing_plan = cd_2000, adj = tn_shp$adj)
+                  existing_plan = cd_2000, adj = tn_shp$adj)
 
-# Adjust pop_muni as needed to balance county/muni splits
-# make pseudo counties with default settings
 map <- map %>%
-    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-        pop_muni = get_target(map)))
+  mutate(
+    pseudo_county = pick_county_muni(
+      map,
+      counties = county,   
+      munis    = muni,     
+      pop_muni = get_target(map)
+    )
+  )
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_2000"
+
+map$state <- "TN"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/TN_2000/TN_cd_2000_map.rds", compress = "xz")

--- a/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
+++ b/analyses/TN_cd_2000/03_sim_TN_cd_2000.R
@@ -1,20 +1,18 @@
 ###############################################################################
 # Simulate plans for `TN_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, August 2025
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg TN_cd_2000}")
 
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
 
 plans <- plans %>%
-    group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
-    ungroup()
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
 plans <- match_numbers(plans, "cd_2000")
 
 cli_process_done()
@@ -28,129 +26,7 @@ cli_process_done()
 cli_process_start("Computing summary statistics for {.pkg TN_cd_2000}")
 
 plans <- add_summary_stats(plans, map)
-
 # Output the summary statistics. Do not edit this path.
 save_summary_stats(plans, "data-out/TN_2000/TN_cd_2000_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-    validate_analysis(plans, map)
-    summary(plans)
-
-    # Black VAP Performance Plot
-    redist.plot.distr_qtys(plans, vap_black/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
-        scale_y_continuous("Percent Black by VAP") +
-        labs(title = "Tennessee Proposed Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020_prop = "black")) +
-        theme_bw()
-
-    # Minority VAP Performance Plot
-    redist.plot.distr_qtys(plans, (total_vap - vap_white)/total_vap,
-        color_thresh = NULL,
-        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-        size = 0.5, alpha = 0.5) +
-        scale_y_continuous("Minority Percentage by VAP") +
-        labs(title = "Tennessee Proposed Plan versus Simulations") +
-        scale_color_manual(values = c(cd_2020_prop = "black")) +
-        theme_bw()
-
-    # Dem seats by BVAP rank -- numeric
-    plans %>%
-        group_by(draw) %>%
-        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
-        subset_sampled() %>%
-        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
-        mutate(dem = ndv > nrv) %>%
-        group_by(bvap_rank) %>%
-        summarize(dem = mean(dem))
-
-    # Dem seats by Minority VAP rank -- numeric
-    plans %>%
-        group_by(draw) %>%
-        mutate(tmvap = (total_vap - vap_white)/total_vap, tmvap_rank = rank(tmvap)) %>%
-        subset_sampled() %>%
-        select(draw, district, tmvap, tmvap_rank, ndv, nrv) %>%
-        mutate(dem = ndv > nrv) %>%
-        group_by(tmvap_rank) %>%
-        summarize(dem = mean(dem))
-
-    # Total Black districts that are performing
-    plans %>%
-        subset_sampled() %>%
-        group_by(draw) %>%
-        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & e_dvs > 0.5)) %>%
-        count(n_black_perf)
-
-    # Total Minority districts that are performing
-    plans %>%
-        subset_sampled() %>%
-        group_by(draw) %>%
-        summarize(n_minority_perf = sum((total_vap - vap_white)/total_vap < 0.5 & e_dvs > 0.5)) %>%
-        count(n_minority_perf)
-
-    # democratic vote
-    plans <- plans %>%
-        mutate(Compactness = distr_compactness(map),
-            `Population deviation` = plan_parity(map),
-            `Democratic vote` = group_frac(map, ndv, (ndv + nrv)))
-    plot(plans, `Democratic vote`, size = 0.5, color_thresh = 0.5) +
-        scale_color_manual(values = c("black", "tomato2", "dodgerblue")) +
-        labs(title = "Democratic vote share by district")
-
-    # majority minority districts
-    plans <- plans %>%
-        mutate(majmin = if_else(total_vap/2 > vap_white, 1, 0))
-    majminavgs <- avg_by_prec(plans, majmin, draws = NA)
-    redist.plot.map(
-        tn_shp,
-        adj = redist.adjacency(tn_shp, plan),
-        plan = NULL,
-        fill = majminavgs,
-        fill_label = "",
-        zoom_to = NULL,
-        title = ""
-    )
-
-    # majority black districts
-    plans <- plans %>%
-        mutate(bvappct = vap_black/total_vap)
-    blackavgs <- avg_by_prec(plans, bvappct, draws = NA)
-    redist.plot.map(
-        tn_shp,
-        adj = redist.adjacency(tn_shp, plan),
-        plan = NULL,
-        fill = blackavgs,
-        fill_label = "",
-        zoom_to = NULL,
-        title = ""
-    )
-
-    # this section does not work
-    plot(plans, (total_vap - vap_white)/total_vap, sort = FALSE, size = 0.5)
-
-    pal <- scales::viridis_pal()(5)[-1]
-    redist.plot.scatter(plans, pct_min, pct_dem,
-        color = pal[subset_sampled(plans)$district]) +
-        scale_color_manual(values = "black")
-
-    avg_by_prec(plans, x, draws = NA)
-    show(plans)
-
-    redist.plot.distr_qtys(
-        plans,
-        qty = total_vap,
-        sort = "asc",
-        geom = "jitter",
-        color_thresh = NULL,
-        size = 0.1,
-        ref_label = total_vap
-    )
-}

--- a/analyses/TN_cd_2000/doc_TN_cd_2000.md
+++ b/analyses/TN_cd_2000/doc_TN_cd_2000.md
@@ -1,23 +1,20 @@
 # 2000 Tennessee Congressional Districts
 
 ## Redistricting requirements
-In Tennessee, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+In ``Tennessee``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
 
 1. be contiguous
 1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.05%.
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
 
 ## Data Sources
-Data for Tennessee comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+Data for ``Tennessee`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Tennessee.
-No special techniques were needed to produce the sample.
+We sample 10,000 districting plans across five independent runs of the SMC algorithm, and then thin them to 5000 plans.
+To reflect Tennessee's traditional norm of minimizing county splits while reducing unnecessary fragmentation of major cities, we create pseudo-counties for use in the county constraint.


### PR DESCRIPTION
## Redistricting requirements
In ``Tennessee``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.

## Data Sources
Data for ``Tennessee`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans across five independent runs of the SMC algorithm, and then thin them to 5000 plans.
To reflect Tennessee's traditional norm of minimizing county splits while reducing unnecessary fragmentation of major cities, we create pseudo-counties for use in the county constraint.

## Validation

<img width="3000" height="4500" alt="validation_20250824_1730" src="https://github.com/user-attachments/assets/9abfdb3b-4c20-45ea-aee6-cdcdfa125eb5" />


```
SMC: 5,000 sampled plans of 9 districts on 2,407 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.57 to 0.80
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv      plan_dev 
        1.006         1.011         1.005         1.015         1.028         1.023         1.033         1.005 
     pop_aian     pop_asian     pop_black      pop_hisp      pop_nhpi     pop_other   pop_overlap       pop_two 
        1.017         1.022         1.026         1.034         1.021         1.018         1.006         1.025 
    pop_white     total_vap      vap_aian     vap_asian     vap_black      vap_hisp      vap_nhpi     vap_other 
        1.030         1.021         1.019         1.022         1.022         1.024         1.015         1.023 
      vap_two     vap_white 
        1.022         1.015 
• R-hat ≤ 1.05: 234
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 234
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       898 (44.9%)     12.0%        1.05 1,262 (100%)      9 
Split 2       906 (45.3%)     10.2%        0.88   980 ( 78%)      9 
Split 3       814 (40.7%)     16.3%        0.82 1,022 ( 81%)      5 
Split 4       844 (42.2%)     15.0%        0.86 1,027 ( 81%)      5 
Split 5       871 (43.5%)     14.8%        0.73 1,029 ( 81%)      4 
Split 6       901 (45.1%)     17.9%        0.80 1,045 ( 83%)      3 
Split 7       899 (44.9%)     10.4%        0.88   975 ( 77%)      5 
Split 8     1,789 (89.5%)      3.7%        0.35   922 ( 73%)      4 
Resample    1,789 (89.5%)       NA%          NA 1,718 (136%)     NA 

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       907 (45.4%)     12.2%        1.08 1,253 ( 99%)      9 
Split 2       866 (43.3%)     15.1%        0.89   979 ( 77%)      6 
Split 3       699 (34.9%)     20.1%        0.86 1,020 ( 81%)      4 
Split 4       783 (39.2%)     23.5%        0.87   999 ( 79%)      3 
Split 5       929 (46.5%)     15.3%        0.75 1,035 ( 82%)      4 
Split 6       794 (39.7%)     18.3%        0.81 1,050 ( 83%)      3 
Split 7       873 (43.6%)     15.1%        0.88   988 ( 78%)      3 
Split 8     1,861 (93.1%)      6.8%        0.28   939 ( 74%)      2 
Resample    1,861 (93.1%)       NA%          NA 1,791 (142%)     NA 

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       872 (43.6%)     13.3%        1.07 1,239 ( 98%)      8 
Split 2       965 (48.3%)     15.7%        0.87   979 ( 77%)      6 
Split 3       765 (38.2%)     19.8%        0.80 1,037 ( 82%)      4 
Split 4       743 (37.2%)     18.9%        0.86 1,017 ( 80%)      4 
Split 5       876 (43.8%)     15.4%        0.73 1,023 ( 81%)      4 
Split 6       916 (45.8%)     19.3%        0.78 1,054 ( 83%)      3 
Split 7       847 (42.4%)     21.9%        0.88 1,008 ( 80%)      2 
Split 8     1,820 (91.0%)      7.0%        0.31   942 ( 75%)      2 
Resample    1,820 (91.0%)       NA%          NA 1,752 (139%)     NA 

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       897 (44.8%)     15.5%        1.08 1,204 ( 95%)      7 
Split 2       987 (49.4%)     11.6%        0.87   943 ( 75%)      8 
Split 3       951 (47.6%)     15.9%        0.81 1,020 ( 81%)      5 
Split 4       937 (46.9%)     18.7%        0.80 1,026 ( 81%)      4 
Split 5     1,014 (50.7%)     12.3%        0.71 1,070 ( 85%)      5 
Split 6       964 (48.2%)     14.6%        0.78 1,072 ( 85%)      4 
Split 7       819 (41.0%)     15.6%        0.87 1,019 ( 81%)      3 
Split 8     1,849 (92.5%)      7.2%        0.29   910 ( 72%)      2 
Resample    1,849 (92.5%)       NA%          NA 1,773 (140%)     NA 

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       884 (44.2%)     15.7%        1.07 1,243 ( 98%)      7 
Split 2       860 (43.0%)     18.3%        0.88   964 ( 76%)      5 
Split 3       853 (42.6%)      8.3%        0.81 1,005 ( 79%)     10 
Split 4       819 (41.0%)     13.3%        0.88 1,020 ( 81%)      6 
Split 5       933 (46.6%)     15.5%        0.76 1,003 ( 79%)      4 
Split 6       949 (47.4%)     14.6%        0.82 1,057 ( 84%)      4 
Split 7       890 (44.5%)     16.1%        0.90 1,012 ( 80%)      3 
Split 8     1,819 (91.0%)      6.9%        0.31   953 ( 75%)      2 
Resample    1,819 (91.0%)       NA%          NA 1,744 (138%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
