### PR TITLE
2020 Virginia State House/Senate Districts

### DIFF
--- a/analyses/VA_leg_2020/01_prep_VA_leg_2020.R
+++ b/analyses/VA_leg_2020/01_prep_VA_leg_2020.R
@@ -1,0 +1,97 @@
+###############################################################################
+# Download and prepare data for `VA_leg_2020` analysis
+# © ALARM Project, November 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg VA_leg_2020}")
+
+path_data <- download_redistricting_file("VA", "data-raw/VA", year = 2020)
+
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/VA_2020/shp_vtd.rds"
+perim_path <- "data-out/VA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong VA} shapefile")
+    # read in redistricting data
+    va_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$VA)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("VA", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("VA"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("VA", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("VA"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("VA", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("VA"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    va_shp <- va_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    va_shp <- va_shp |>
+        left_join(y = leg_from_baf(state = "VA"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = va_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        va_shp <- rmapshaper::ms_simplify(va_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    va_shp$adj <- adjacency(va_shp)
+
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(va_shp$adj, va_shp$ssd_2020)
+    ccm(va_shp$adj, va_shp$shd_2020)
+
+    va_shp <- va_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(va_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    va_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong VA} shapefile")
+}
+
+# visualize the enacted maps using:
+redistio::draw(va_shp, va_shp$ssd_2020)
+redistio::draw(va_shp, va_shp$shd_2020)

--- a/analyses/VA_leg_2020/02_setup_VA_leg_2020.R
+++ b/analyses/VA_leg_2020/02_setup_VA_leg_2020.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `VA_leg_2020`
+# © ALARM Project, November 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg VA_leg_2020}")
+
+map_ssd <- redist_map(va_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = va_shp$adj)
+
+map_shd <- redist_map(va_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = va_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "VA_SSD_2020"
+attr(map_shd, "analysis_name") <- "VA_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/VA_2020/VA_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/VA_2020/VA_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/VA_leg_2020/03_sim_VA_shd_2020.R
+++ b/analyses/VA_leg_2020/03_sim_VA_shd_2020.R
@@ -1,0 +1,55 @@
+###############################################################################
+# Simulate plans for `VA_shd_2020` SHD
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg VA_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 20
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 3e3, runs = 5,             # increase sample size from 2000 to 3000
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/VA_2020/VA_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg VA_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/VA_2020/VA_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/VA_leg_2020/03_sim_VA_ssd_2020.R
+++ b/analyses/VA_leg_2020/03_sim_VA_ssd_2020.R
@@ -1,0 +1,55 @@
+###############################################################################
+# Simulate plans for `VA_ssd_2020` SSD
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg VA_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/VA_2020/VA_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg VA_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/VA_2020/VA_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/VA_leg_2020/03_sim_VA_ssd_2020.R
+++ b/analyses/VA_leg_2020/03_sim_VA_ssd_2020.R
@@ -8,11 +8,11 @@ cli_process_start("Running simulations for {.pkg VA_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3)
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
 
 plans <- redist_smc(
     map_ssd,
-    nsims = 2e3, runs = 5,
+    nsims = 3e3, runs = 5,                     # increase sample size from 2000 to 3000
     counties = pseudo_county,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),

--- a/analyses/VA_leg_2020/doc_VA_leg_2020.md
+++ b/analyses/VA_leg_2020/doc_VA_leg_2020.md
@@ -1,0 +1,27 @@
+# 2020 Virginia State House/Senate Districts
+
+## Redistricting requirements
+In Virginia, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. Be contiguous [NCSL, 186]
+2. have equal populations [NCSL, 23]
+3. Be geographically compact [NCSL, 186]
+4. While the preservation of county and municipal boundaries is often considered a traditional practice, it is not a statutory requirement in Virginia [NCSL, 186]
+5. Preserve communities of interest [NCSL, 186]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 15,000 districting plans for Virginia's lower house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+No special techniques were needed to produce the sample.
+
+We sample 10,000 districting plans for Virginia's upper house across 5 independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.

--- a/analyses/VA_leg_2020/doc_VA_leg_2020.md
+++ b/analyses/VA_leg_2020/doc_VA_leg_2020.md
@@ -23,5 +23,6 @@ We sample 15,000 districting plans for Virginia's lower house across 5 independe
 We then thinned the number of samples to 10,000.
 No special techniques were needed to produce the sample.
 
-We sample 10,000 districting plans for Virginia's upper house across 5 independent runs of the SMC algorithm.
+We sample 15,000 districting plans for Virginia's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 2020 Virginia State House/Senate Districts

## Redistricting requirements
In Virginia, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. Be contiguous [NCSL, 186]
2. Have equal populations [NCSL, 23]
3. Be geographically compact [NCSL, 186]
4. While the preservation of county and municipal boundaries is often considered a traditional practice, it is not a statutory requirement in Virginia [NCSL, 186]
5. Preserve communities of interest [NCSL, 186]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 15,000 districting plans for Virginia's lower house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
No special techniques were needed to produce the sample.

We sample 10,000 districting plans for Virginia's upper house across 5 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
## SHD

**<img width="3000" height="5400" alt="validation_20260111_0950" src="https://github.com/user-attachments/assets/839c46e6-80b1-476b-bd74-efbfbe3b6d4f" />**

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 100 districts on 2,465 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 99
• `mh_accept_per_smc` = 54
• `pair_rule` = uniform
Plan diversity 80% range: 0.77 to 0.85
76 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20      comp_edge    comp_polsby  county_splits          e_dem 
         1.013          1.014          1.017          1.021          1.018          1.018          1.005          1.011          1.003          1.008 
         e_dvs           egap    muni_splits        ndshare            ndv            nrv          pbias       plan_dev       pop_aian      pop_asian 
         1.018          1.007          1.006          1.018          1.018          1.014          1.014          1.000          1.027          1.026 
     pop_black       pop_hisp       pop_nhpi      pop_other    pop_overlap        pop_two      pop_white         pr_dem pre_16_dem_cli pre_16_rep_tru 
         1.013          1.030          1.023          1.021          1.006          1.012          1.014          1.006          1.013          1.021 
pre_20_dem_bid pre_20_rep_tru      total_vap uss_18_dem_kai uss_18_rep_ste uss_20_dem_war uss_20_rep_gad       vap_aian      vap_asian      vap_black 
         1.018          1.017          1.011          1.014          1.018          1.018          1.018          1.025          1.020          1.013 
      vap_hisp       vap_nhpi      vap_other        vap_two      vap_white 
         1.025          1.018          1.016          1.007          1.015 
• R-hat ≤ 1.05: 4424
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 4424
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1     1,418 (47.3%)    100.0%        1.30 1,861 ( 98%) 
Split 2     1,577 (52.6%)     99.3%        1.29 1,480 ( 78%) 
Split 3     1,609 (53.6%)     98.7%        1.21 1,525 ( 80%) 
Split 4     1,686 (56.2%)     97.5%        1.10 1,534 ( 81%) 
Split 5     1,783 (59.4%)     97.2%        1.03 1,543 ( 81%) 
Split 6     1,877 (62.6%)     95.7%        0.93 1,607 ( 85%) 
Split 7     1,931 (64.4%)     94.8%        0.88 1,638 ( 86%) 
Split 8     2,002 (66.7%)     92.4%        0.85 1,631 ( 86%) 
Split 9     2,074 (69.1%)     92.7%        0.79 1,684 ( 89%) 
Split 10    2,145 (71.5%)     90.5%        0.75 1,663 ( 88%) 
Split 11    2,127 (70.9%)     90.2%        0.74 1,704 ( 90%) 
Split 12    2,221 (74.0%)     89.6%        0.69 1,689 ( 89%) 
Split 13    2,219 (74.0%)     88.2%        0.68 1,716 ( 90%) 
Split 14    2,314 (77.1%)     86.5%        0.64 1,749 ( 92%) 
Split 15    2,322 (77.4%)     86.3%        0.63 1,736 ( 92%) 
Split 16    2,359 (78.6%)     84.3%        0.60 1,716 ( 90%) 
Split 17    2,351 (78.4%)     82.6%        0.58 1,765 ( 93%) 
Split 18    2,403 (80.1%)     82.6%        0.56 1,774 ( 94%) 
Split 19    2,457 (81.9%)     80.8%        0.53 1,786 ( 94%) 
Split 20    2,444 (81.5%)     80.4%        0.53 1,807 ( 95%) 
Split 21    2,499 (83.3%)     77.9%        0.50 1,756 ( 93%) 
Split 22    2,514 (83.8%)     77.6%        0.48 1,793 ( 95%) 
Split 23    2,526 (84.2%)     76.8%        0.48 1,832 ( 97%) 
Split 24    2,557 (85.2%)     76.0%        0.46 1,777 ( 94%) 
Split 25    2,565 (85.5%)     74.7%        0.45 1,794 ( 95%) 
Split 26    2,580 (86.0%)     74.0%        0.43 1,786 ( 94%) 
Split 27    2,592 (86.4%)     73.2%        0.42 1,787 ( 94%) 
Split 28    2,614 (87.1%)     70.9%        0.42 1,824 ( 96%) 
Split 29    2,609 (87.0%)     70.1%        0.41 1,841 ( 97%) 
Split 30    2,642 (88.1%)     69.0%        0.39 1,831 ( 97%) 
Split 31    2,650 (88.3%)     68.3%        0.38 1,823 ( 96%) 
Split 32    2,664 (88.8%)     67.6%        0.38 1,804 ( 95%) 
Split 33    2,654 (88.5%)     67.3%        0.38 1,813 ( 96%) 
Split 34    2,673 (89.1%)     65.0%        0.37 1,841 ( 97%) 
Split 35    2,695 (89.8%)     65.1%        0.36 1,828 ( 96%) 
Split 36    2,710 (90.3%)     63.5%        0.35 1,864 ( 98%) 
Split 37    2,712 (90.4%)     62.8%        0.34 1,817 ( 96%) 
Split 38    2,718 (90.6%)     61.3%        0.34 1,843 ( 97%) 
Split 39    2,732 (91.1%)     60.3%        0.33 1,837 ( 97%) 
Split 40    2,726 (90.9%)     60.7%        0.34 1,841 ( 97%) 
Split 41    2,753 (91.8%)     59.0%        0.31 1,868 ( 99%) 
Split 42    2,763 (92.1%)     56.9%        0.31 1,867 ( 98%) 
Split 43    2,753 (91.8%)     57.3%        0.31 1,827 ( 96%) 
Split 44    2,765 (92.2%)     56.9%        0.30 1,861 ( 98%) 
Split 45    2,771 (92.4%)     56.1%        0.30 1,838 ( 97%) 
Split 46    2,790 (93.0%)     56.1%        0.28 1,842 ( 97%) 
Split 47    2,798 (93.3%)     55.4%        0.28 1,816 ( 96%) 
Split 48    2,807 (93.6%)     53.0%        0.27 1,851 ( 98%) 
Split 49    2,817 (93.9%)     52.7%        0.27 1,874 ( 99%) 
Split 50    2,809 (93.6%)     51.7%        0.27 1,851 ( 98%) 
Split 51    2,830 (94.3%)     51.7%        0.26 1,851 ( 98%) 
Split 52    2,827 (94.2%)     50.9%        0.26 1,844 ( 97%) 
Split 53    2,830 (94.3%)     50.2%        0.25 1,833 ( 97%) 
Split 54    2,836 (94.5%)     48.1%        0.25 1,879 ( 99%) 
Split 55    2,836 (94.5%)     48.3%        0.25 1,866 ( 98%) 
Split 56    2,846 (94.9%)     48.2%        0.24 1,853 ( 98%) 
Split 57    2,850 (95.0%)     46.4%        0.24 1,879 ( 99%) 
Split 58    2,853 (95.1%)     45.8%        0.23 1,888 (100%) 
Split 59    2,853 (95.1%)     45.1%        0.24 1,839 ( 97%) 
Split 60    2,866 (95.5%)     45.0%        0.22 1,869 ( 99%) 
Split 61    2,864 (95.5%)     45.1%        0.22 1,915 (101%) 
Split 62    2,879 (96.0%)     44.3%        0.21 1,874 ( 99%) 
Split 63    2,871 (95.7%)     42.7%        0.22 1,852 ( 98%) 
Split 64    2,878 (95.9%)     43.3%        0.21 1,833 ( 97%) 
Split 65    2,883 (96.1%)     42.1%        0.21 1,871 ( 99%) 
Split 66    2,882 (96.1%)     41.3%        0.21 1,840 ( 97%) 
Split 67    2,888 (96.3%)     41.1%        0.20 1,868 ( 99%) 
Split 68    2,887 (96.2%)     39.8%        0.20 1,835 ( 97%) 
Split 69    2,892 (96.4%)     39.2%        0.20 1,838 ( 97%) 
Split 70    2,896 (96.5%)     39.9%        0.20 1,843 ( 97%) 
Split 71    2,897 (96.6%)     38.9%        0.20 1,863 ( 98%) 
Split 72    2,900 (96.7%)     37.1%        0.19 1,865 ( 98%) 
Split 73    2,900 (96.7%)     36.8%        0.19 1,824 ( 96%) 
Split 74    2,907 (96.9%)     37.5%        0.18 1,873 ( 99%) 
Split 75    2,909 (97.0%)     36.3%        0.18 1,856 ( 98%) 
Split 76    2,912 (97.1%)     35.9%        0.18 1,892 (100%) 
Split 77    2,910 (97.0%)     34.9%        0.18 1,847 ( 97%) 
Split 78    2,921 (97.4%)     35.4%        0.17 1,859 ( 98%) 
Split 79    2,923 (97.4%)     34.9%        0.17 1,888 (100%) 
Split 80    2,921 (97.4%)     33.7%        0.17 1,875 ( 99%) 
Split 81    2,926 (97.5%)     33.6%        0.16 1,854 ( 98%) 
Split 82    2,927 (97.6%)     33.4%        0.16 1,870 ( 99%) 
Split 83    2,925 (97.5%)     32.6%        0.16 1,856 ( 98%) 
Split 84    2,925 (97.5%)     31.3%        0.17 1,880 ( 99%) 
Split 85    2,929 (97.6%)     31.0%        0.16 1,826 ( 96%) 
Split 86    2,931 (97.7%)     31.2%        0.16 1,842 ( 97%) 
Split 87    2,932 (97.7%)     30.6%        0.16 1,862 ( 98%) 
Split 88    2,931 (97.7%)     30.1%        0.16 1,878 ( 99%) 
Split 89    2,933 (97.8%)     30.0%        0.16 1,875 ( 99%) 
Split 90    2,936 (97.9%)     28.7%        0.15 1,838 ( 97%) 
Split 91    2,942 (98.1%)     29.2%        0.14 1,845 ( 97%) 
Split 92    2,942 (98.1%)     27.4%        0.14 1,838 ( 97%) 
Split 93    2,941 (98.0%)     28.2%        0.14 1,832 ( 97%) 
Split 94    2,944 (98.1%)     27.4%        0.14 1,832 ( 97%) 
Split 95    2,947 (98.2%)     27.0%        0.14 1,817 ( 96%) 
Split 96    2,949 (98.3%)     26.8%        0.14 1,806 ( 95%) 
Split 97    2,952 (98.4%)     26.4%        0.13 1,807 ( 95%) 
Split 98    2,959 (98.6%)     25.3%        0.12 1,736 ( 92%) 
Split 99    2,962 (98.7%)     24.8%        0.12 1,581 ( 83%) 
Resample    2,962 (98.7%)       NA%          NA 2,851 (150%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      48.4%                54
MS Step 2      47.6%               162
MS Step 3      47.7%               162
MS Step 4      47.5%               162
MS Step 5      47.5%               162
MS Step 6      47.5%               162
MS Step 7      47.3%               162
MS Step 8      47.4%               162
MS Step 9      47.2%               162
MS Step 10     47.0%               162
MS Step 11     46.9%               162
MS Step 12     46.9%               162
MS Step 13     46.7%               162
MS Step 14     46.5%               162
MS Step 15     46.5%               162
MS Step 16     46.5%               162
MS Step 17     46.0%               162
MS Step 18     45.9%               162
MS Step 19     45.6%               162
MS Step 20     45.4%               162
MS Step 21     45.3%               162
MS Step 22     45.1%               162
MS Step 23     45.0%               162
MS Step 24     44.8%               162
MS Step 25     44.4%               162
MS Step 26     44.4%               162
MS Step 27     44.3%               162
MS Step 28     44.0%               162
MS Step 29     43.8%               162
MS Step 30     43.7%               162
MS Step 31     43.4%               162
MS Step 32     43.1%               162
MS Step 33     42.9%               162
MS Step 34     42.6%               162
MS Step 35     42.4%               162
MS Step 36     42.3%               162
MS Step 37     42.0%               162
MS Step 38     41.7%               162
MS Step 39     41.5%               162
MS Step 40     41.3%               162
MS Step 41     41.0%               162
MS Step 42     40.9%               162
MS Step 43     40.7%               162
MS Step 44     40.3%               162
MS Step 45     40.1%               162
MS Step 46     39.9%               162
MS Step 47     39.9%               162
MS Step 48     39.5%               162
MS Step 49     39.3%               162
MS Step 50     39.1%               162
MS Step 51     38.9%               162
MS Step 52     38.7%               162
MS Step 53     38.5%               162
MS Step 54     38.3%               162
MS Step 55     38.1%               162
MS Step 56     37.7%               162
MS Step 57     37.7%               162
MS Step 58     37.5%               162
MS Step 59     37.2%               162
MS Step 60     37.1%               162
MS Step 61     36.8%               162
MS Step 62     36.5%               162
MS Step 63     36.4%               162
MS Step 64     36.1%               162
MS Step 65     36.0%               162
MS Step 66     35.8%               162
MS Step 67     35.6%               162
MS Step 68     35.4%               162
MS Step 69     35.2%               162
MS Step 70     34.9%               162
MS Step 71     34.7%               162
MS Step 72     34.5%               162
MS Step 73     34.3%               162
MS Step 74     34.1%               162
MS Step 75     33.8%               162
MS Step 76     33.7%               162
MS Step 77     33.5%               162
MS Step 78     33.2%               162
MS Step 79     33.0%               216
MS Step 80     32.8%               216
MS Step 81     32.7%               216
MS Step 82     32.6%               216
MS Step 83     32.5%               216
MS Step 84     32.2%               216
MS Step 85     32.1%               216
MS Step 86     31.8%               216
MS Step 87     31.6%               216
MS Step 88     31.5%               216
MS Step 89     31.3%               216
MS Step 90     31.1%               216
MS Step 91     30.9%               216
MS Step 92     30.7%               216
MS Step 93     30.5%               216
MS Step 94     30.3%               216
MS Step 95     30.2%               216
MS Step 96     29.9%               216
MS Step 97     29.7%               216
MS Step 98     29.5%               216
MS Step 99     29.4%               216

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```
## SSD

**<img width="3000" height="5400" alt="validation_20260111_0951" src="https://github.com/user-attachments/assets/97c71b54-bc11-4ac0-8de2-f1d97cb44f7a" />**

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 40 districts on 2,465 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 39
• `mh_accept_per_smc` = 34
• `pair_rule` = uniform
Plan diversity 80% range: 0.73 to 0.85
27 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20      comp_edge    comp_polsby  county_splits          e_dem 
         1.005          1.004          1.006          1.004          1.006          1.005          1.003          1.003          1.002          1.005 
         e_dvs           egap    muni_splits        ndshare            ndv            nrv          pbias       plan_dev       pop_aian      pop_asian 
         1.007          1.005          1.002          1.006          1.006          1.005          1.001          1.000          1.004          1.007 
     pop_black       pop_hisp       pop_nhpi      pop_other    pop_overlap        pop_two      pop_white         pr_dem pre_16_dem_cli pre_16_rep_tru 
         1.003          1.004          1.004          1.006          1.003          1.004          1.003          1.003          1.005          1.004 
pre_20_dem_bid pre_20_rep_tru      total_vap uss_18_dem_kai uss_18_rep_ste uss_20_dem_war uss_20_rep_gad       vap_aian      vap_asian      vap_black 
         1.006          1.005          1.002          1.004          1.006          1.005          1.004          1.005          1.007          1.004 
      vap_hisp       vap_nhpi      vap_other        vap_two      vap_white 
         1.003          1.004          1.003          1.003          1.004 
• R-hat ≤ 1.05: 1773
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1773
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1     1,391 (46.4%)    100.0%        1.28 1,919 (101%) 
Split 2     1,545 (51.5%)     98.1%        1.28 1,420 ( 75%) 
Split 3     1,663 (55.4%)     96.5%        1.17 1,517 ( 80%) 
Split 4     1,739 (58.0%)     94.5%        1.07 1,539 ( 81%) 
Split 5     1,797 (59.9%)     92.3%        1.03 1,566 ( 83%) 
Split 6     1,875 (62.5%)     90.4%        0.95 1,631 ( 86%) 
Split 7     1,947 (64.9%)     88.0%        0.91 1,608 ( 85%) 
Split 8     2,041 (68.0%)     84.6%        0.84 1,648 ( 87%) 
Split 9     2,105 (70.2%)     82.5%        0.78 1,643 ( 87%) 
Split 10    2,118 (70.6%)     80.1%        0.74 1,685 ( 89%) 
Split 11    2,183 (72.8%)     79.1%        0.72 1,701 ( 90%) 
Split 12    2,199 (73.3%)     75.5%        0.66 1,696 ( 89%) 
Split 13    2,279 (76.0%)     74.3%        0.65 1,709 ( 90%) 
Split 14    2,268 (75.6%)     71.4%        0.63 1,726 ( 91%) 
Split 15    2,327 (77.6%)     69.5%        0.60 1,757 ( 93%) 
Split 16    2,363 (78.8%)     67.2%        0.58 1,712 ( 90%) 
Split 17    2,413 (80.4%)     66.4%        0.54 1,756 ( 93%) 
Split 18    2,416 (80.5%)     63.1%        0.54 1,753 ( 92%) 
Split 19    2,444 (81.5%)     61.8%        0.53 1,759 ( 93%) 
Split 20    2,439 (81.3%)     59.9%        0.51 1,778 ( 94%) 
Split 21    2,511 (83.7%)     57.1%        0.48 1,770 ( 93%) 
Split 22    2,528 (84.3%)     56.3%        0.46 1,804 ( 95%) 
Split 23    2,549 (85.0%)     54.8%        0.45 1,745 ( 92%) 
Split 24    2,582 (86.1%)     53.1%        0.43 1,803 ( 95%) 
Split 25    2,584 (86.1%)     51.4%        0.43 1,784 ( 94%) 
Split 26    2,593 (86.4%)     49.0%        0.42 1,794 ( 95%) 
Split 27    2,618 (87.3%)     48.1%        0.40 1,803 ( 95%) 
Split 28    2,645 (88.2%)     47.4%        0.38 1,803 ( 95%) 
Split 29    2,657 (88.6%)     45.0%        0.38 1,816 ( 96%) 
Split 30    2,685 (89.5%)     43.7%        0.36 1,811 ( 95%) 
Split 31    2,677 (89.2%)     42.6%        0.36 1,831 ( 97%) 
Split 32    2,699 (90.0%)     41.5%        0.35 1,789 ( 94%) 
Split 33    2,724 (90.8%)     40.6%        0.33 1,753 ( 92%) 
Split 34    2,727 (90.9%)     37.6%        0.33 1,787 ( 94%) 
Split 35    2,744 (91.5%)     37.1%        0.32 1,802 ( 95%) 
Split 36    2,769 (92.3%)     35.9%        0.30 1,739 ( 92%) 
Split 37    2,792 (93.1%)     34.7%        0.29 1,758 ( 93%) 
Split 38    2,820 (94.0%)     33.8%        0.27 1,760 ( 93%) 
Split 39    2,835 (94.5%)     33.2%        0.26 1,663 ( 88%) 
Resample    2,835 (94.5%)       NA%          NA 2,689 (142%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      49.5%                34
MS Step 2      48.1%               102
MS Step 3      48.0%               102
MS Step 4      47.6%               102
MS Step 5      46.9%               102
MS Step 6      46.3%               102
MS Step 7      46.0%               102
MS Step 8      45.4%               102
MS Step 9      44.9%               102
MS Step 10     44.1%               102
MS Step 11     43.3%               102
MS Step 12     42.6%               102
MS Step 13     42.4%               102
MS Step 14     41.4%               102
MS Step 15     40.8%               102
MS Step 16     40.1%               102
MS Step 17     39.6%               102
MS Step 18     39.0%               102
MS Step 19     38.4%               102
MS Step 20     37.7%               102
MS Step 21     37.2%               102
MS Step 22     36.6%               102
MS Step 23     35.9%               102
MS Step 24     35.3%               102
MS Step 25     34.3%               102
MS Step 26     34.0%               102
MS Step 27     33.4%               102
MS Step 28     32.8%               102
MS Step 29     32.3%               136
MS Step 30     31.7%               136
MS Step 31     31.0%               136
MS Step 32     30.5%               136
MS Step 33     30.1%               136
MS Step 34     29.5%               136
MS Step 35     29.2%               136
MS Step 36     28.5%               136
MS Step 37     27.9%               136
MS Step 38     27.6%               136
MS Step 39     27.0%               136

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low numbers of unique
plans. R-hat values for summary statistics should be between 1 and 1.05.

```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited


@tylersimko

