### PR TITLE
utils.R Update for the cd_1990 Analysis

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -80,7 +80,7 @@ join_vtd_shapefile <- function(data, year = 2020) {
     counties <- censable::fips_2010 |>
       dplyr::filter(state == state_fp) |>
       dplyr::pull(county)
-  
+
     files <- lapply(
       counties,
       function(cty) {
@@ -216,7 +216,7 @@ vest_crosswalk <- function(cvap, state) {
   cw <- pl_crosswalk(toupper(state))
   vest_cw <- left_join(vest_cw, select(cw, -int_land), by = c("GEOID", "GEOID_to"))
   rt <- pl_retally(cvap, crosswalk = vest_cw)
-  
+
   baf <- pl_get_baf(toupper(state), "VTD") |>
     purrr::pluck(1) |>
     rename(GEOID = BLOCKID) |>
@@ -224,7 +224,7 @@ vest_crosswalk <- function(cvap, state) {
       STATEFP = censable::match_fips(state),
       GEOID20 = paste0(STATEFP, COUNTYFP, DISTRICT)
     )
-  
+
   rt <- rt |> left_join(baf, by = "GEOID")
 
   # agg


### PR DESCRIPTION
@christopherkenny This PR tries to update the two functions below to enable the 1990 analysis.
Please feel free to edit the PR or reply to my questions below so that we can complete the preparation.

`download_redistricting_file()`
**Assumption**: `{abbr}_1990.csv` files are stored in the `road-1990` folder under `census-2020`.
**Request**: Could you please save the CSV files there?

`join_vtd_shapefile()`
**Assumption**: `{abbr}_1990.csv` files are identical to the `{abbr}_2000.csv` files, except that the former include the `cd_1980` variable.
**Question**: Instead of tinytiger::tt_voting_districts, which function should we use? Once we decide, I can update the code accordingly.