### PR TITLE
2020 Colorado State House/Senate Districts

### DIFF
--- a/analyses/CO_leg_2020/01_prep_CO_leg_2020.R
+++ b/analyses/CO_leg_2020/01_prep_CO_leg_2020.R
@@ -22,9 +22,6 @@ cli_process_start("Downloading files for {.pkg CO_leg_2020}")
 
 path_data <- download_redistricting_file("CO", "data-raw/CO", year = 2020)
 
-# TODO other files here (as necessary). All paths should start with `path_`
-# If large, consider checking to see if these files exist before downloading
-
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -45,10 +42,10 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_ssd <- make_from_baf("CO", "SLDU", "VTD", year = 2020)  |>
         transmute(GEOID = paste0(censable::match_fips("CO"), vtd),
-                  ssd_2010 = as.integer(sldu))
+            ssd_2010 = as.integer(sldu))
     d_shd <- make_from_baf("CO", "SLDL", "VTD", year = 2020)  |>
         transmute(GEOID = paste0(censable::match_fips("CO"), vtd),
-                  shd_2010 = as.integer(sldl))
+            shd_2010 = as.integer(sldl))
 
     co_shp <- co_shp |>
         left_join(d_muni, by = "GEOID") |>
@@ -62,26 +59,20 @@ if (!file.exists(here(shp_path))) {
     co_shp <- co_shp |>
         left_join(y = leg_from_baf(state = "CO"), by = "GEOID")
 
-
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = co_shp,
-                             perim_path = here(perim_path)) |>
+        perim_path = here(perim_path)) |>
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) |>
+            keep_shapes = TRUE) |>
             suppressWarnings()
     }
 
     # create adjacency graph
     co_shp$adj <- adjacency(co_shp)
-
-    # TODO any custom adjacency graph edits here
 
     # check max number of connected components
     # 1 is one fully connected component, more is worse
@@ -97,4 +88,3 @@ if (!file.exists(here(shp_path))) {
     co_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong CO} shapefile")
 }
-

--- a/analyses/CO_leg_2020/01_prep_CO_leg_2020.R
+++ b/analyses/CO_leg_2020/01_prep_CO_leg_2020.R
@@ -1,0 +1,100 @@
+###############################################################################
+# Download and prepare data for `CO_leg_2020` analysis
+# © ALARM Project, October 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CO_leg_2020}")
+
+path_data <- download_redistricting_file("CO", "data-raw/CO", year = 2020)
+
+# TODO other files here (as necessary). All paths should start with `path_`
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CO_2020/shp_vtd.rds"
+perim_path <- "data-out/CO_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CO} shapefile")
+    # read in redistricting data
+    co_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$CO)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("CO", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("CO"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("CO", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("CO"), vtd),
+                  ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("CO", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("CO"), vtd),
+                  shd_2010 = as.integer(sldl))
+
+    co_shp <- co_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    co_shp <- co_shp |>
+        left_join(y = leg_from_baf(state = "CO"), by = "GEOID")
+
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = co_shp,
+                             perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    co_shp$adj <- adjacency(co_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(co_shp$adj, co_shp$ssd_2020)
+    ccm(co_shp$adj, co_shp$shd_2020)
+
+    co_shp <- co_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(co_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    co_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CO} shapefile")
+}
+

--- a/analyses/CO_leg_2020/02_setup_CO_leg_2020.R
+++ b/analyses/CO_leg_2020/02_setup_CO_leg_2020.R
@@ -1,0 +1,35 @@
+###############################################################################
+# Set up redistricting simulation for `CO_leg_2020`
+# © ALARM Project, October 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CO_leg_2020}")
+
+# TODO any pre-computation (usually not necessary)
+
+map_ssd <- redist_map(co_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = co_shp$adj)
+
+map_shd <- redist_map(co_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = co_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "CO_SSD_2020"
+attr(map_shd, "analysis_name") <- "CO_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/CO_2020/CO_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/CO_2020/CO_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CO_leg_2020/02_setup_CO_leg_2020.R
+++ b/analyses/CO_leg_2020/02_setup_CO_leg_2020.R
@@ -4,24 +4,19 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg CO_leg_2020}")
 
-# TODO any pre-computation (usually not necessary)
-
 map_ssd <- redist_map(co_shp, pop_tol = 0.05,
     existing_plan = ssd_2020, adj = co_shp$adj)
 
 map_shd <- redist_map(co_shp, pop_tol = 0.05,
     existing_plan = shd_2020, adj = co_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_ssd)))
+        pop_muni = get_target(map_ssd)))
 map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_shd)))
+        pop_muni = get_target(map_shd)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
@@ -1,0 +1,76 @@
+###############################################################################
+# Simulate plans for `CO_shd_2020` SHD
+# © ALARM Project, October 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CO_shd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 40
+
+plans <- redist_smc(
+  map_shd,
+  nsims = 2e3, runs = 5,
+  counties = pseudo_county,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CO_2020/CO_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CO_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CO_2020/CO_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+    # Extra validation plots for custom constraints -----
+    # TODO remove this section if no custom constraints
+    plans <- plans %>% mutate(dvs_20 = group_frac(map_shd, adv_20, adv_20 + arv_20))
+    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+      lims(y = c(0.25, 0.9)) +
+      labs(title = "Competitiveness")
+}

--- a/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
@@ -6,34 +6,19 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CO_shd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2020)
 
-# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
 mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 40
 
 plans <- redist_smc(
-  map_shd,
-  nsims = 2e3, runs = 5,
-  counties = pseudo_county,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
+    map_shd,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
 )
-
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans |>
     group_by(chain) |>
@@ -43,8 +28,6 @@ plans <- match_numbers(plans, "shd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/CO_2020/CO_shd_2020_plans.rds"), compress = "xz")
@@ -68,9 +51,8 @@ if (interactive()) {
     summary(plans)
 
     # Extra validation plots for custom constraints -----
-    # TODO remove this section if no custom constraints
     plans <- plans %>% mutate(dvs_20 = group_frac(map_shd, adv_20, adv_20 + arv_20))
     redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
-      lims(y = c(0.25, 0.9)) +
-      labs(title = "Competitiveness")
+        lims(y = c(0.25, 0.9)) +
+        labs(title = "Competitiveness")
 }

--- a/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
@@ -8,16 +8,23 @@ cli_process_start("Running simulations for {.pkg CO_shd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 40
+constr <- redist_constr(map_shd) %>%
+    add_constr_total_plan_splits(strength = 1.4, admin = map_shd$county) %>%
+    add_constr_total_plan_splits(strength = 3, admin = map_shd$county_muni)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 630
 
 plans <- redist_smc(
     map_shd,
-    nsims = 2e3, runs = 5,
+    nsims = 3e3, runs = 5,
     counties = pseudo_county,
+    constraints = constr,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = TRUE
+    verbose = TRUE,
+    pop_temper = 0.04,
+    ncores = 0L
 )
 
 plans <- plans |>

--- a/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_shd_2020.R
@@ -10,13 +10,13 @@ set.seed(2020)
 
 constr <- redist_constr(map_shd) %>%
     add_constr_total_plan_splits(strength = 1.4, admin = map_shd$county) %>%
-    add_constr_total_plan_splits(strength = 3, admin = map_shd$county_muni)
+    add_constr_total_plan_splits(strength = 2.8, admin = map_shd$county_muni)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 630
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 850
 
 plans <- redist_smc(
     map_shd,
-    nsims = 3e3, runs = 5,
+    nsims = 4e3, runs = 5,
     counties = pseudo_county,
     constraints = constr,
     sampling_space = "linking_edge",

--- a/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
@@ -6,38 +6,19 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg CO_ssd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
-# Set up competitiveness targets ----
-#cons <- redist_constr(map_ssd) %>%
-#  add_constr_compet(300, ndv, nrv, pow = 1)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2020)
 
-# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 15
 
 plans <- redist_smc(
-  map_ssd,
-  nsims = 2e3, runs = 5,
-  counties = pseudo_county,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-#  constraints = cons,
-  verbose = TRUE
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
 )
-
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans |>
     group_by(chain) |>
@@ -47,8 +28,6 @@ plans <- match_numbers(plans, "ssd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/CO_2020/CO_ssd_2020_plans.rds"), compress = "xz")
@@ -74,7 +53,7 @@ if (interactive()) {
     # Extra validation plots for custom constraints -----
     plans <- plans %>% mutate(dvs_20 = group_frac(map_ssd, adv_20, adv_20 + arv_20))
     redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
-           lims(y = c(0.25, 0.9)) +
-           labs(title = "Competitiveness")
+        lims(y = c(0.25, 0.9)) +
+        labs(title = "Competitiveness")
 
 }

--- a/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
@@ -1,0 +1,80 @@
+###############################################################################
+# Simulate plans for `CO_ssd_2020` SSD
+# © ALARM Project, October 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CO_ssd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+# Set up competitiveness targets ----
+#cons <- redist_constr(map_ssd) %>%
+#  add_constr_compet(300, ndv, nrv, pow = 1)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 15
+
+plans <- redist_smc(
+  map_ssd,
+  nsims = 2e3, runs = 5,
+  counties = pseudo_county,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+#  constraints = cons,
+  verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CO_2020/CO_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CO_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CO_2020/CO_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    # Extra validation plots for custom constraints -----
+    plans <- plans %>% mutate(dvs_20 = group_frac(map_ssd, adv_20, adv_20 + arv_20))
+    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+           lims(y = c(0.25, 0.9)) +
+           labs(title = "Competitiveness")
+
+}

--- a/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
@@ -8,16 +8,22 @@ cli_process_start("Running simulations for {.pkg CO_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 15
+constr <- redist_constr(map_ssd) %>%
+    add_constr_total_plan_splits(strength = 2, admin = map_ssd$county) %>%
+    add_constr_total_plan_splits(strength = 1, admin = map_ssd$county_muni)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 50
 
 plans <- redist_smc(
     map_ssd,
     nsims = 2e3, runs = 5,
     counties = pseudo_county,
+    constraints = constr,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = TRUE
+    verbose = TRUE,
+    pop_temper = 0.03
 )
 
 plans <- plans |>

--- a/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
@@ -12,7 +12,7 @@ constr <- redist_constr(map_ssd) %>%
   add_constr_total_plan_splits(strength = 2.6, admin = map_ssd$county) %>%
   add_constr_total_plan_splits(strength = 1, admin = map_ssd$county_muni)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 170
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 300
 
 plans <- redist_smc(
     map_ssd,

--- a/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
+++ b/analyses/CO_leg_2020/03_sim_CO_ssd_2020.R
@@ -9,10 +9,10 @@ cli_process_start("Running simulations for {.pkg CO_ssd_2020}")
 set.seed(2020)
 
 constr <- redist_constr(map_ssd) %>%
-    add_constr_total_plan_splits(strength = 2, admin = map_ssd$county) %>%
-    add_constr_total_plan_splits(strength = 1, admin = map_ssd$county_muni)
+  add_constr_total_plan_splits(strength = 2.6, admin = map_ssd$county) %>%
+  add_constr_total_plan_splits(strength = 1, admin = map_ssd$county_muni)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 50
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 170
 
 plans <- redist_smc(
     map_ssd,

--- a/analyses/CO_leg_2020/doc_CO_leg_2020.md
+++ b/analyses/CO_leg_2020/doc_CO_leg_2020.md
@@ -1,0 +1,27 @@
+# 2020 Colorado State House/Senate Districts
+
+## Redistricting requirements
+In Colorado, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous (p. 184)
+1. have equal populations (p. 24)
+1. be geographically compact (p. 184)
+1. preserve county and municipality boundaries as much as possible (p. 184)
+1. preserve whole communities of interest (p. 184)
+1. maximize the number of politically competitive districts (p. 185)
+1. not be drawn protect incumbents (p. 185)
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Colorado comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample XX,XXX districting plans for Colorado's lower house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000 [TODO delete if only 10,000 total samples].
+No special techniques were needed to produce the sample.

--- a/analyses/CO_leg_2020/doc_CO_leg_2020.md
+++ b/analyses/CO_leg_2020/doc_CO_leg_2020.md
@@ -22,6 +22,5 @@ Data for Colorado comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample XX,XXX districting plans for Colorado's lower house across 5 independent runs of the SMC algorithm.
-We then thinned the number of samples to 10,000 [TODO delete if only 10,000 total samples].
+We sample 10,000 districting plans for Colorado's lower house across 5 independent runs of the SMC algorithm.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Colorado, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous (p. 184)
1. have equal populations (p. 24)
1. be geographically compact (p. 184)
1. preserve county and municipality boundaries as much as possible (p. 184)
1. preserve whole communities of interest (p. 184)
1. maximize the number of politically competitive districts (p. 185)
1. not be drawn protect incumbents (p. 185)


### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Colorado comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Colorado's lower house across 5 independent runs of the SMC algorithm.
Total county and municipality constraints are used to reduce the number of total county and municipality splits.
## Validation

**State Senate**

<img width="3000" height="5400" alt="validation_20260812_2040" src="https://github.com/user-attachments/assets/f9c3f023-87e3-4bcf-a413-4924ccffe016" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 35
                 districts on 3,108 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.03
Mergesplit Parameters:
• `total_ms_steps` = 34
• `mh_accept_per_smc` = 312
• `pair_rule` = uniform
Plan diversity 80% range: 0.63 to 0.76
23 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16 
              1.035               1.026               1.028               1.040 
             arv_18              arv_20      atg_18_dem_wei      atg_18_rep_bra 
              1.035               1.026               1.028               1.038 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.021               1.011               1.012               1.001 
              e_dem               e_dvs                egap      gov_18_dem_pol 
              1.014               1.047               1.015               1.026 
     gov_18_rep_sta         muni_splits             ndshare                 ndv 
              1.039               1.012               1.045               1.030 
                nrv               pbias            plan_dev            pop_aian 
              1.040               1.010               1.000               1.042 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.031               1.033               1.021               1.013 
          pop_other         pop_overlap             pop_two           pop_white 
              1.028               1.040               1.017               1.025 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.012               1.036               1.038               1.029 
     pre_20_rep_tru      sos_18_dem_gri      sos_18_rep_wil total_county_splits 
              1.027               1.027               1.025               1.014 
  total_muni_splits           total_vap      uss_16_dem_ben      uss_16_rep_gle 
              1.006               1.003               1.027               1.037 
     uss_20_dem_hic      uss_20_rep_gar            vap_aian           vap_asian 
              1.028               1.031               1.045               1.030 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.034               1.025               1.022               1.033 
            vap_two           vap_white 
              1.007               1.017 
• R-hat ≤ 1.05: 1867
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1867
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique    
Split 1         74 (3.7%)    100.0%        6.39 1,254 ( 99%)  * 
Split 2        120 (6.0%)     96.9%        6.28   229 ( 18%)    
Split 3        161 (8.1%)     92.9%        6.10   361 ( 29%)    
Split 4        152 (7.6%)     89.4%        5.87   394 ( 31%)    
Split 5       240 (12.0%)     87.9%        5.50   449 ( 36%)    
Split 6       263 (13.2%)     86.6%        5.37   516 ( 41%)    
Split 7       316 (15.8%)     83.3%        5.35   514 ( 41%)    
Split 8       350 (17.5%)     80.6%        5.16   588 ( 47%)    
Split 9       361 (18.0%)     81.7%        4.97   585 ( 46%)    
Split 10      345 (17.3%)     79.6%        4.77   628 ( 50%)    
Split 11      445 (22.2%)     75.7%        4.78   661 ( 52%)    
Split 12      466 (23.3%)     76.6%        4.46   647 ( 51%)    
Split 13      436 (21.8%)     75.4%        4.33   672 ( 53%)    
Split 14      530 (26.5%)     76.5%        4.06   643 ( 51%)    
Split 15      578 (28.9%)     75.3%        3.83   716 ( 57%)    
Split 16      660 (33.0%)     72.3%        3.54   755 ( 60%)    
Split 17      662 (33.1%)     72.9%        3.31   771 ( 61%)    
Split 18      698 (34.9%)     69.6%        3.04   779 ( 62%)    
Split 19      726 (36.3%)     68.1%        2.58   837 ( 66%)    
Split 20      863 (43.2%)     66.2%        2.38   870 ( 69%)    
Split 21      906 (45.3%)     66.2%        2.00   907 ( 72%)    
Split 22    1,003 (50.1%)     63.5%        1.80   913 ( 72%)    
Split 23    1,043 (52.1%)     60.2%        1.65   977 ( 77%)    
Split 24    1,102 (55.1%)     58.6%        1.43 1,001 ( 79%)    
Split 25    1,171 (58.6%)     57.2%        1.26 1,020 ( 81%)    
Split 26    1,198 (59.9%)     54.1%        1.21 1,033 ( 82%)    
Split 27    1,285 (64.3%)     53.2%        1.12 1,056 ( 84%)    
Split 28    1,298 (64.9%)     52.3%        1.04 1,074 ( 85%)    
Split 29    1,308 (65.4%)     48.4%        0.97 1,051 ( 83%)    
Split 30    1,306 (65.3%)     47.4%        0.97 1,064 ( 84%)    
Split 31    1,333 (66.6%)     45.2%        0.94 1,050 ( 83%)    
Split 32    1,411 (70.5%)     43.2%        0.86 1,088 ( 86%)    
Split 33    1,437 (71.9%)     39.0%        0.81 1,064 ( 84%)    
Split 34    1,529 (76.4%)     38.6%        0.68 1,019 ( 81%)    
Resample    1,529 (76.4%)       NA%          NA 1,549 (123%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1       5.9%               312
MS Step 2       8.5%              5616
MS Step 3      10.8%              3744
MS Step 4      12.1%              3120
MS Step 5      13.3%              2808
MS Step 6      13.8%              2496
MS Step 7      14.5%              2496
MS Step 8      15.4%              2184
MS Step 9      15.8%              2184
MS Step 10     16.6%              2184
MS Step 11     16.9%              2184
MS Step 12     17.3%              1872
MS Step 13     17.8%              1872
MS Step 14     18.4%              1872
MS Step 15     18.9%              1872
MS Step 16     19.5%              1872
MS Step 17     20.0%              1872
MS Step 18     20.6%              1872
MS Step 19     21.3%              1560
MS Step 20     22.0%              1560
MS Step 21     22.6%              1560
MS Step 22     23.3%              1560
MS Step 23     23.8%              1560
MS Step 24     24.2%              1560
MS Step 25     24.5%              1560
MS Step 26     24.8%              1560
MS Step 27     25.0%              1560
MS Step 28     25.2%              1248
MS Step 29     25.4%              1248
MS Step 30     25.5%              1248
MS Step 31     25.6%              1248
MS Step 32     25.6%              1248
MS Step 33     25.5%              1248
MS Step 34     26.3%              1248
```

**State House**

<img width="3000" height="5400" alt="validation_20260813_1714" src="https://github.com/user-attachments/assets/41a866da-a099-47e5-bbe8-1d4bb8cb9823" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 65
                 districts on 3,108 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.04
Mergesplit Parameters:
• `total_ms_steps` = 64
• `mh_accept_per_smc` = 872
• `pair_rule` = uniform
Plan diversity 80% range: 0.66 to 0.77
47 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16 
              1.018               1.022               1.018               1.009 
             arv_18              arv_20      atg_18_dem_wei      atg_18_rep_bra 
              1.008               1.011               1.022               1.008 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.011               1.003               1.014               1.004 
              e_dem               e_dvs                egap      gov_18_dem_pol 
              1.005               1.021               1.012               1.022 
     gov_18_rep_sta         muni_splits             ndshare                 ndv 
              1.009               1.011               1.020               1.021 
                nrv               pbias            plan_dev            pop_aian 
              1.008               1.014               1.000               1.022 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.022               1.012               1.012               1.012 
          pop_other         pop_overlap             pop_two           pop_white 
              1.014               1.005               1.009               1.012 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.008               1.025               1.009               1.017 
     pre_20_rep_tru      sos_18_dem_gri      sos_18_rep_wil total_county_splits 
              1.011               1.019               1.008               1.003 
  total_muni_splits           total_vap      uss_16_dem_ben      uss_16_rep_gle 
              1.003               1.003               1.015               1.009 
     uss_20_dem_hic      uss_20_rep_gar            vap_aian           vap_asian 
              1.019               1.011               1.023               1.017 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.018               1.016               1.014               1.013 
            vap_two           vap_white 
              1.011               1.013 
• R-hat ≤ 1.05: 3463
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3463
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique    
Split 1        118 (2.9%)    100.0%         8.3 2,557 (101%)  * 
Split 2        123 (3.1%)     97.6%         8.0   457 ( 18%)  * 
Split 3        180 (4.5%)     96.7%         7.7   517 ( 20%)  * 
Split 4        171 (4.3%)     93.9%         7.6   623 ( 25%)  * 
Split 5        308 (7.7%)     92.5%         7.2   704 ( 28%)    
Split 6        393 (9.8%)     90.7%         7.0   768 ( 30%)    
Split 7       462 (11.5%)     89.4%         6.7   852 ( 34%)    
Split 8       449 (11.2%)     88.2%         6.7   897 ( 35%)    
Split 9       515 (12.9%)     87.7%         6.4   915 ( 36%)    
Split 10      523 (13.1%)     87.2%         6.4   979 ( 39%)    
Split 11      556 (13.9%)     84.3%         6.2   993 ( 39%)    
Split 12      624 (15.6%)     84.1%         6.1 1,023 ( 40%)    
Split 13      645 (16.1%)     83.3%         5.9 1,080 ( 43%)    
Split 14      720 (18.0%)     81.3%         5.9 1,116 ( 44%)    
Split 15      684 (17.1%)     80.0%         5.6 1,161 ( 46%)    
Split 16      673 (16.8%)     79.9%         5.6 1,165 ( 46%)    
Split 17      879 (22.0%)     80.3%         5.3 1,162 ( 46%)    
Split 18      840 (21.0%)     78.0%         5.3 1,275 ( 50%)    
Split 19      967 (24.2%)     79.0%         5.1 1,279 ( 51%)    
Split 20    1,009 (25.2%)     76.4%         4.9 1,292 ( 51%)    
Split 21    1,050 (26.2%)     75.8%         4.6 1,373 ( 54%)    
Split 22    1,089 (27.2%)     77.3%         4.3 1,391 ( 55%)    
Split 23    1,185 (29.6%)     75.3%         4.3 1,444 ( 57%)    
Split 24    1,301 (32.5%)     73.9%         3.9 1,521 ( 60%)    
Split 25    1,294 (32.4%)     73.5%         3.7 1,543 ( 61%)    
Split 26    1,432 (35.8%)     72.5%         3.3 1,581 ( 63%)    
Split 27    1,480 (37.0%)     70.9%         3.1 1,667 ( 66%)    
Split 28    1,600 (40.0%)     70.5%         2.9 1,663 ( 66%)    
Split 29    1,730 (43.3%)     70.6%         2.7 1,750 ( 69%)    
Split 30    1,782 (44.5%)     68.7%         2.4 1,819 ( 72%)    
Split 31    1,905 (47.6%)     69.0%         2.3 1,822 ( 72%)    
Split 32    1,975 (49.4%)     67.4%         2.1 1,882 ( 74%)    
Split 33    1,991 (49.8%)     66.7%         2.1 1,918 ( 76%)    
Split 34    2,020 (50.5%)     66.3%         2.0 1,923 ( 76%)    
Split 35    2,139 (53.5%)     64.5%         1.9 1,964 ( 78%)    
Split 36    2,145 (53.6%)     62.5%         1.8 1,975 ( 78%)    
Split 37    2,195 (54.9%)     63.0%         1.7 1,962 ( 78%)    
Split 38    2,233 (55.8%)     61.3%         1.7 1,997 ( 79%)    
Split 39    2,269 (56.7%)     60.5%         1.6 2,046 ( 81%)    
Split 40    2,289 (57.2%)     58.7%         1.6 2,038 ( 81%)    
Split 41    2,338 (58.4%)     57.4%         1.6 2,024 ( 80%)    
Split 42    2,319 (58.0%)     56.3%         1.6 2,053 ( 81%)    
Split 43    2,411 (60.3%)     54.8%         1.5 2,074 ( 82%)    
Split 44    2,397 (59.9%)     54.2%         1.5 2,110 ( 83%)    
Split 45    2,410 (60.2%)     52.0%         1.5 2,064 ( 82%)    
Split 46    2,412 (60.3%)     50.6%         1.5 2,107 ( 83%)    
Split 47    2,387 (59.7%)     51.1%         1.4 2,078 ( 82%)    
Split 48    2,471 (61.8%)     49.1%         1.4 2,102 ( 83%)    
Split 49    2,473 (61.8%)     48.3%         1.5 2,116 ( 84%)    
Split 50    2,484 (62.1%)     46.2%         1.4 2,096 ( 83%)    
Split 51    2,483 (62.1%)     44.9%         1.4 2,122 ( 84%)    
Split 52    2,486 (62.2%)     45.3%         1.4 2,104 ( 83%)    
Split 53    2,463 (61.6%)     43.2%         1.4 2,074 ( 82%)    
Split 54    2,418 (60.4%)     41.4%         1.4 2,081 ( 82%)    
Split 55    2,463 (61.6%)     40.4%         1.4 2,095 ( 83%)    
Split 56    2,417 (60.4%)     39.7%         1.4 2,102 ( 83%)    
Split 57    2,451 (61.3%)     39.7%         1.4 2,095 ( 83%)    
Split 58    2,381 (59.5%)     38.5%         1.4 2,065 ( 82%)    
Split 59    2,342 (58.6%)     36.0%         1.4 2,077 ( 82%)    
Split 60    2,311 (57.8%)     36.0%         1.5 2,061 ( 82%)    
Split 61    2,261 (56.5%)     35.5%         1.5 2,039 ( 81%)    
Split 62    2,251 (56.3%)     34.6%         1.6 2,032 ( 80%)    
Split 63    2,223 (55.6%)     33.8%         1.5 1,997 ( 79%)    
Split 64    2,325 (58.1%)     33.0%         1.5 1,921 ( 76%)    
Resample    2,325 (58.1%)       NA%          NA 2,568 (102%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1       3.8%               872
MS Step 2       6.0%             23544
MS Step 3       7.8%             14824
MS Step 4       9.0%             11336
MS Step 5       9.8%             10464
MS Step 6      10.6%              9592
MS Step 7      11.2%              8720
MS Step 8      11.6%              7848
MS Step 9      12.3%              7848
MS Step 10     12.8%              7848
MS Step 11     13.2%              6976
MS Step 12     13.7%              6976
MS Step 13     14.2%              6976
MS Step 14     14.5%              6976
MS Step 15     15.1%              6104
MS Step 16     15.5%              6104
MS Step 17     16.0%              6104
MS Step 18     16.3%              6104
MS Step 19     16.7%              6104
MS Step 20     17.2%              5232
MS Step 21     17.6%              5232
MS Step 22     18.2%              5232
MS Step 23     18.5%              5232
MS Step 24     19.0%              5232
MS Step 25     19.5%              5232
MS Step 26     20.0%              5232
MS Step 27     20.3%              5232
MS Step 28     20.9%              4360
MS Step 29     21.3%              4360
MS Step 30     21.8%              4360
MS Step 31     22.2%              4360
MS Step 32     22.6%              4360
MS Step 33     23.0%              4360
MS Step 34     23.4%              4360
MS Step 35     23.6%              4360
MS Step 36     24.0%              4360
MS Step 37     24.2%              4360
MS Step 38     24.4%              4360
MS Step 39     24.7%              4360
MS Step 40     24.9%              4360
MS Step 41     25.1%              4360
MS Step 42     25.4%              3488
MS Step 43     25.6%              3488
MS Step 44     25.7%              3488
MS Step 45     25.9%              3488
MS Step 46     26.0%              3488
MS Step 47     26.1%              3488
MS Step 48     26.1%              3488
MS Step 49     26.3%              3488
MS Step 50     26.4%              3488
MS Step 51     26.6%              3488
MS Step 52     26.5%              3488
MS Step 53     26.5%              3488
MS Step 54     26.6%              3488
MS Step 55     26.6%              3488
MS Step 56     26.7%              3488
MS Step 57     26.6%              3488
MS Step 58     26.6%              3488
MS Step 59     26.6%              3488
MS Step 60     26.6%              3488
MS Step 61     26.6%              3488
MS Step 62     26.6%              3488
MS Step 63     26.6%              3488
MS Step 64     29.3%              3488
```
## Additional Notes

**Competitiveness Requirement - State Senate**

<img width="1626" height="948" alt="compet_ssd_new" src="https://github.com/user-attachments/assets/30bb86bb-43fd-4635-bcc4-0c8e9de5969b" />

**Competitiveness Requirement - State House**

<img width="1288" height="940" alt="compet_shd_new" src="https://github.com/user-attachments/assets/a22f26e8-c8fa-4881-bd36-fb378775bd76" />

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited



