### PR TITLE
2000 California Congressional Districts

### DIFF
--- a/analyses/CA_cd_2000/01_prep_CA_cd_2000.R
+++ b/analyses/CA_cd_2000/01_prep_CA_cd_2000.R
@@ -1,0 +1,90 @@
+###############################################################################
+# Download and prepare data for CA_cd_2000 analysis
+# © ALARM Project, August 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  library(stringr) 
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CA_cd_2000}")
+path_data <- download_redistricting_file("CA", "data-raw/CA", year = 2000)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CA_2000/shp_vtd.rds"
+perim_path <- "data-out/CA_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong CA} shapefile")
+  
+  # read in redistricting data
+  ca_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+    join_vtd_shapefile(year = 2000) %>%
+    st_transform(EPSG$CA)
+  
+  ca_shp <- ca_shp %>%
+    rename(muni = place) %>%
+    mutate(muni = as.character(muni),
+           county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(muni, county_muni, cd_1990, .after = county)
+
+# Reallocate counts from two islands to nearest mainland neighbors, then drop them to keep contiguity.
+  xwalk <- tibble::tibble(
+    donor_GEOID = c("06037599100", "06037599000"),
+    recip_GEOID = c("06037297300", "06037297500")
+  )
+  
+  idx_donors <- match(xwalk$donor_GEOID, ca_shp$GEOID)
+  idx_recip  <- match(xwalk$recip_GEOID, ca_shp$GEOID)
+  stopifnot(all(!is.na(idx_donors)), all(!is.na(idx_recip)))
+  
+  counts_cols <- c(
+    "pop","vap","ndv","nrv",
+    grep("^pop_(white|black|hisp|asian|aian|nhpi|two|other)$", names(ca_shp), value = TRUE),
+    grep("^vap_(white|black|hisp|asian|aian|nhpi|two|other)$", names(ca_shp), value = TRUE)
+  ) |> intersect(names(ca_shp))
+  
+  for (k in seq_along(idx_donors)) {
+    i <- idx_donors[k]; j <- idx_recip[k]
+    di <- sf::st_drop_geometry(ca_shp[i, counts_cols, drop = FALSE]); di[is.na(di)] <- 0
+    dj <- sf::st_drop_geometry(ca_shp[j, counts_cols, drop = FALSE]); dj[is.na(dj)] <- 0
+    ca_shp[j, counts_cols] <- as.data.frame(mapply(`+`, dj, di, SIMPLIFY = FALSE))
+    ca_shp[i, counts_cols] <- 0
+  }
+  
+  ca_shp <- ca_shp %>%
+    filter(!GEOID %in% xwalk$donor_GEOID)
+  
+  dir.create(dirname(here(perim_path)), recursive = TRUE, showWarnings = FALSE)
+  redistmetrics::prep_perims(ca_shp, perim_path = here(perim_path)) %>% invisible()
+  
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    ca_shp <- rmapshaper::ms_simplify(ca_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  ca_shp$adj <- redist.adjacency(ca_shp)
+  
+  ca_shp <- ca_shp %>%
+    fix_geo_assignment(muni)
+  
+  write_rds(ca_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  ca_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong CA} shapefile")
+}

--- a/analyses/CA_cd_2000/02_setup_CA_cd_2000.R
+++ b/analyses/CA_cd_2000/02_setup_CA_cd_2000.R
@@ -1,0 +1,66 @@
+###############################################################################
+# Set up redistricting simulation for `CA_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CA_cd_2000}")
+
+adj0 <- redist.adjacency(ca_shp)
+
+map <- redist_map(ca_shp, pop_tol = 0.005,
+                  existing_plan = "cd_2000", adj = adj0)
+attr(map, "existing_col") <- "cd_2000"
+
+# Pseudo-county
+map <- map %>%
+  mutate(
+    pseudo_county = pick_county_muni(
+      map,
+      counties = county,   
+      munis    = muni,     
+      pop_muni = get_target(map)
+    )
+  )
+attr(map, "existing_col") <- "cd_2000"
+
+map <- map %>%
+  mutate(
+    uid = row_number(),
+    ndv = coalesce(ndv, 0),
+    nrv = coalesce(nrv, 0)
+  )
+attr(map, "existing_col") <- "cd_2000"
+
+counties_south <- paste0("06", c("037","071","059","065","073","025"))
+counties_bay   <- paste0("06", c("001","013","039","047","053","067","069",
+                                 "075","077","081","085","087","095","099","113"))
+
+# build clean submaps 
+# South
+south_sf  <- dplyr::filter(map_sf, county %in% counties_south)
+adj_south <- redist.adjacency(south_sf)
+map_south <- redist_map(south_sf, ndists = 30, pop_tol = 0.005, adj = adj_south)
+attr(map_south, "existing_col") <- NULL
+if ("cd_2000" %in% names(map_south)) map_south[["cd_2000"]] <- NULL
+
+# Bay
+bay_sf  <- dplyr::filter(map_sf, county %in% counties_bay)
+adj_bay <- redist.adjacency(bay_sf)
+map_bay <- redist_map(bay_sf, ndists = 15, pop_tol = 0.005, adj = adj_bay)
+attr(map_bay, "existing_col") <- NULL
+if ("cd_2000" %in% names(map_bay)) map_bay[["cd_2000"]] <- NULL
+
+# cluster flag
+map <- map %>%
+  mutate(cluster = case_when(county %in% counties_bay ~ "Bay",
+                             county %in% counties_south ~ "South",
+                             TRUE ~ "Remainder"))
+attr(map, "existing_col") <- "cd_2000"
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CA_2000"
+
+map$state <- "CA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CA_2000/CA_cd_2000_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CA_cd_2000/03_sim_CA_cd_2000.R
+++ b/analyses/CA_cd_2000/03_sim_CA_cd_2000.R
@@ -1,0 +1,411 @@
+###############################################################################
+# Simulate plans for `CA_cd_2000`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CA_cd_2000}")
+
+nsims_regional <- 200L
+nsims_state    <- 200L
+
+sampling_space_val <- tryCatch(
+  getFromNamespace("LINKING_EDGE_SPACE", "redist"),  
+  error = function(e) "linking_edge"                 
+)
+
+# Simulate southern CA ----
+seam_south <- c(
+  '06037113202',
+  '06037113211',
+  '06037113231',
+  '06037134401',
+  '06037135203',
+  '06037137302',
+  '06037800201',
+  '06037800302',
+  '06037800323',
+  '06037800325',
+  '06037800326',
+  '06037800404',
+  '06037900102',
+  '06037900200',
+  '06037900900',
+  '06037901203',
+  '06037920104',
+  '06037920106',
+  '06037920303',
+  '06037920326',
+  '06071008901',
+  '06071010300',
+  '06071011600'
+)
+
+map_south$boundary <- map_south$GEOID %in% seam_south
+
+if (exists("cd_2000",  inherits = FALSE)) rm(cd_2000)
+if (exists("exist_col", inherits = FALSE)) rm(exist_col)
+attr(map_south, "existing_col") <- NULL
+
+cons_south <- redist_constr(map_south) %>%
+  add_constr_grp_hinge(
+    strength = 6,
+    group_pop = vap_hisp,
+    total_pop = vap,
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -3,
+    group_pop = vap_hisp,
+    total_pop = vap,
+    tgts_group = .3
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -3,
+    group_pop = vap_hisp,
+    total_pop = vap,
+    tgts_group = .2
+  ) %>%
+  add_constr_custom(
+    strength = 5,
+    fn = function(plan, distr) {
+      as.numeric(!any(plan[map_south$boundary] == 0))
+    }
+  )
+
+n_steps_south <- floor(sum(map_south$pop) / attr(map_south, "pop_bounds")[2])
+n_steps_south <- attr(map_south, "ndists") - 1L
+
+set.seed(2000)
+
+plans_south <- redist_smc(
+  map_south,
+  nsims = nsims_regional, runs = 5,
+  counties = pseudo_county,
+  constraints = cons_south,
+  n_steps = n_steps_south, pop_temper = 0.03, seq_alpha = 0.97,
+  sampling_space = sampling_space_val,
+  ms_params = list(ms_frequency = 1L, ms_moves_multiplier = 30),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  ncores = parallel::detectCores()
+)
+
+if (!"keep" %in% names(plans_south)) plans_south <- plans_south %>% mutate(keep = TRUE)
+
+write_rds(plans_south, here("data-raw/CA/plans_south.rds"), compress = "xz")
+
+# Simulate large bay area ----
+seam_bay <- c(
+  '06013359101',
+  '06013365001',
+  '06013365002',
+  '06013378000',
+  '06039000102',
+  '06039000103',
+  '06039000105',
+  '06039000400',
+  '06039001000',
+  '06047000100',
+  '06047001901',
+  '06047001902',
+  '06047002100',
+  '06047002400',
+  '06053011400',
+  '06067007100',
+  '06067007206',
+  '06067007417',
+  '06067007418',
+  '06067007419',
+  '06067007421',
+  '06067008113',
+  '06067008124',
+  '06067008127',
+  '06067008128',
+  '06067008143',
+  '06067008203',
+  '06067008210',
+  '06067008211',
+  '06067008501',
+  '06067008502',
+  '06067008503',
+  '06067008600',
+  '06067009404',
+  '06067009406',
+  '06069000800',
+  '06075017902',
+  '06075047901',
+  '06075060100',
+  '06077004702',
+  '06095250102',
+  '06095250800',
+  '06095251803',
+  '06095251804',
+  '06095251902',
+  '06095251903',
+  '06095252201',
+  '06095252202',
+  '06095252307',
+  '06095252903',
+  '06099000101',
+  '06099000102',
+  '06099002801',
+  '06099002901',
+  '06113010102',
+  '06113011300',
+  '06113011400',
+  '06113011500'
+)
+
+map_bay$boundary <- map_bay$GEOID %in% seam_bay
+
+if (exists("cd_2000",  inherits = FALSE)) rm(cd_2000)
+if (exists("exist_col", inherits = FALSE)) rm(exist_col)
+attr(map_bay, "existing_col") <- NULL
+
+cons_bay <- redist_constr(map_bay) %>%
+  add_constr_grp_hinge(
+    strength = 2.5,
+    group_pop = vap_hisp,
+    total_pop = vap,
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -2.5,
+    group_pop = vap_hisp,
+    total_pop = vap,
+    tgts_group = .3
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -2.5,
+    group_pop = vap_hisp,
+    total_pop = vap,
+    tgts_group = .2
+  ) %>%
+  add_constr_grp_hinge(
+    strength = 3,
+    group_pop = vap_asian,
+    total_pop = vap,
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -3,
+    group_pop = vap_asian,
+    total_pop = vap,
+    tgts_group = .3
+  ) %>%
+  add_constr_grp_hinge(
+    strength = -3,
+    group_pop = vap_asian,
+    total_pop = vap,
+    tgts_group = .2
+  ) %>%
+  add_constr_custom(
+    strength = 5,
+    fn = function(plan, distr) {
+      as.numeric(!any(plan[map_bay$boundary] == 0))
+    }
+  )
+
+n_steps_bay <- floor(sum(map_bay$pop) / attr(map_bay, "pop_bounds")[2])
+n_steps_bay   <- attr(map_bay,   "ndists") - 1L 
+
+set.seed(2000)
+
+plans_bay <- redist_smc(
+  map_bay,
+  nsims = nsims_regional, runs = 5,
+  counties = pseudo_county,
+  constraints = cons_bay,
+  n_steps = n_steps_bay, pop_temper = 0.03, seq_alpha = 0.97, 
+  sampling_space = sampling_space_val,
+  ms_params = list(ms_frequency = 1L, ms_moves_multiplier = 15),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  ncores = parallel::detectCores()
+)
+if (!"keep" %in% names(plans_bay)) plans_bay <- plans_bay %>% mutate(keep = TRUE)
+
+write_rds(plans_bay,   here("data-raw/CA/plans_bay.rds"),   compress = "xz")
+
+# Pull it all together ----
+# Make sure statewide map has enacted attribute
+attr(map, "existing_col") <- "cd_2000"
+stopifnot(is.character(attr(map, "existing_col")),
+          length(attr(map, "existing_col")) == 1,
+          identical(attr(map, "existing_col"), "cd_2000"))
+
+draws_south <- ncol(redist::get_plans_matrix(redist::subset_sampled(plans_south)))
+draws_bay   <- ncol(redist::get_plans_matrix(redist::subset_sampled(plans_bay)))
+
+# set statewide nsims to at least the max regional draws
+nsims_state <- max(draws_south, draws_bay)
+
+init <- prep_particles(
+  map = map,
+  map_plan_list = list(
+    south = list(
+      map = map_south,
+      plans = plans_south
+    ),
+    bay = list(
+      map = map_bay,
+      plans = plans_bay
+    )
+  ),
+  uid = GEOID,
+  dist_keep = keep,
+  nsims = nsims_state
+)
+
+set.seed(2000)
+
+cons_final <- redist_constr(map) %>%
+  add_constr_grp_hinge(strength = 1.5, group_pop = vap_hisp,  total_pop = vap) %>%
+  add_constr_grp_hinge(strength = 1.5, group_pop = vap_asian, total_pop = vap)
+
+plans <- redist_smc(
+  map,
+  nsims = nsims_state, runs = 5,
+  counties = county,
+  constraints = cons_final,
+  #init_particles = init,
+  pop_temper = 0.03, seq_alpha  = 0.97,
+  sampling_space = sampling_space_val,
+  ms_params = list(ms_frequency = 1L, ms_moves_multiplier = 53),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  ncores = parallel::detectCores()
+)
+
+attr(plans, "existing_col") <- "cd_2000"
+attr(plans, "prec_pop") <- map$pop
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CA_2000/CA_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg  CA_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CA_2000/CA_cd_2000_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  plans   <- plans %>% mutate(total_vap = total_vap)
+  enac_sum <- plans %>% subset_ref() %>% mutate(total_vap = total_vap)
+  
+  plans <- plans %>%
+    group_by(draw, district) %>%
+    mutate(e_dvs = if_else(sum(ndv + nrv, na.rm = TRUE) > 0,
+                           sum(ndv, na.rm = TRUE) / sum(ndv + nrv, na.rm = TRUE),
+                           NA_real_)) %>%
+    ungroup()
+  
+  p1 <- redist.plot.hist(plans %>% group_by(draw) %>%
+                           mutate(hisp_dem = sum((vap_hisp/total_vap > 0.5) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Hispanic and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(hisp_dem = sum((vap_hisp/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Hispanic > 40% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(hisp_dem = sum((vap_hisp/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Hispanic > 30% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(ha_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.5) & e_dvs > 0.5)), qty = ha_dem) +
+    labs(x = "Number of Hispanic + Asian and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Hispanic + Asian > 40% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(hisp_dem = sum(((vap_hisp + vap_asian)/total_vap > 0.3) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Hispanic + Asian > 30% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(asian_dem = sum((vap_asian/total_vap > 0.5) & e_dvs > 0.5)), qty = asian_dem) +
+    labs(x = "Number of Asian and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(hisp_dem = sum((vap_asian/total_vap > 0.4) & e_dvs > 0.5)), qty = hisp_dem) +
+    labs(x = "Number of Asian > 40% and Dem. Majority") +
+    redist.plot.hist(plans %>% group_by(draw) %>%
+                       mutate(coalition_dem = sum(((vap_asian + vap_hisp + vap_black)/total_vap > 0.5) & e_dvs > 0.5)), qty = coalition_dem) +
+    labs(x = "Number of Hispanic + Asian + Black and Dem. Majority") &
+    theme_bw()
+  
+  ggsave("data-raw/CA/hist.pdf", p1, width = 11, height = 8)
+  
+  
+  enac_sum <- plans %>%
+    subset_ref() %>%
+    mutate(minority = (total_vap - vap_white)/(total_vap),
+           dist_lab = str_pad(district, width = 2, pad = "0"),
+           minority_rank = rank(minority), # ascending order
+           hisp_rank = rank(vap_hisp),
+           asian_rank = rank(vap_asian),
+           ha_rank = rank(vap_hisp + vap_asian),
+           coalition_rank = rank(vap_hisp + vap_asian + vap_black),
+           compact_rank = rank(comp_polsby)
+    )
+  
+  p2 <- redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+                               color_thresh = NULL,
+                               color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                               size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Hispanic by VAP") +
+    labs(title = "CA Enacted versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    geom_hline(yintercept = 0.5, linetype = "dotted") +
+    geom_text(data = enac_sum, aes(x = hisp_rank, label = round(e_dvs, 2)),
+              vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+              color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+    redist.plot.distr_qtys(plans, vap_asian/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Asian by VAP") +
+    labs(title = "CA Enacted versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    geom_hline(yintercept = 0.5, linetype = "dotted") +
+    geom_text(data = enac_sum, aes(x = asian_rank, label = round(e_dvs, 2)),
+              vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+              color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+    redist.plot.distr_qtys(plans, (vap_asian + vap_hisp)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Hispanic or Asian by VAP") +
+    labs(title = "CA Enacted versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    geom_hline(yintercept = 0.5, linetype = "dotted") +
+    geom_text(data = enac_sum, aes(x = ha_rank, label = round(e_dvs, 2)),
+              vjust = 3, y = Inf, size = 2.5, fontface = "bold", lineheight = 0.8, alpha = 0.8,
+              color = ifelse(subset_ref(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C")) +
+    redist.plot.distr_qtys(plans, (vap_asian + vap_hisp + vap_black)/total_vap,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Coalition by VAP") +
+    labs(title = "CA Enacted versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    geom_hline(yintercept = 0.5, linetype = "dotted") +
+    redist.plot.distr_qtys(plans %>% number_by(e_dvs), (vap_asian + vap_hisp + vap_black)/total_vap, sort = FALSE,
+                           color_thresh = NULL,
+                           color = ifelse(subset_sampled(plans)$e_dvs > 0.5, "#3D77BB", "#B25D4C"),
+                           size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Coalition by VAP") +
+    labs(title = "CA Enacted versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    geom_hline(yintercept = 0.5, linetype = "dotted")
+  
+  ggsave("data-raw/CA/boxplot.pdf", p2, width = 11, height = 8)
+  
+}

--- a/analyses/CA_cd_2000/doc_CA_cd_2000.md
+++ b/analyses/CA_cd_2000/doc_CA_cd_2000.md
@@ -1,0 +1,33 @@
+# 2000 California Congressional Districts
+
+## Redistricting requirements
+In ``California``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. preserve city, county, neighborhood, and community of interest boundaries as much as possible
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to limit the county and municipality splits. We add VRA constraints encouraging Hispanic VAP and Asian VAP majorities in districts.
+
+## Data Sources
+Data for ``California`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+We reallocated the population and voting data from two offshore precincts, which left the adjacency graph disconnected even after linking them to mainland neighbors, to their nearest mainland precincts, and dropped them from the adjacency graph to ensure both statistical integrity and topological contiguity.
+
+## Simulation Notes
+We sample 200 districting plans in each cluster across 5 independent runs of the SMC algorithm.
+We next sample 5,000 districting plans for California across 5 independent runs of the SMC algorithm for the remainder.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint. 
+
+### 1. Clustering Procedure
+First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:
+- South: Los Angeles, San Bernardino, Orange, Riverside, San Diego, and Imperial
+- Bay: Alameda, Contra Costa, Fresno, Kings, Madera, Madera, Merced, Monterey, Sacramento, San Benito, San Francisco, San Joaquin, San Mateo, Santa Clara, Santa Cruz, Solano, Stanislaus, Tulare, and Yolo
+
+We sample in each of these regions with a population deviation of 0.5%. We sample 30 districts in the southern region and 15 districts in the Bay Area. Because each cluster will have leftover population, we apply an additional constraint that
+incentivizes leaving any unassigned areas on the edge of these clusters to avoid discontiguities. For each cluster, we add VRA constraints encouraging Hispanic VAP and Asian VAP concentrations in districts, in line with the enacted plan.
+
+### 2. Combination Procedure
+Then, these partial map simulations are combined to run statewide simulations. The statewide run fills in the remainder of the state’s 53 districts.


### PR DESCRIPTION
## Redistricting requirements
In ``California``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. preserve city, county, neighborhood, and community of interest boundaries as much as possible

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We use a pseudo-county constraint to limit the county and municipality splits. We add VRA constraints encouraging Hispanic VAP and Asian VAP majorities in districts.

## Data Sources
Data for ``California`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
We reallocated the population and voting data from two offshore precincts, which left the adjacency graph disconnected even after linking them to mainland neighbors, to their nearest mainland precincts, and dropped them from the adjacency graph to ensure both statistical integrity and topological contiguity.

## Simulation Notes
We sample 200 districting plans in each cluster across 5 independent runs of the SMC algorithm.
We next sample 5,000 districting plans for California across 5 independent runs of the SMC algorithm for the remainder.
To balance county and municipality splits, we create pseudocounties for use in the county constraint. 

### 1. Clustering Procedure
First, we run partial SMC in two pieces: the south and the Bay Area. The counties in each cluster are:
- South: Los Angeles, San Bernardino, Orange, Riverside, San Diego, and Imperial
- Bay: Alameda, Contra Costa, Fresno, Kings, Madera, Madera, Merced, Monterey, Sacramento, San Benito, San Francisco, San Joaquin, San Mateo, Santa Clara, Santa Cruz, Solano, Stanislaus, Tulare, and Yolo

We sample in each of these regions with a population deviation of 0.5%. We sample 30 districts in the southern region and 15 districts in the Bay Area. Because each cluster will have leftover population, we apply an additional constraint that
incentivizes leaving any unassigned areas on the edge of these clusters to avoid discontiguities. For each cluster, we add VRA constraints encouraging Hispanic VAP and Asian VAP concentrations in districts, in line with the enacted plan.

### 2. Combination Procedure
Then, these partial map simulations are combined to run statewide simulations. The statewide run fills in the remainder of the state’s 53 districts.

## Validation

<img width="3000" height="4500" alt="validation_20250827_2314" src="https://github.com/user-attachments/assets/8d9aae75-8a95-45d5-95d3-d6efe87d3db6" />


```
✔ Running simulations for CA_cd_2000 ... done
SMC with Merge-Split MCMC Steps: 5,000 sampled plans of 53 districts on
7,047 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge
forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.03
Mergesplit Parameters:
• `total_ms_steps` = 52
• `ms_moves_multiplier` = 53
• `merge_prob_type` = uniform
Plan diversity 80% range: 0.8 to 0.9
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare 
        1.006         1.008         1.020         1.012         1.035 
          ndv           nrv      plan_dev      pop_aian     pop_asian 
        1.010         1.016         1.001         1.047         1.012 
    pop_black      pop_hisp      pop_nhpi     pop_other   pop_overlap 
        1.017         1.012         1.017         1.012         1.014 
      pop_two     pop_white     total_vap      vap_aian     vap_asian 
        1.011         1.023         1.015         1.045         1.013 
    vap_black      vap_hisp      vap_nhpi     vap_other       vap_two 
        1.017         1.018         1.017         1.011         1.012 
    vap_white 
        1.019 
• R-hat ≤ 1.05: 1378
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1378
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       240 (24.0%)    100.0%        1.18   637 (101%) 
Split 2       396 (39.6%)     96.5%        1.01   425 ( 67%) 
Split 3       530 (53.0%)     91.7%        0.84   480 ( 76%) 
Split 4       557 (55.7%)     86.6%        0.78   530 ( 84%) 
Split 5       631 (63.1%)     80.5%        0.65   532 ( 84%) 
Split 6       687 (68.7%)     76.3%        0.62   557 ( 88%) 
Split 7       703 (70.3%)     71.3%        0.57   551 ( 87%) 
Split 8       763 (76.3%)     65.3%        0.52   568 ( 90%) 
Split 9       767 (76.7%)     61.9%        0.51   588 ( 93%) 
Split 10      806 (80.6%)     60.2%        0.45   570 ( 90%) 
Split 11      842 (84.2%)     58.5%        0.42   580 ( 92%) 
Split 12      855 (85.5%)     54.8%        0.41   601 ( 95%) 
Split 13      859 (85.9%)     52.9%        0.40   592 ( 94%) 
Split 14      872 (87.2%)     48.5%        0.38   584 ( 92%) 
Split 15      883 (88.3%)     47.4%        0.35   598 ( 95%) 
Split 16      905 (90.5%)     42.9%        0.33   616 ( 97%) 
Split 17      905 (90.5%)     44.4%        0.31   600 ( 95%) 
Split 18      906 (90.6%)     40.2%        0.31   621 ( 98%) 
Split 19      912 (91.2%)     36.6%        0.30   605 ( 96%) 
Split 20      922 (92.2%)     36.9%        0.29   606 ( 96%) 
Split 21      931 (93.1%)     34.7%        0.27   618 ( 98%) 
Split 22      936 (93.6%)     31.6%        0.26   607 ( 96%) 
Split 23      946 (94.6%)     31.1%        0.24   621 ( 98%) 
Split 24      942 (94.2%)     29.1%        0.24   614 ( 97%) 
Split 25      952 (95.2%)     28.2%        0.23   606 ( 96%) 
Split 26      948 (94.8%)     27.3%        0.23   616 ( 97%) 
Split 27      959 (95.9%)     25.2%        0.21   613 ( 97%) 
Split 28      955 (95.5%)     23.0%        0.22   617 ( 98%) 
Split 29      955 (95.5%)     23.5%        0.21   621 ( 98%) 
Split 30      958 (95.8%)     22.0%        0.21   612 ( 97%) 
Split 31      963 (96.3%)     21.6%        0.19   624 ( 99%) 
Split 32      967 (96.7%)     20.3%        0.18   610 ( 97%) 
Split 33      962 (96.2%)     19.4%        0.20   616 ( 97%) 
Split 34      969 (96.9%)     18.5%        0.18   598 ( 95%) 
Split 35      968 (96.8%)     17.5%        0.18   620 ( 98%) 
Split 36      968 (96.8%)     17.1%        0.18   614 ( 97%) 
Split 37      969 (96.9%)     16.3%        0.18   614 ( 97%) 
Split 38      974 (97.4%)     16.4%        0.16   598 ( 95%) 
Split 39      975 (97.5%)     15.3%        0.16   610 ( 97%) 
Split 40      973 (97.3%)     14.1%        0.17   623 ( 99%) 
Split 41      977 (97.7%)     14.1%        0.15   611 ( 97%) 
Split 42      975 (97.5%)     13.0%        0.16   596 ( 94%) 
Split 43      978 (97.8%)     12.8%        0.15   599 ( 95%) 
Split 44      977 (97.7%)     13.3%        0.15   606 ( 96%) 
Split 45      979 (97.9%)     12.6%        0.15   633 (100%) 
Split 46      981 (98.1%)     11.0%        0.14   625 ( 99%) 
Split 47      979 (97.9%)     11.2%        0.15   618 ( 98%) 
Split 48      980 (98.0%)     10.7%        0.14   595 ( 94%) 
Split 49      985 (98.5%)      9.6%        0.12   617 ( 98%) 
Split 50      985 (98.5%)      9.7%        0.13   584 ( 92%) 
Split 51      989 (98.9%)      9.9%        0.11   605 ( 96%) 
Split 52      989 (98.9%)      9.3%        0.10   555 ( 88%) 
Resample      989 (98.9%)       NA%          NA   953 (151%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (5,000
samples)
           Acc. rate MS Moves per Plan
MS Step 1      39.1%                53
MS Step 2      39.8%               159
MS Step 3      40.7%               159
MS Step 4      40.6%               159
MS Step 5      40.3%               159
MS Step 6      39.9%               159
MS Step 7      39.5%               159
MS Step 8      39.1%               159
MS Step 9      38.4%               159
MS Step 10     37.5%               159
MS Step 11     36.6%               159
MS Step 12     36.0%               159
MS Step 13     35.3%               159
MS Step 14     34.6%               159
MS Step 15     33.9%               159
MS Step 16     32.9%               159
MS Step 17     31.8%               212
MS Step 18     31.1%               212
MS Step 19     30.5%               212
MS Step 20     29.4%               212
MS Step 21     28.9%               212
MS Step 22     28.1%               212
MS Step 23     27.5%               212
MS Step 24     26.5%               212
MS Step 25     25.9%               212
MS Step 26     26.1%               212
MS Step 27     24.7%               212
MS Step 28     23.7%               265
MS Step 29     23.0%               265
MS Step 30     22.3%               265
MS Step 31     21.7%               265
MS Step 32     21.0%               265
MS Step 33     20.2%               265
MS Step 34     19.9%               265
MS Step 35     19.1%               318
MS Step 36     18.5%               318
MS Step 37     18.1%               318
MS Step 38     17.5%               318
MS Step 39     16.9%               318
MS Step 40     16.5%               318
MS Step 41     16.0%               371
MS Step 42     15.5%               371
MS Step 43     15.1%               371
MS Step 44     14.8%               371
MS Step 45     14.2%               371
MS Step 46     13.8%               424
MS Step 47     13.3%               424
MS Step 48     13.0%               424
MS Step 49     12.8%               424
MS Step 50     12.3%               424
MS Step 51     11.8%               477
MS Step 52     11.7%               477

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       151 (15.1%)    100.0%       1.209   640 (101%) 
Split 2       408 (40.8%)     97.4%       0.956   405 ( 64%) 
Split 3       499 (49.9%)     92.9%       0.890   511 ( 81%) 
Split 4       553 (55.3%)     84.1%       0.726   496 ( 78%) 
Split 5       542 (54.2%)     81.6%       0.687   544 ( 86%) 
Split 6       649 (64.9%)     76.3%       0.650   549 ( 87%) 
Split 7       692 (69.2%)     71.3%       0.565   560 ( 89%) 
Split 8       741 (74.1%)     68.5%       0.553   586 ( 93%) 
Split 9       781 (78.1%)     63.9%       0.505   573 ( 91%) 
Split 10      806 (80.6%)     60.2%       0.473   602 ( 95%) 
Split 11      821 (82.1%)     55.7%       0.458   576 ( 91%) 
Split 12      824 (82.4%)     53.1%       0.435   595 ( 94%) 
Split 13      866 (86.6%)     53.6%       0.383   592 ( 94%) 
Split 14      859 (85.9%)     48.4%       0.379   613 ( 97%) 
Split 15      858 (85.8%)     44.9%       0.379   590 ( 93%) 
Split 16      884 (88.4%)     44.9%       0.335   610 ( 97%) 
Split 17      900 (90.0%)     43.4%       0.319   618 ( 98%) 
Split 18      903 (90.3%)     40.6%       0.315   594 ( 94%) 
Split 19      915 (91.5%)     37.5%       0.300   620 ( 98%) 
Split 20      914 (91.4%)     35.3%       0.293   618 ( 98%) 
Split 21      921 (92.1%)     35.3%       0.278   605 ( 96%) 
Split 22      940 (94.0%)     31.7%       0.252   626 ( 99%) 
Split 23      936 (93.6%)     30.0%       0.261   620 ( 98%) 
Split 24      942 (94.2%)     29.4%       0.247   614 ( 97%) 
Split 25      944 (94.4%)     28.6%       0.240   595 ( 94%) 
Split 26      947 (94.7%)     27.7%       0.232   614 ( 97%) 
Split 27      956 (95.6%)     24.8%       0.208   607 ( 96%) 
Split 28      959 (95.9%)     24.0%       0.208   624 ( 99%) 
Split 29      953 (95.3%)     23.5%       0.219   603 ( 95%) 
Split 30      956 (95.6%)     22.5%       0.214   610 ( 97%) 
Split 31      964 (96.4%)     21.2%       0.196   617 ( 98%) 
Split 32      964 (96.4%)     21.0%       0.193   628 ( 99%) 
Split 33      965 (96.5%)     19.1%       0.190   610 ( 97%) 
Split 34      967 (96.7%)     18.5%       0.190   604 ( 96%) 
Split 35      969 (96.9%)     17.6%       0.179   610 ( 97%) 
Split 36      967 (96.7%)     17.1%       0.180   611 ( 97%) 
Split 37      974 (97.4%)     16.9%       0.162   617 ( 98%) 
Split 38      976 (97.6%)     15.5%       0.159   608 ( 96%) 
Split 39      976 (97.6%)     15.9%       0.158   600 ( 95%) 
Split 40      975 (97.5%)     15.0%       0.162   605 ( 96%) 
Split 41      975 (97.5%)     13.6%       0.160   610 ( 97%) 
Split 42      978 (97.8%)     14.1%       0.152   601 ( 95%) 
Split 43      975 (97.5%)     13.1%       0.163   617 ( 98%) 
Split 44      976 (97.6%)     12.9%       0.157   608 ( 96%) 
Split 45      980 (98.0%)     11.9%       0.144   602 ( 95%) 
Split 46      979 (97.9%)     10.8%       0.150   610 ( 97%) 
Split 47      983 (98.3%)     10.6%       0.134   611 ( 97%) 
Split 48      983 (98.3%)     10.0%       0.136   610 ( 97%) 
Split 49      984 (98.4%)      9.9%       0.133   600 ( 95%) 
Split 50      985 (98.5%)     10.0%       0.125   603 ( 95%) 
Split 51      989 (98.9%)      9.6%       0.106   569 ( 90%) 
Split 52      991 (99.1%)      8.9%       0.097   546 ( 86%) 
Resample      991 (99.1%)       NA%          NA   953 (151%) 

Sampling diagnostics for Mergesplit Steps of SMC run 2 of 5 (5,000
samples)
           Acc. rate MS Moves per Plan
MS Step 1      39.0%                53
MS Step 2      39.6%               159
MS Step 3      40.1%               159
MS Step 4      40.1%               159
MS Step 5      40.4%               159
MS Step 6      39.9%               159
MS Step 7      39.8%               159
MS Step 8      38.9%               159
MS Step 9      38.4%               159
MS Step 10     38.0%               159
MS Step 11     37.0%               159
MS Step 12     36.5%               159
MS Step 13     35.5%               159
MS Step 14     34.4%               159
MS Step 15     33.5%               159
MS Step 16     32.8%               159
MS Step 17     32.1%               212
MS Step 18     31.2%               212
MS Step 19     30.3%               212
MS Step 20     29.6%               212
MS Step 21     29.0%               212
MS Step 22     28.0%               212
MS Step 23     27.2%               212
MS Step 24     26.6%               212
MS Step 25     25.7%               212
MS Step 26     26.0%               212
MS Step 27     24.5%               212
MS Step 28     23.6%               265
MS Step 29     22.9%               265
MS Step 30     22.0%               265
MS Step 31     21.6%               265
MS Step 32     20.8%               265
MS Step 33     20.2%               265
MS Step 34     19.6%               265
MS Step 35     18.9%               318
MS Step 36     18.4%               318
MS Step 37     17.8%               318
MS Step 38     17.4%               318
MS Step 39     16.6%               318
MS Step 40     16.3%               371
MS Step 41     15.6%               371
MS Step 42     15.3%               371
MS Step 43     14.9%               371
MS Step 44     14.5%               371
MS Step 45     14.0%               371
MS Step 46     13.4%               424
MS Step 47     13.0%               424
MS Step 48     12.8%               424
MS Step 49     12.3%               424
MS Step 50     11.9%               477
MS Step 51     11.5%               477
MS Step 52     11.2%               477

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       246 (24.6%)    100.0%       1.175   628 ( 99%) 
Split 2       334 (33.4%)     96.4%       1.004   417 ( 66%) 
Split 3       474 (47.4%)     90.6%       0.885   474 ( 75%) 
Split 4       544 (54.4%)     88.2%       0.790   491 ( 78%) 
Split 5       637 (63.7%)     81.1%       0.680   509 ( 81%) 
Split 6       668 (66.8%)     76.5%       0.607   563 ( 89%) 
Split 7       639 (63.9%)     73.2%       0.607   573 ( 91%) 
Split 8       755 (75.5%)     66.9%       0.534   562 ( 89%) 
Split 9       745 (74.5%)     62.3%       0.511   575 ( 91%) 
Split 10      789 (78.9%)     60.5%       0.476   583 ( 92%) 
Split 11      800 (80.0%)     55.9%       0.462   585 ( 93%) 
Split 12      833 (83.3%)     53.5%       0.422   591 ( 93%) 
Split 13      856 (85.6%)     50.6%       0.395   591 ( 93%) 
Split 14      863 (86.3%)     49.8%       0.385   598 ( 95%) 
Split 15      869 (86.9%)     44.9%       0.371   594 ( 94%) 
Split 16      902 (90.2%)     44.4%       0.329   583 ( 92%) 
Split 17      900 (90.0%)     41.6%       0.328   607 ( 96%) 
Split 18      911 (91.1%)     38.9%       0.299   619 ( 98%) 
Split 19      915 (91.5%)     38.8%       0.305   616 ( 97%) 
Split 20      922 (92.2%)     33.2%       0.291   595 ( 94%) 
Split 21      924 (92.4%)     34.4%       0.286   592 ( 94%) 
Split 22      932 (93.2%)     31.6%       0.269   607 ( 96%) 
Split 23      935 (93.5%)     30.6%       0.258   618 ( 98%) 
Split 24      938 (93.8%)     28.9%       0.250   611 ( 97%) 
Split 25      944 (94.4%)     27.3%       0.242   614 ( 97%) 
Split 26      952 (95.2%)     26.2%       0.226   615 ( 97%) 
Split 27      961 (96.1%)     24.5%       0.204   622 ( 98%) 
Split 28      956 (95.6%)     24.1%       0.215   624 ( 99%) 
Split 29      956 (95.6%)     24.0%       0.212   609 ( 96%) 
Split 30      961 (96.1%)     22.9%       0.199   603 ( 95%) 
Split 31      963 (96.3%)     21.9%       0.196   613 ( 97%) 
Split 32      965 (96.5%)     20.3%       0.191   603 ( 95%) 
Split 33      965 (96.5%)     20.3%       0.191   606 ( 96%) 
Split 34      968 (96.8%)     18.3%       0.182   626 ( 99%) 
Split 35      972 (97.2%)     17.0%       0.171   619 ( 98%) 
Split 36      968 (96.8%)     17.2%       0.179   617 ( 98%) 
Split 37      973 (97.3%)     17.1%       0.165   623 ( 99%) 
Split 38      974 (97.4%)     15.0%       0.165   595 ( 94%) 
Split 39      973 (97.3%)     14.7%       0.167   624 ( 99%) 
Split 40      976 (97.6%)     14.2%       0.155   612 ( 97%) 
Split 41      975 (97.5%)     13.6%       0.158   608 ( 96%) 
Split 42      973 (97.3%)     12.6%       0.168   602 ( 95%) 
Split 43      977 (97.7%)     12.5%       0.156   613 ( 97%) 
Split 44      976 (97.6%)     12.6%       0.157   601 ( 95%) 
Split 45      980 (98.0%)     11.3%       0.146   620 ( 98%) 
Split 46      982 (98.2%)     11.0%       0.137   601 ( 95%) 
Split 47      981 (98.1%)     11.4%       0.141   592 ( 94%) 
Split 48      984 (98.4%)     10.5%       0.133   610 ( 97%) 
Split 49      984 (98.4%)      9.9%       0.131   591 ( 93%) 
Split 50      985 (98.5%)      9.2%       0.126   581 ( 92%) 
Split 51      988 (98.8%)      9.7%       0.109   569 ( 90%) 
Split 52      990 (99.0%)      8.6%       0.098   577 ( 91%) 
Resample      990 (99.0%)       NA%          NA   949 (150%) 

Sampling diagnostics for Mergesplit Steps of SMC run 3 of 5 (5,000
samples)
           Acc. rate MS Moves per Plan
MS Step 1      39.4%                53
MS Step 2      39.6%               159
MS Step 3      40.3%               159
MS Step 4      40.4%               159
MS Step 5      40.0%               159
MS Step 6      40.0%               159
MS Step 7      39.6%               159
MS Step 8      39.0%               159
MS Step 9      38.5%               159
MS Step 10     37.3%               159
MS Step 11     36.3%               159
MS Step 12     35.6%               159
MS Step 13     35.4%               159
MS Step 14     34.6%               159
MS Step 15     33.7%               159
MS Step 16     33.3%               159
MS Step 17     32.2%               212
MS Step 18     31.5%               212
MS Step 19     30.8%               212
MS Step 20     29.6%               212
MS Step 21     28.9%               212
MS Step 22     28.2%               212
MS Step 23     27.3%               212
MS Step 24     26.5%               212
MS Step 25     26.0%               212
MS Step 26     26.4%               212
MS Step 27     24.7%               212
MS Step 28     23.6%               265
MS Step 29     23.0%               265
MS Step 30     22.3%               265
MS Step 31     21.6%               265
MS Step 32     21.1%               265
MS Step 33     20.3%               265
MS Step 34     19.8%               265
MS Step 35     19.3%               318
MS Step 36     18.6%               318
MS Step 37     17.9%               318
MS Step 38     17.5%               318
MS Step 39     17.0%               318
MS Step 40     16.3%               318
MS Step 41     15.8%               371
MS Step 42     15.5%               371
MS Step 43     15.0%               371
MS Step 44     14.4%               371
MS Step 45     14.1%               371
MS Step 46     13.7%               424
MS Step 47     13.2%               424
MS Step 48     12.9%               424
MS Step 49     12.4%               424
MS Step 50     12.1%               477
MS Step 51     11.7%               477
MS Step 52     11.3%               477

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       191 (19.1%)    100.0%        1.24   645 (102%) 
Split 2       399 (39.9%)     97.5%        0.98   404 ( 64%) 
Split 3       445 (44.5%)     90.3%        0.85   496 ( 78%) 
Split 4       552 (55.2%)     87.1%        0.76   517 ( 82%) 
Split 5       648 (64.8%)     80.0%        0.69   528 ( 84%) 
Split 6       652 (65.2%)     74.0%        0.62   561 ( 89%) 
Split 7       743 (74.3%)     73.3%        0.57   553 ( 87%) 
Split 8       742 (74.2%)     68.2%        0.53   577 ( 91%) 
Split 9       776 (77.6%)     63.8%        0.50   575 ( 91%) 
Split 10      807 (80.7%)     59.2%        0.46   587 ( 93%) 
Split 11      834 (83.4%)     57.9%        0.45   588 ( 93%) 
Split 12      808 (80.8%)     53.0%        0.45   594 ( 94%) 
Split 13      862 (86.2%)     51.5%        0.38   590 ( 93%) 
Split 14      871 (87.1%)     47.2%        0.38   610 ( 97%) 
Split 15      882 (88.2%)     45.1%        0.38   598 ( 95%) 
Split 16      889 (88.9%)     45.5%        0.34   599 ( 95%) 
Split 17      906 (90.6%)     40.8%        0.32   603 ( 95%) 
Split 18      909 (90.9%)     38.9%        0.32   608 ( 96%) 
Split 19      915 (91.5%)     36.4%        0.31   594 ( 94%) 
Split 20      918 (91.8%)     34.1%        0.30   591 ( 93%) 
Split 21      925 (92.5%)     35.1%        0.28   620 ( 98%) 
Split 22      933 (93.3%)     32.5%        0.27   625 ( 99%) 
Split 23      936 (93.6%)     30.9%        0.26   628 ( 99%) 
Split 24      943 (94.3%)     29.2%        0.25   607 ( 96%) 
Split 25      945 (94.5%)     27.3%        0.24   623 ( 99%) 
Split 26      951 (95.1%)     26.8%        0.23   623 ( 99%) 
Split 27      959 (95.9%)     24.2%        0.21   607 ( 96%) 
Split 28      957 (95.7%)     22.9%        0.21   615 ( 97%) 
Split 29      957 (95.7%)     23.3%        0.21   619 ( 98%) 
Split 30      959 (95.9%)     22.7%        0.21   628 ( 99%) 
Split 31      964 (96.4%)     21.0%        0.19   598 ( 95%) 
Split 32      962 (96.2%)     19.5%        0.19   607 ( 96%) 
Split 33      962 (96.2%)     19.7%        0.20   608 ( 96%) 
Split 34      966 (96.6%)     18.3%        0.19   610 ( 97%) 
Split 35      966 (96.6%)     18.8%        0.19   604 ( 96%) 
Split 36      970 (97.0%)     17.8%        0.18   609 ( 96%) 
Split 37      973 (97.3%)     16.3%        0.17   617 ( 98%) 
Split 38      975 (97.5%)     15.3%        0.16   611 ( 97%) 
Split 39      975 (97.5%)     14.9%        0.16   618 ( 98%) 
Split 40      973 (97.3%)     14.2%        0.17   626 ( 99%) 
Split 41      977 (97.7%)     13.8%        0.16   593 ( 94%) 
Split 42      976 (97.6%)     13.3%        0.16   626 ( 99%) 
Split 43      980 (98.0%)     13.1%        0.15   610 ( 97%) 
Split 44      979 (97.9%)     12.6%        0.15   610 ( 97%) 
Split 45      981 (98.1%)     11.5%        0.14   620 ( 98%) 
Split 46      982 (98.2%)     11.3%        0.14   608 ( 96%) 
Split 47      979 (97.9%)     11.4%        0.15   605 ( 96%) 
Split 48      983 (98.3%)     10.7%        0.13   608 ( 96%) 
Split 49      982 (98.2%)     10.1%        0.14   576 ( 91%) 
Split 50      986 (98.6%)      9.7%        0.12   575 ( 91%) 
Split 51      988 (98.8%)      9.1%        0.11   576 ( 91%) 
Split 52      990 (99.0%)      8.4%        0.10   551 ( 87%) 
Resample      990 (99.0%)       NA%          NA   955 (151%) 

Sampling diagnostics for Mergesplit Steps of SMC run 4 of 5 (5,000
samples)
           Acc. rate MS Moves per Plan
MS Step 1      39.1%                53
MS Step 2      39.3%               159
MS Step 3      40.3%               159
MS Step 4      40.1%               159
MS Step 5      40.2%               159
MS Step 6      39.9%               159
MS Step 7      39.3%               159
MS Step 8      39.3%               159
MS Step 9      38.6%               159
MS Step 10     37.7%               159
MS Step 11     37.0%               159
MS Step 12     36.4%               159
MS Step 13     35.2%               159
MS Step 14     34.5%               159
MS Step 15     33.9%               159
MS Step 16     32.8%               159
MS Step 17     32.2%               212
MS Step 18     31.2%               212
MS Step 19     30.3%               212
MS Step 20     29.6%               212
MS Step 21     28.8%               212
MS Step 22     27.9%               212
MS Step 23     27.4%               212
MS Step 24     26.4%               212
MS Step 25     25.8%               212
MS Step 26     26.3%               212
MS Step 27     24.7%               212
MS Step 28     23.6%               265
MS Step 29     22.9%               265
MS Step 30     22.4%               265
MS Step 31     21.5%               265
MS Step 32     20.8%               265
MS Step 33     20.3%               265
MS Step 34     19.7%               265
MS Step 35     19.1%               318
MS Step 36     18.5%               318
MS Step 37     18.0%               318
MS Step 38     17.5%               318
MS Step 39     17.0%               318
MS Step 40     16.5%               318
MS Step 41     16.0%               371
MS Step 42     15.3%               371
MS Step 43     15.2%               371
MS Step 44     14.6%               371
MS Step 45     14.0%               371
MS Step 46     13.5%               424
MS Step 47     13.2%               424
MS Step 48     12.7%               424
MS Step 49     12.4%               424
MS Step 50     11.9%               477
MS Step 51     11.5%               477
MS Step 52     11.1%               477

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       241 (24.1%)    100.0%       1.180   614 ( 97%) 
Split 2       322 (32.2%)     96.1%       0.996   413 ( 65%) 
Split 3       476 (47.6%)     90.4%       0.892   467 ( 74%) 
Split 4       514 (51.4%)     86.3%       0.783   519 ( 82%) 
Split 5       628 (62.8%)     80.9%       0.716   525 ( 83%) 
Split 6       654 (65.4%)     74.9%       0.647   557 ( 88%) 
Split 7       702 (70.2%)     72.1%       0.570   561 ( 89%) 
Split 8       687 (68.7%)     69.6%       0.553   581 ( 92%) 
Split 9       781 (78.1%)     62.7%       0.510   557 ( 88%) 
Split 10      807 (80.7%)     61.2%       0.468   564 ( 89%) 
Split 11      816 (81.6%)     56.8%       0.449   601 ( 95%) 
Split 12      844 (84.4%)     53.5%       0.426   596 ( 94%) 
Split 13      858 (85.8%)     51.6%       0.401   592 ( 94%) 
Split 14      869 (86.9%)     48.1%       0.381   603 ( 95%) 
Split 15      899 (89.9%)     46.2%       0.341   596 ( 94%) 
Split 16      897 (89.7%)     42.8%       0.336   608 ( 96%) 
Split 17      907 (90.7%)     40.8%       0.311   619 ( 98%) 
Split 18      906 (90.6%)     38.7%       0.305   593 ( 94%) 
Split 19      924 (92.4%)     38.8%       0.289   618 ( 98%) 
Split 20      920 (92.0%)     35.5%       0.289   609 ( 96%) 
Split 21      928 (92.8%)     34.6%       0.278   602 ( 95%) 
Split 22      934 (93.4%)     33.0%       0.262   620 ( 98%) 
Split 23      928 (92.8%)     31.7%       0.271   626 ( 99%) 
Split 24      947 (94.7%)     29.3%       0.236   607 ( 96%) 
Split 25      943 (94.3%)     29.0%       0.241   626 ( 99%) 
Split 26      948 (94.8%)     25.9%       0.233   596 ( 94%) 
Split 27      953 (95.3%)     25.3%       0.220   611 ( 97%) 
Split 28      957 (95.7%)     23.7%       0.210   614 ( 97%) 
Split 29      958 (95.8%)     23.9%       0.210   601 ( 95%) 
Split 30      960 (96.0%)     22.5%       0.199   598 ( 95%) 
Split 31      959 (95.9%)     21.6%       0.205   622 ( 98%) 
Split 32      962 (96.2%)     20.1%       0.198   632 (100%) 
Split 33      965 (96.5%)     19.8%       0.191   616 ( 97%) 
Split 34      968 (96.8%)     18.7%       0.180   610 ( 97%) 
Split 35      962 (96.2%)     18.3%       0.193   612 ( 97%) 
Split 36      972 (97.2%)     17.5%       0.169   614 ( 97%) 
Split 37      972 (97.2%)     16.9%       0.169   618 ( 98%) 
Split 38      972 (97.2%)     16.1%       0.174   601 ( 95%) 
Split 39      972 (97.2%)     14.6%       0.170   622 ( 98%) 
Split 40      977 (97.7%)     14.2%       0.152   618 ( 98%) 
Split 41      977 (97.7%)     14.0%       0.152   611 ( 97%) 
Split 42      978 (97.8%)     13.6%       0.153   617 ( 98%) 
Split 43      976 (97.6%)     13.3%       0.158   610 ( 97%) 
Split 44      978 (97.8%)     12.1%       0.150   605 ( 96%) 
Split 45      979 (97.9%)     11.6%       0.147   622 ( 98%) 
Split 46      981 (98.1%)     11.8%       0.141   611 ( 97%) 
Split 47      980 (98.0%)     10.6%       0.146   597 ( 94%) 
Split 48      982 (98.2%)     10.8%       0.139   621 ( 98%) 
Split 49      985 (98.5%)      9.9%       0.128   600 ( 95%) 
Split 50      986 (98.6%)      9.8%       0.124   605 ( 96%) 
Split 51      990 (99.0%)      9.5%       0.101   598 ( 95%) 
Split 52      990 (99.0%)      9.1%       0.098   562 ( 89%) 
Resample      990 (99.0%)       NA%          NA   959 (152%) 

Sampling diagnostics for Mergesplit Steps of SMC run 5 of 5 (5,000
samples)
           Acc. rate MS Moves per Plan
MS Step 1      38.9%                53
MS Step 2      39.0%               159
MS Step 3      40.1%               159
MS Step 4      40.3%               159
MS Step 5      40.0%               159
MS Step 6      40.0%               159
MS Step 7      39.5%               159
MS Step 8      38.9%               159
MS Step 9      38.1%               159
MS Step 10     37.6%               159
MS Step 11     36.9%               159
MS Step 12     36.1%               159
MS Step 13     35.0%               159
MS Step 14     34.5%               159
MS Step 15     33.7%               159
MS Step 16     32.9%               159
MS Step 17     32.2%               212
MS Step 18     31.4%               212
MS Step 19     30.3%               212
MS Step 20     29.7%               212
MS Step 21     28.7%               212
MS Step 22     28.3%               212
MS Step 23     27.4%               212
MS Step 24     26.8%               212
MS Step 25     26.1%               212
MS Step 26     26.4%               212
MS Step 27     24.7%               212
MS Step 28     23.9%               265
MS Step 29     23.3%               265
MS Step 30     22.4%               265
MS Step 31     21.7%               265
MS Step 32     21.2%               265
MS Step 33     20.4%               265
MS Step 34     19.9%               265
MS Step 35     19.2%               318
MS Step 36     18.7%               318
MS Step 37     18.2%               318
MS Step 38     17.6%               318
MS Step 39     17.3%               318
MS Step 40     16.5%               318
MS Step 41     16.1%               371
MS Step 42     15.6%               371
MS Step 43     15.0%               371
MS Step 44     14.7%               371
MS Step 45     14.3%               371
MS Step 46     13.7%               371
MS Step 47     13.1%               424
MS Step 48     12.8%               424
MS Step 49     12.4%               424
MS Step 50     12.0%               477
MS Step 51     11.6%               477
MS Step 52     11.3%               477

•  Watch out for low effective samples, very low acceptance rates (less
than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
@philipwosull 