### PR TITLE
1990 Louisiana Congressional Districts

### DIFF
--- a/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `LA_cd_1990` analysis
+# © ALARM Project, November 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg LA_cd_1990}")
+
+path_data <- download_redistricting_file("LA", "data-raw/LA", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/LA_1990/shp_vtd.rds"
+perim_path <- "data-out/LA_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong LA} shapefile")
+  # read in redistricting data
+  la_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(state = as.character(state)) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$LA)
+  
+  la_shp <- la_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = la_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  la_shp$adj <- redist.adjacency(la_shp)
+  
+  write_rds(la_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  la_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong LA} shapefile")
+}

--- a/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Download and prepare data for `LA_cd_1990` analysis
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 suppressMessages({

--- a/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/01_prep_LA_cd_1990.R
@@ -1,18 +1,18 @@
 ###############################################################################
 # Download and prepare data for `LA_cd_1990` analysis
-# © ALARM Project, November 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
 suppressMessages({
-  library(dplyr)
-  library(readr)
-  library(sf)
-  library(redist)
-  library(geomander)
-  library(baf)
-  library(cli)
-  library(here)
-  devtools::load_all() # load utilities
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
 })
 
 # Download necessary files for analysis -----
@@ -27,36 +27,36 @@ shp_path <- "data-out/LA_1990/shp_vtd.rds"
 perim_path <- "data-out/LA_1990/perim.rds"
 
 if (!file.exists(here(shp_path))) {
-  cli_process_start("Preparing {.strong LA} shapefile")
-  # read in redistricting data
-  la_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
-    mutate(state = as.character(state)) |>
-    join_vtd_shapefile(year = 1990) |>
-    st_transform(EPSG$LA)
-  
-  la_shp <- la_shp |>
-    rename(muni = place) |>
-    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
-    relocate(muni, county_muni, cd_1980, .after = county)
-  
-  # Create perimeters in case shapes are simplified
-  redistmetrics::prep_perims(shp = la_shp,
-                             perim_path = here(perim_path)) |>
-    invisible()
-  
-  # simplifies geometry for faster processing, plotting, and smaller shapefiles
-  if (requireNamespace("rmapshaper", quietly = TRUE)) {
-    la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
-                                      keep_shapes = TRUE) |>
-      suppressWarnings()
-  }
-  
-  # create adjacency graph
-  la_shp$adj <- redist.adjacency(la_shp)
-  
-  write_rds(la_shp, here(shp_path), compress = "gz")
-  cli_process_done()
+    cli_process_start("Preparing {.strong LA} shapefile")
+    # read in redistricting data
+    la_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(state = as.character(state)) |>
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$LA)
+
+    la_shp <- la_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = la_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    la_shp$adj <- redist.adjacency(la_shp)
+
+    write_rds(la_shp, here(shp_path), compress = "gz")
+    cli_process_done()
 } else {
-  la_shp <- read_rds(here(shp_path))
-  cli_alert_success("Loaded {.strong LA} shapefile")
+    la_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong LA} shapefile")
 }

--- a/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `LA_cd_1990`
+# © ALARM Project, November 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_1990}")
+
+map <- redist_map(la_shp, pop_tol = 0.005,
+                  existing_plan = cd_1990, adj = la_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "LA_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/LA_1990/LA_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Set up redistricting simulation for `LA_cd_1990`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_1990}")
 

--- a/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/02_setup_LA_cd_1990.R
@@ -1,11 +1,11 @@
 ###############################################################################
 # Set up redistricting simulation for `LA_cd_1990`
-# © ALARM Project, November 2025
+# © ALARM Project, February 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg LA_cd_1990}")
 
 map <- redist_map(la_shp, pop_tol = 0.005,
-                  existing_plan = cd_1990, adj = la_shp$adj)
+    existing_plan = cd_1990, adj = la_shp$adj)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "LA_1990"

--- a/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
@@ -1,0 +1,61 @@
+###############################################################################
+# Simulate plans for `LA_cd_1990`
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_cd_1990}")
+
+constr <- redist_constr(map) %>%
+  add_constr_grp_hinge(30, vap - vap_white, vap, 0.50) %>%
+  add_constr_grp_hinge(-25, vap - vap_white, vap, 0.41) %>%
+  add_constr_grp_inv_hinge(10, vap - vap_white, vap, 0.55)
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, constraints = constr)
+
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_1990/LA_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_1990/LA_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Validation plots
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  # Black VAP Performance Plot  
+  redist.plot.distr_qtys(plans, vap_black / total_vap,
+                         color_thresh = NULL,
+                         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+                         size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Black by VAP") +
+    labs(title = "Louisiana Proposed Plan versus Simulations") +
+    scale_color_manual(values = c(cd_2000 = "black")) +
+    theme_bw()
+  
+  # Total Black districts that are performing
+  plans %>%
+    subset_sampled() %>%
+    group_by(draw) %>%
+    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+    count(n_black_perf)
+}

--- a/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
@@ -1,23 +1,55 @@
 ###############################################################################
 # Simulate plans for `LA_cd_1990`
-# © ALARM Project, November 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg LA_cd_1990}")
 
-constr <- redist_constr(map) %>%
-  add_constr_grp_hinge(30, vap - vap_white, vap, 0.50) %>%
-  add_constr_grp_hinge(-25, vap - vap_white, vap, 0.41) %>%
-  add_constr_grp_inv_hinge(10, vap - vap_white, vap, 0.55)
+BVAP_THRESH <- 0.30
+DEM_THRESH  <- 0.45
+ndists <- attr(map, "ndists")
+
+constr <- redist_constr(map) |>
+    add_constr_grp_hinge(
+        0.01,
+        vap_black,
+        vap,
+        BVAP_THRESH
+    ) |>
+    add_constr_min_group_frac(
+        strength      = -1,
+        group_pops    = list(map$vap_black, map$ndv),
+        total_pops    = list(map$vap, map$nrv + map$ndv),
+        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
+        thresh        = -0.9,
+        only_nregions = seq.int(2, ndists)
+    ) |>
+    add_constr_min_group_frac(
+        strength      = -1,
+        group_pops    = list(map$vap_black, map$ndv),
+        total_pops    = list(map$vap, map$nrv + map$ndv),
+        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
+        thresh        = -1.9,
+        only_nregions = ndists
+    )
 
 set.seed(1990)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, constraints = constr)
+plans <- redist_smc(
+    map,
+    nsims = 1e3,
+    runs = 5,
+    counties = county,
+    constraints = constr,
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    sampling_space = "spanning_forest",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = 80)
+)
 
 plans <- plans |>
-  group_by(chain) |>
-  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
-  ungroup()
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
@@ -39,23 +71,23 @@ cli_process_done()
 
 # Validation plots
 if (interactive()) {
-  library(ggplot2)
-  library(patchwork)
-  
-  # Black VAP Performance Plot  
-  redist.plot.distr_qtys(plans, vap_black / total_vap,
-                         color_thresh = NULL,
-                         color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
-                         size = 0.5, alpha = 0.5) +
-    scale_y_continuous("Percent Black by VAP") +
-    labs(title = "Louisiana Proposed Plan versus Simulations") +
-    scale_color_manual(values = c(cd_2000 = "black")) +
-    theme_bw()
-  
-  # Total Black districts that are performing
-  plans %>%
-    subset_sampled() %>%
-    group_by(draw) %>%
-    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
-    count(n_black_perf)
+    library(ggplot2)
+    library(patchwork)
+
+    # Black VAP Performance Plot
+    redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Louisiana Proposed Plan versus Simulations") +
+        scale_color_manual(values = c(cd_2000 = "black")) +
+        theme_bw()
+
+    # Total Black districts that are performing
+    plans %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
 }

--- a/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
+++ b/analyses/LA_cd_1990/03_sim_LA_cd_1990.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Simulate plans for `LA_cd_1990`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 # Run the simulation -----
@@ -8,64 +8,53 @@ cli_process_start("Running simulations for {.pkg LA_cd_1990}")
 
 BVAP_THRESH <- 0.30
 DEM_THRESH  <- 0.45
-ndists <- attr(map, "ndists")
 
 constr <- redist_constr(map) |>
     add_constr_grp_hinge(
         0.01,
         vap_black,
         vap,
-        BVAP_THRESH
-    ) |>
-    add_constr_min_group_frac(
-        strength      = -1,
-        group_pops    = list(map$vap_black, map$ndv),
-        total_pops    = list(map$vap, map$nrv + map$ndv),
-        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
-        thresh        = -0.9,
-        only_nregions = seq.int(2, ndists)
-    ) |>
-    add_constr_min_group_frac(
-        strength      = -1,
-        group_pops    = list(map$vap_black, map$ndv),
-        total_pops    = list(map$vap, map$nrv + map$ndv),
-        min_fracs     = c(BVAP_THRESH, DEM_THRESH),
-        thresh        = -1.9,
-        only_nregions = ndists
-    )
+        BVAP_THRESH)
 
 set.seed(1990)
 plans <- redist_smc(
     map,
-    nsims = 1e3,
+    nsims = 2e4,
     runs = 5,
     counties = county,
-    constraints = constr,
-    split_params = list(splitting_schedule = "any_valid_sizes"),
-    sampling_space = "spanning_forest",
-    ms_params = list(frequency = 1L, mh_accept_per_smc = 80)
+    constraints = constr
 )
-
-plans <- plans |>
-    group_by(chain) |>
-    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
-    ungroup()
 plans <- match_numbers(plans, "cd_1990")
+
+# Subset plans that are not performing
+n_perf <- plans %>%
+  mutate(
+    bvap = group_frac(map, vap_black, vap),
+    ndshare = group_frac(map, ndv, nrv + ndv)
+  ) %>%
+  group_by(draw) %>%
+  summarize(n_black_perf = sum(bvap > BVAP_THRESH & ndshare > DEM_THRESH))
+
+plans_5k <- plans %>%
+  anti_join(filter(n_perf, n_black_perf == 0), by = "draw") %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>%
+  ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
 # Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/LA_1990/LA_cd_1990_plans.rds"), compress = "xz")
+write_rds(plans_5k, here("data-out/LA_1990/LA_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg LA_cd_1990}")
 
-plans <- add_summary_stats(plans, map)
+plans_5k <- add_summary_stats(plans_5k, map)
 
 # Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/LA_1990/LA_cd_1990_stats.csv")
+save_summary_stats(plans_5k, "data-out/LA_1990/LA_cd_1990_stats.csv")
 
 cli_process_done()
 

--- a/analyses/LA_cd_1990/doc_LA_cd_1990.md
+++ b/analyses/LA_cd_1990/doc_LA_cd_1990.md
@@ -1,0 +1,23 @@
+# 1990 Louisiana Congressional Districts
+
+## Redistricting requirements
+In Louisiana, there are no specific legal requirements.
+We impose the following constraints. 
+In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%. We add group hinge constraints to encourage at least one majority-minority district while discouraging both cracking and packing of minority voters.
+
+## Data Sources
+Data for Louisiana comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/LA_cd_1990/doc_LA_cd_1990.md
+++ b/analyses/LA_cd_1990/doc_LA_cd_1990.md
@@ -9,7 +9,7 @@ In our simulations, districts must:
 1. have equal populations
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We add group hinge constraints and thresholded hard constraints to encourage at least one majority-minority district while discouraging both cracking and packing of minority voters.
+We enforce a maximum population deviation of 0.5%. We add group hinge constraints to encourage at least one majority-minority district.
 
 ## Data Sources
 Data for Louisiana comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
@@ -18,6 +18,5 @@ Data for Louisiana comes from the [ALARM Project's update](https://dataverse.har
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm.
-We also use new algorithmic mergesplit parameters to improve mixing. 
+We sample 100,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm. We remove all plans that do not contain at least one district with BVAP above 30% and Democratic vote share above 45%. We then thin the filtered sample to 5,000 plans.
 No special techniques were needed to produce the sample.

--- a/analyses/LA_cd_1990/doc_LA_cd_1990.md
+++ b/analyses/LA_cd_1990/doc_LA_cd_1990.md
@@ -19,4 +19,3 @@ No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 100,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm. We remove all plans that do not contain at least one district with BVAP above 30% and Democratic vote share above 45%. We then thin the filtered sample to 5,000 plans.
-No special techniques were needed to produce the sample.

--- a/analyses/LA_cd_1990/doc_LA_cd_1990.md
+++ b/analyses/LA_cd_1990/doc_LA_cd_1990.md
@@ -9,7 +9,7 @@ In our simulations, districts must:
 1. have equal populations
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%. We add group hinge constraints to encourage at least one majority-minority district while discouraging both cracking and packing of minority voters.
+We enforce a maximum population deviation of 0.5%. We add group hinge constraints and thresholded hard constraints to encourage at least one majority-minority district while discouraging both cracking and packing of minority voters.
 
 ## Data Sources
 Data for Louisiana comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
@@ -18,6 +18,6 @@ Data for Louisiana comes from the [ALARM Project's update](https://dataverse.har
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm.
-We then thinned the number of samples to 5,000. 
+We sample 5,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm.
+We also use new algorithmic mergesplit parameters to improve mixing. 
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Louisiana, there are no specific legal requirements.
We impose the following constraints. 
In our simulations, districts must:

1. be contiguous
1. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add group hinge constraints to encourage at least one majority-minority district.

## Data Sources
Data for Louisiana comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 100,000 districting plans for Louisiana across 5 independent runs of the SMC algorithm. We remove all plans that do not contain at least one district with a BVAP above 30% and a Democratic vote share above 45%. We then thin the filtered sample to 5,000 plans.

## Validation
<img width="3000" height="4500" alt="validation_20260308_0105" src="https://github.com/user-attachments/assets/c283971f-f721-482c-9326-96934437726d" />

```
SMC: 5,000 sampled plans of 7 districts on 1,108 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:          
• `weight_type` = optimal
• `seq_alpha` = 1        
• `pop_temper` = 0       
Plan diversity 80% range: 0.46 to 0.78
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv      plan_dev      pop_aian 
        1.002         1.001         1.000         1.001         1.003         1.003         1.002         1.001         1.002 
    pop_asian     pop_black      pop_hisp     pop_other   pop_overlap     pop_white     total_vap      vap_aian     vap_asian 
        1.002         1.002         1.001         1.002         1.001         1.003         1.002         1.002         1.001 
    vap_black      vap_hisp     vap_other     vap_white 
        1.002         1.001         1.003         1.003 
• R-hat ≤ 1.05: 154      
• 1.05 < R-hat ≤ 1.1: 0  
• R-hat > 1.1: 0         
• Total R-hats: 154      
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique Est. k 
Split 1     9,072 (45.4%)      9.9%        0.93 12,620 (100%)      6 
Split 2     9,204 (46.0%)     12.9%        0.79 10,003 ( 79%)      4 
Split 3     9,543 (47.7%)     15.9%        0.75 10,249 ( 81%)      3 
Split 4     8,929 (44.6%)     14.7%        0.72 10,450 ( 83%)      3 
Split 5     9,868 (49.3%)     16.8%        0.71 10,275 ( 81%)      2 
Split 6    17,187 (85.9%)      5.8%        0.41  9,502 ( 75%)      2 
Resample   17,187 (85.9%)       NA%          NA 16,758 (133%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3
or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@philipwosull 

## Additional Notes
BVAP performance plot:
<img width="637" height="571" alt="Ordered district" src="https://github.com/user-attachments/assets/1a9fff5d-4c2e-4eb7-95da-be0c40378c5d" />

Total Black performant districts:
```
  n_black_perf    n
1            0  701
2            1 4298
3            2    1
```