### PR TITLE
1990 Idaho Congressional Districts

### DIFF
--- a/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
@@ -112,6 +112,10 @@ if (!file.exists(here(shp_path))) {
 
     id_shp$adj <- adj
 
+    id_shp$muni <- ifelse(is.na(id_shp$muni) | id_shp$muni == "NA",
+                     id_shp$county_muni,
+                     id_shp$muni)
+
     id_shp <- id_shp %>%
       fix_geo_assignment(muni)
 

--- a/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
@@ -1,0 +1,79 @@
+###############################################################################
+# Download and prepare data for `ID_cd_1990` analysis
+# © ALARM Project, November 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg ID_cd_1990}")
+
+
+path_data <- download_redistricting_file("ID", "data-raw/ID", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/ID_1990/shp_vtd.rds"
+perim_path <- "data-out/ID_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong ID} shapefile")
+    # read in redistricting data
+    raw_data <- read_csv(here(path_data), col_types = cols(GEOID = "c"))
+    raw_data$state = as.character(raw_data$state)
+    shapefile <- st_read(tract_path, quiet = TRUE) |>
+        rename(state_shp = state)
+    id_shp <- raw_data |>
+        left_join(shapefile, by = "GEOID")
+    # manually set state to ID
+    id_shp = mutate(id_shp, state = "ID") |>
+        st_as_sf()
+
+    # id_shp = join_vtd_shapefile(raw_data, year = 1990)
+
+    id_shp = st_transform(id_shp, EPSG$ID)
+
+    id_shp <- id_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county.x, str_c(county.x, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county.x)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = id_shp,
+                               perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        id_shp <- rmapshaper::ms_simplify(id_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+    id_shp <- id_shp |>
+      select(-county.y, -tract.y, -state_shp)
+
+    # create adjacency graph
+    id_shp$adj <- redist.adjacency(id_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    write_rds(id_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    id_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong ID} shapefile")
+}

--- a/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
@@ -49,8 +49,6 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county.x, str_c(county.x, muni))) |>
         relocate(muni, county_muni, cd_1980, .after = county.x)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = id_shp,
                                perim_path = here(perim_path)) |>

--- a/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/01_prep_ID_cd_1990.R
@@ -39,9 +39,6 @@ if (!file.exists(here(shp_path))) {
     # manually set state to ID
     id_shp = mutate(id_shp, state = "ID") |>
         st_as_sf()
-
-    # id_shp = join_vtd_shapefile(raw_data, year = 1990)
-
     id_shp = st_transform(id_shp, EPSG$ID)
 
     id_shp <- id_shp |>
@@ -55,7 +52,6 @@ if (!file.exists(here(shp_path))) {
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         id_shp <- rmapshaper::ms_simplify(id_shp, keep = 0.05,
                                                  keep_shapes = TRUE) |>

--- a/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
@@ -1,0 +1,29 @@
+###############################################################################
+# Set up redistricting simulation for `ID_cd_1990`
+# © ALARM Project, November 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg ID_cd_1990}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(id_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = id_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map |>
+    mutate(pseudo_county = pick_county_muni(map, counties = county.x, munis = muni,
+                                            pop_muni = get_target(map)))
+map <- map %>%
+  rename(county = county.x)
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "ID_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/ID_1990/ID_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
@@ -9,10 +9,8 @@ map <- redist_map(id_shp, pop_tol = 0.005,
 
 # make pseudo counties with default settings
 map <- map |>
-    mutate(pseudo_county = pick_county_muni(map, counties = county.x, munis = muni,
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-map <- map %>%
-  rename(county = county.x)
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
@@ -4,14 +4,9 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg ID_cd_1990}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(id_shp, pop_tol = 0.005,
     existing_plan = cd_1990, adj = id_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county.x, munis = muni,

--- a/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/02_setup_ID_cd_1990.R
@@ -11,8 +11,6 @@ map <- redist_map(id_shp, pop_tol = 0.005,
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "ID_1990"

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -1,0 +1,60 @@
+###############################################################################
+# Simulate plans for `ID_cd_1990`
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg ID_cd_1990}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(1990)
+
+
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/ID_1990/ID_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg ID_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/ID_1990/ID_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -6,9 +6,6 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg ID_cd_1990}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
 #  - For many districts / tighter population tolerances, try setting
 #  `pop_temper=0.01` and nudging upward from there. Monitor the output for
 #  efficiency!
@@ -32,8 +29,6 @@ plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/ID_1990/ID_cd_1990_plans.rds"), compress = "xz")

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -53,3 +53,4 @@ if (interactive()) {
     validate_analysis(plans, map)
     summary(plans)
 }
+

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -6,20 +6,10 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg ID_cd_1990}")
 
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(1990)
 
 
 plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans |>
     group_by(chain) |>
@@ -52,4 +42,3 @@ if (interactive()) {
     validate_analysis(plans, map)
     summary(plans)
 }
-

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -45,7 +45,6 @@ save_summary_stats(plans, "data-out/ID_1990/ID_cd_1990_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
+++ b/analyses/ID_cd_1990/03_sim_ID_cd_1990.R
@@ -8,7 +8,6 @@ cli_process_start("Running simulations for {.pkg ID_cd_1990}")
 
 set.seed(1990)
 
-
 plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
 
 plans <- plans |>

--- a/analyses/ID_cd_1990/doc_ID_cd_1990.md
+++ b/analyses/ID_cd_1990/doc_ID_cd_1990.md
@@ -8,6 +8,7 @@ In Idaho, we consult [Idaho Redistricting Law 1990](https://www.commoncause.org/
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible 
 1. prevent floterial districts
+1. be connected by highways
 
 
 ### Algorithmic Constraints
@@ -17,7 +18,7 @@ We enforce a maximum population deviation of 0.5%.
 Data for Idaho comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+A custom adjacency map based on the highways of Idaho was created. Columns where muni = NA had their muni values set to the county_muni values of that column.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Idaho across 5 independent runs of the SMC algorithm.

--- a/analyses/ID_cd_1990/doc_ID_cd_1990.md
+++ b/analyses/ID_cd_1990/doc_ID_cd_1990.md
@@ -1,0 +1,25 @@
+# 1990 Idaho Congressional Districts
+
+## Redistricting requirements
+In Idaho, we consult [Idaho Redistricting Law 1990](https://www.commoncause.org/wp-content/uploads/2019/12/Idaho-Redistricting-Law.pdf) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible 
+1. prevent floterial districts
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Idaho comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Idaho across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/ID_cd_1990/doc_ID_cd_1990.md
+++ b/analyses/ID_cd_1990/doc_ID_cd_1990.md
@@ -8,8 +8,7 @@ In Idaho, we consult [Idaho Redistricting Law 1990](https://www.commoncause.org/
 1. be geographically compact
 1. preserve county and municipality boundaries as much as possible 
 1. prevent floterial districts
-1. be connected by highways
-
+1. connect counties based on highways
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
@@ -18,7 +17,7 @@ We enforce a maximum population deviation of 0.5%.
 Data for Idaho comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-A custom adjacency map based on the highways of Idaho was created. Columns where muni = NA had their muni values set to the county_muni values of that column.
+A custom adjacency map based on the highways of Idaho was created, where counties not connected by highways had their borders removed. Columns where muni = NA had their muni values set to the county_muni values of that column.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Idaho across 5 independent runs of the SMC algorithm.


### PR DESCRIPTION
# 1990 Idaho Congressional Districts

## Redistricting requirements
In Idaho, we consult [Idaho Redistricting Law 1990](https://www.commoncause.org/wp-content/uploads/2019/12/Idaho-Redistricting-Law.pdf) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible 
1. prevent floterial districts


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Idaho comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Idaho across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="4500" alt="validation_20251126_0944" src="https://github.com/user-attachments/assets/c9e69ae5-3447-4688-98cf-9b5b8c54cde0" />

```
SMC: 5,000 sampled plans of 2 districts on 269 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0

Plan diversity 80% range: 0.077 to 0.692
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_asian     pop_white     pop_black      pop_hisp 
        1.000         1.000         1.000         1.001         1.000         1.001         1.000         1.001         1.000 
     pop_aian     pop_other      vap_hisp      vap_aian     vap_black     vap_other     vap_white     vap_asian county_splits 
        1.000         1.000         1.000         1.000         1.001         1.000         1.001         1.001         1.000 
  muni_splits           ndv           nrv       ndshare 
        1.001         1.000         1.000         1.001 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,957 (97.8%)      2.8%         0.3 1,274 (101%)      3 
Resample    1,843 (92.2%)       NA%         0.3 1,752 (139%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,958 (97.9%)      2.0%         0.3 1,258 (100%)      4 
Resample    1,849 (92.4%)       NA%         0.3 1,756 (139%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,958 (97.9%)      2.1%         0.3 1,268 (100%)      4 
Resample    1,847 (92.4%)       NA%         0.3 1,752 (139%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,957 (97.8%)      2.0%        0.31 1,246 ( 99%)      4 
Resample    1,844 (92.2%)       NA%        0.31 1,752 (139%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,958 (97.9%)      2.1%         0.3 1,250 ( 99%)      4 
Resample    1,848 (92.4%)       NA%         0.3 1,763 (139%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with
`hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing constraints, or increasing the population tolerance. If the
acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

Reviewers:
@christopherkenny
@tylersimko
