### PR TITLE
2020 South Carolina State House/Senate Districts

### DIFF
--- a/analyses/SC_leg_2020/01_prep_SC_leg_2020.R
+++ b/analyses/SC_leg_2020/01_prep_SC_leg_2020.R
@@ -1,0 +1,96 @@
+###############################################################################
+# Download and prepare data for `SC_leg_2020` analysis
+# © ALARM Project, November 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg SC_leg_2020}")
+
+path_data <- download_redistricting_file("SC", "data-raw/SC", year = 2020)
+
+# If large, consider checking to see if these files exist before downloading
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/SC_2020/shp_vtd.rds"
+perim_path <- "data-out/SC_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong SC} shapefile")
+    # read in redistricting data
+    sc_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$SC)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("SC", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("SC"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("SC", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("SC"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("SC", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("SC"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    sc_shp <- sc_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    sc_shp <- sc_shp |>
+        left_join(y = leg_from_baf(state = "SC"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = sc_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        sc_shp <- rmapshaper::ms_simplify(sc_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    sc_shp$adj <- adjacency(sc_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(sc_shp$adj, sc_shp$ssd_2020)
+    ccm(sc_shp$adj, sc_shp$shd_2020)
+
+    sc_shp <- sc_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(sc_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    sc_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong SC} shapefile")
+}
+
+# visualize the enacted maps using:
+redistio::draw(sc_shp, sc_shp$ssd_2020)
+redistio::draw(sc_shp, sc_shp$shd_2020)

--- a/analyses/SC_leg_2020/02_setup_SC_leg_2020.R
+++ b/analyses/SC_leg_2020/02_setup_SC_leg_2020.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `SC_leg_2020`
+# © ALARM Project, November 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg SC_leg_2020}")
+
+map_ssd <- redist_map(sc_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = sc_shp$adj)
+
+map_shd <- redist_map(sc_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = sc_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "SC_SSD_2020"
+attr(map_shd, "analysis_name") <- "SC_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/SC_2020/SC_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/SC_2020/SC_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/SC_leg_2020/03_sim_SC_shd_2020.R
+++ b/analyses/SC_leg_2020/03_sim_SC_shd_2020.R
@@ -1,0 +1,55 @@
+###############################################################################
+# Simulate plans for `SC_shd_2020` SHD
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg SC_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 20. ## increase by 20
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 3.5e3, runs = 5,       ## increase samples by 1500 to 3500
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/SC_2020/SC_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg SC_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/SC_2020/SC_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/SC_leg_2020/03_sim_SC_ssd_2020.R
+++ b/analyses/SC_leg_2020/03_sim_SC_ssd_2020.R
@@ -1,0 +1,56 @@
+###############################################################################
+# Simulate plans for `SC_ssd_2020` SSD
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg SC_ssd_2020}")
+
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/SC_2020/SC_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg SC_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/SC_2020/SC_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/SC_leg_2020/doc_SC_leg_2020.md
+++ b/analyses/SC_leg_2020/doc_SC_leg_2020.md
@@ -1,0 +1,29 @@
+# 2020 South Carolina State House/Senate Districts
+
+## Redistricting requirements
+In South Carolina, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous [NCSL, 186]
+2. have equal populations [NCSL, 23]
+3. be geographically compact [NCSL, 186]
+4. preserve political subdivisions and communities of interests [NCSL, 186]
+5. preserve cores of prior districts [NCSL, 187]
+6. avoid pairing incumbents [NCSL, 187]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for South Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 17,500 districting plans for South Carolina's lower house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+No special techniques were needed to produce the sample.
+
+We sample 10,000 districting plans for South Carolina's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In South Carolina, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous [NCSL, 186]
2. have equal populations [NCSL, 23]
3. be geographically compact [NCSL, 186]
4. preserve political subdivisions and communities of interests [NCSL, 186]
5. preserve cores of prior districts [NCSL, 187]
6. avoid pairing incumbents [NCSL, 187]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for South Carolina comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 17,500 districting plans for South Carolina's lower house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
No special techniques were needed to produce the sample.

We sample 10,000 districting plans for South Carolina's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
No special techniques were needed to produce the sample.

## Validation

## SHD
**<img width="3000" height="4500" alt="validation_20251126_1529" src="https://github.com/user-attachments/assets/ec8a7359-bd8e-4ae4-8956-041ba5888d85" />**

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 124 districts on 2,268 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 123
• `mh_accept_per_smc` = 62
• `pair_rule` = uniform
Plan diversity 80% range: 0.70 to 0.77
92 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20 atg_18_dem_ana atg_18_rep_wil 
         1.021          1.022          1.029          1.027          1.027          1.021          1.023          1.026 
     comp_edge    comp_polsby  county_splits          e_dem          e_dvs           egap gov_18_dem_smi gov_18_rep_mcm 
         1.014          1.008          1.010          1.027          1.033          1.033          1.018          1.028 
   muni_splits        ndshare            ndv            nrv          pbias       plan_dev       pop_aian      pop_asian 
         1.005          1.031          1.020          1.027          1.008          1.001          1.014          1.021 
     pop_black       pop_hisp       pop_nhpi      pop_other    pop_overlap        pop_two      pop_white         pr_dem 
         1.034          1.023          1.011          1.016          1.007          1.021          1.024          1.019 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru sos_18_dem_whi sos_18_rep_ham      total_vap uss_16_dem_dix 
         1.018          1.028          1.029          1.022          1.026          1.025          1.018          1.016 
uss_16_rep_sco uss_20_dem_har uss_20_rep_gra       vap_aian      vap_asian      vap_black       vap_hisp       vap_nhpi 
         1.026          1.030          1.021          1.014          1.021          1.027          1.025          1.013 
     vap_other        vap_two      vap_white 
         1.011          1.030          1.025 
• R-hat ≤ 1.05: 6232
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 6232
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
          Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1      1,629 (46.5%)    100.0%       1.137 2,231 (101%) 
Split 2      1,887 (53.9%)     99.4%       1.124 1,725 ( 78%) 
Split 3      2,059 (58.8%)     98.8%       1.028 1,804 ( 82%) 
Split 4      2,114 (60.4%)     97.9%       0.942 1,849 ( 84%) 
Split 5      2,209 (63.1%)     97.1%       0.880 1,895 ( 86%) 
Split 6      2,332 (66.6%)     96.6%       0.838 1,932 ( 87%) 
Split 7      2,469 (70.5%)     95.2%       0.767 1,927 ( 87%) 
Split 8      2,489 (71.1%)     94.3%       0.716 2,004 ( 91%) 
Split 9      2,585 (73.9%)     93.7%       0.703 1,980 ( 89%) 
Split 10     2,651 (75.7%)     92.4%       0.645 2,026 ( 92%) 
Split 11     2,715 (77.6%)     91.4%       0.618 2,041 ( 92%) 
Split 12     2,735 (78.1%)     90.2%       0.602 2,032 ( 92%) 
Split 13     2,782 (79.5%)     90.0%       0.570 2,032 ( 92%) 
Split 14     2,828 (80.8%)     89.3%       0.540 2,069 ( 94%) 
Split 15     2,879 (82.3%)     88.8%       0.505 2,067 ( 93%) 
Split 16     2,898 (82.8%)     87.7%       0.510 2,096 ( 95%) 
Split 17     2,943 (84.1%)     85.6%       0.488 2,116 ( 96%) 
Split 18     2,942 (84.1%)     85.6%       0.481 2,102 ( 95%) 
Split 19     2,994 (85.5%)     84.4%       0.454 2,131 ( 96%) 
Split 20     3,028 (86.5%)     83.7%       0.435 2,112 ( 95%) 
Split 21     3,046 (87.0%)     82.2%       0.421 2,121 ( 96%) 
Split 22     3,072 (87.8%)     81.5%       0.405 2,141 ( 97%) 
Split 23     3,084 (88.1%)     79.9%       0.403 2,126 ( 96%) 
Split 24     3,116 (89.0%)     79.1%       0.376 2,115 ( 96%) 
Split 25     3,117 (89.1%)     78.3%       0.378 2,123 ( 96%) 
Split 26     3,108 (88.8%)     77.5%       0.372 2,146 ( 97%) 
Split 27     3,127 (89.3%)     76.6%       0.373 2,114 ( 96%) 
Split 28     3,155 (90.1%)     77.6%       0.356 2,134 ( 96%) 
Split 29     3,187 (91.0%)     74.7%       0.336 2,159 ( 98%) 
Split 30     3,188 (91.1%)     74.5%       0.333 2,131 ( 96%) 
Split 31     3,202 (91.5%)     74.7%       0.323 2,134 ( 96%) 
Split 32     3,231 (92.3%)     71.8%       0.310 2,146 ( 97%) 
Split 33     3,216 (91.9%)     71.9%       0.311 2,152 ( 97%) 
Split 34     3,235 (92.4%)     70.2%       0.303 2,170 ( 98%) 
Split 35     3,236 (92.5%)     69.4%       0.298 2,178 ( 98%) 
Split 36     3,247 (92.8%)     68.7%       0.295 2,123 ( 96%) 
Split 37     3,257 (93.1%)     67.8%       0.292 2,155 ( 97%) 
Split 38     3,266 (93.3%)     68.1%       0.284 2,152 ( 97%) 
Split 39     3,275 (93.6%)     67.6%       0.281 2,172 ( 98%) 
Split 40     3,295 (94.1%)     65.5%       0.268 2,160 ( 98%) 
Split 41     3,295 (94.1%)     64.9%       0.263 2,202 (100%) 
Split 42     3,290 (94.0%)     64.4%       0.265 2,173 ( 98%) 
Split 43     3,290 (94.0%)     64.8%       0.263 2,173 ( 98%) 
Split 44     3,303 (94.4%)     62.7%       0.257 2,172 ( 98%) 
Split 45     3,319 (94.8%)     61.7%       0.245 2,191 ( 99%) 
Split 46     3,320 (94.9%)     60.9%       0.248 2,160 ( 98%) 
Split 47     3,321 (94.9%)     61.2%       0.244 2,187 ( 99%) 
Split 48     3,334 (95.3%)     60.0%       0.235 2,195 ( 99%) 
Split 49     3,337 (95.3%)     59.4%       0.232 2,178 ( 98%) 
Split 50     3,337 (95.3%)     57.8%       0.233 2,196 ( 99%) 
Split 51     3,352 (95.8%)     55.6%       0.219 2,158 ( 98%) 
Split 52     3,344 (95.6%)     57.0%       0.226 2,168 ( 98%) 
Split 53     3,349 (95.7%)     56.2%       0.219 2,192 ( 99%) 
Split 54     3,349 (95.7%)     55.5%       0.220 2,148 ( 97%) 
Split 55     3,360 (96.0%)     54.5%       0.214 2,162 ( 98%) 
Split 56     3,354 (95.8%)     53.3%       0.219 2,219 (100%) 
Split 57     3,368 (96.2%)     52.4%       0.208 2,172 ( 98%) 
Split 58     3,372 (96.4%)     52.9%       0.203 2,203 (100%) 
Split 59     3,377 (96.5%)     50.9%       0.197 2,182 ( 99%) 
Split 60     3,380 (96.6%)     50.5%       0.197 2,159 ( 98%) 
Split 61     3,386 (96.8%)     50.5%       0.191 2,177 ( 98%) 
Split 62     3,385 (96.7%)     49.8%       0.193 2,160 ( 98%) 
Split 63     3,388 (96.8%)     48.1%       0.190 2,182 ( 99%) 
Split 64     3,392 (96.9%)     48.0%       0.185 2,198 ( 99%) 
Split 65     3,393 (96.9%)     48.4%       0.183 2,172 ( 98%) 
Split 66     3,394 (97.0%)     47.5%       0.185 2,169 ( 98%) 
Split 67     3,400 (97.1%)     46.4%       0.178 2,204 (100%) 
Split 68     3,405 (97.3%)     45.3%       0.173 2,200 ( 99%) 
Split 69     3,402 (97.2%)     46.4%       0.175 2,168 ( 98%) 
Split 70     3,410 (97.4%)     45.0%       0.169 2,189 ( 99%) 
Split 71     3,405 (97.3%)     44.5%       0.174 2,195 ( 99%) 
Split 72     3,402 (97.2%)     43.5%       0.177 2,242 (101%) 
Split 73     3,409 (97.4%)     42.5%       0.166 2,200 ( 99%) 
Split 74     3,412 (97.5%)     41.7%       0.165 2,213 (100%) 
Split 75     3,408 (97.4%)     41.9%       0.169 2,196 ( 99%) 
Split 76     3,412 (97.5%)     40.7%       0.166 2,173 ( 98%) 
Split 77     3,416 (97.6%)     40.7%       0.163 2,181 ( 99%) 
Split 78     3,419 (97.7%)     40.8%       0.159 2,174 ( 98%) 
Split 79     3,422 (97.8%)     38.7%       0.155 2,150 ( 97%) 
Split 80     3,418 (97.6%)     39.1%       0.159 2,207 (100%) 
Split 81     3,417 (97.6%)     37.8%       0.160 2,186 ( 99%) 
Split 82     3,418 (97.6%)     38.5%       0.160 2,192 ( 99%) 
Split 83     3,423 (97.8%)     37.9%       0.154 2,208 (100%) 
Split 84     3,425 (97.9%)     37.0%       0.152 2,194 ( 99%) 
Split 85     3,428 (97.9%)     36.8%       0.149 2,184 ( 99%) 
Split 86     3,431 (98.0%)     36.2%       0.146 2,208 (100%) 
Split 87     3,429 (98.0%)     35.2%       0.148 2,179 ( 98%) 
Split 88     3,433 (98.1%)     34.7%       0.143 2,204 (100%) 
Split 89     3,435 (98.1%)     34.9%       0.141 2,188 ( 99%) 
Split 90     3,435 (98.1%)     34.5%       0.143 2,167 ( 98%) 
Split 91     3,436 (98.2%)     34.2%       0.139 2,190 ( 99%) 
Split 92     3,442 (98.3%)     33.7%       0.134 2,175 ( 98%) 
Split 93     3,441 (98.3%)     32.6%       0.134 2,156 ( 97%) 
Split 94     3,440 (98.3%)     32.8%       0.136 2,209 (100%) 
Split 95     3,442 (98.3%)     32.2%       0.134 2,166 ( 98%) 
Split 96     3,441 (98.3%)     32.1%       0.135 2,191 ( 99%) 
Split 97     3,441 (98.3%)     31.9%       0.135 2,175 ( 98%) 
Split 98     3,439 (98.3%)     31.0%       0.136 2,193 ( 99%) 
Split 99     3,445 (98.4%)     30.1%       0.128 2,181 ( 99%) 
Split 100    3,444 (98.4%)     30.8%       0.132 2,201 ( 99%) 
Split 101    3,442 (98.3%)     29.9%       0.133 2,168 ( 98%) 
Split 102    3,446 (98.4%)     29.8%       0.129 2,178 ( 98%) 
Split 103    3,445 (98.4%)     28.9%       0.130 2,187 ( 99%) 
Split 104    3,448 (98.5%)     28.9%       0.127 2,202 (100%) 
Split 105    3,447 (98.5%)     28.5%       0.127 2,172 ( 98%) 
Split 106    3,452 (98.6%)     27.5%       0.120 2,173 ( 98%) 
Split 107    3,452 (98.6%)     27.2%       0.121 2,170 ( 98%) 
Split 108    3,451 (98.6%)     26.8%       0.122 2,176 ( 98%) 
Split 109    3,456 (98.7%)     26.6%       0.116 2,148 ( 97%) 
Split 110    3,454 (98.7%)     25.9%       0.118 2,193 ( 99%) 
Split 111    3,455 (98.7%)     26.1%       0.116 2,194 ( 99%) 
Split 112    3,458 (98.8%)     25.5%       0.113 2,172 ( 98%) 
Split 113    3,455 (98.7%)     25.1%       0.117 2,162 ( 98%) 
Split 114    3,459 (98.8%)     25.1%       0.112 2,151 ( 97%) 
Split 115    3,459 (98.8%)     24.8%       0.112 2,142 ( 97%) 
Split 116    3,459 (98.8%)     24.1%       0.113 2,134 ( 96%) 
Split 117    3,462 (98.9%)     23.8%       0.109 2,141 ( 97%) 
Split 118    3,462 (98.9%)     23.3%       0.108 2,121 ( 96%) 
Split 119    3,463 (98.9%)     22.8%       0.107 2,140 ( 97%) 
Split 120    3,467 (99.1%)     23.0%       0.101 2,052 ( 93%) 
Split 121    3,468 (99.1%)     22.3%       0.099 2,041 ( 92%) 
Split 122    3,474 (99.2%)     22.0%       0.089 1,988 ( 90%) 
Split 123    3,474 (99.3%)     22.2%       0.088 1,772 ( 80%) 
Resample     3,474 (99.3%)       NA%          NA 3,386 (153%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
            Acc. rate MS Steps per Plan
MS Step 1       51.5%                62
MS Step 2       51.1%               124
MS Step 3       51.1%               124
MS Step 4       51.0%               124
MS Step 5       51.2%               124
MS Step 6       51.1%               124
MS Step 7       51.2%               124
MS Step 8       51.1%               124
MS Step 9       51.0%               124
MS Step 10      51.0%               124
MS Step 11      51.0%               124
MS Step 12      51.0%               124
MS Step 13      50.9%               124
MS Step 14      50.8%               124
MS Step 15      50.7%               124
MS Step 16      50.6%               124
MS Step 17      50.6%               124
MS Step 18      50.3%               124
MS Step 19      50.5%               124
MS Step 20      50.1%               124
MS Step 21      50.2%               124
MS Step 22      49.9%               124
MS Step 23      49.8%               186
MS Step 24      49.7%               186
MS Step 25      49.6%               186
MS Step 26      49.4%               186
MS Step 27      49.2%               186
MS Step 28      49.2%               186
MS Step 29      49.0%               186
MS Step 30      48.8%               186
MS Step 31      48.7%               186
MS Step 32      48.6%               186
MS Step 33      48.4%               186
MS Step 34      48.3%               186
MS Step 35      48.3%               186
MS Step 36      48.2%               186
MS Step 37      48.0%               186
MS Step 38      47.8%               186
MS Step 39      47.6%               186
MS Step 40      47.5%               186
MS Step 41      47.3%               186
MS Step 42      47.1%               186
MS Step 43      47.1%               186
MS Step 44      46.7%               186
MS Step 45      46.6%               186
MS Step 46      46.6%               186
MS Step 47      46.5%               186
MS Step 48      46.2%               186
MS Step 49      46.0%               186
MS Step 50      46.0%               186
MS Step 51      45.6%               186
MS Step 52      45.6%               186
MS Step 53      45.3%               186
MS Step 54      45.2%               186
MS Step 55      45.1%               186
MS Step 56      44.9%               186
MS Step 57      44.7%               186
MS Step 58      44.5%               186
MS Step 59      44.4%               186
MS Step 60      44.3%               186
MS Step 61      44.1%               186
MS Step 62      43.9%               186
MS Step 63      43.7%               186
MS Step 64      43.6%               186
MS Step 65      43.3%               186
MS Step 66      43.2%               186
MS Step 67      43.0%               186
MS Step 68      42.8%               186
MS Step 69      42.7%               186
MS Step 70      42.6%               186
MS Step 71      42.4%               186
MS Step 72      42.1%               186
MS Step 73      42.0%               186
MS Step 74      41.9%               186
MS Step 75      41.5%               186
MS Step 76      41.5%               186
MS Step 77      41.3%               186
MS Step 78      41.2%               186
MS Step 79      41.1%               186
MS Step 80      40.8%               186
MS Step 81      40.6%               186
MS Step 82      40.4%               186
MS Step 83      40.3%               186
MS Step 84      40.1%               186
MS Step 85      39.8%               186
MS Step 86      39.8%               186
MS Step 87      39.5%               186
MS Step 88      39.4%               186
MS Step 89      39.3%               186
MS Step 90      39.0%               186
MS Step 91      38.9%               186
MS Step 92      38.6%               186
MS Step 93      38.5%               186
MS Step 94      38.3%               186
MS Step 95      38.3%               186
MS Step 96      38.0%               186
MS Step 97      38.0%               186
MS Step 98      37.9%               186
MS Step 99      37.6%               186
MS Step 100     37.5%               186
MS Step 101     37.3%               186
MS Step 102     37.1%               186
MS Step 103     37.0%               186
MS Step 104     36.8%               186
MS Step 105     36.4%               186
MS Step 106     36.4%               186
MS Step 107     36.3%               186
MS Step 108     36.1%               186
MS Step 109     35.9%               186
MS Step 110     35.9%               186
MS Step 111     35.5%               186
MS Step 112     35.5%               186
MS Step 113     35.4%               186
MS Step 114     35.2%               186
MS Step 115     35.1%               186
MS Step 116     34.9%               186
MS Step 117     34.9%               186
MS Step 118     34.7%               186
MS Step 119     34.5%               186
MS Step 120     34.4%               186
MS Step 121     34.5%               186
MS Step 122     34.3%               186
MS Step 123     34.2%               186

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## SSD
**<img width="3000" height="4500" alt="validation_20251126_1645" src="https://github.com/user-attachments/assets/1d6ba116-421d-4191-b0f4-d8fc7836260a" />**
```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 46 districts on 2,268 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 45
• `mh_accept_per_smc` = 16
• `pair_rule` = uniform
Plan diversity 80% range: 0.65 to 0.79
30 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
        adv_16         adv_18         adv_20         arv_16         arv_18         arv_20 atg_18_dem_ana atg_18_rep_wil 
         1.014          1.012          1.017          1.015          1.013          1.008          1.016          1.014 
     comp_edge    comp_polsby  county_splits          e_dem          e_dvs           egap gov_18_dem_smi gov_18_rep_mcm 
         1.003          1.010          1.019          1.008          1.018          1.009          1.015          1.010 
   muni_splits        ndshare            ndv            nrv          pbias       plan_dev       pop_aian      pop_asian 
         1.021          1.018          1.015          1.012          1.011          1.001          1.022          1.042 
     pop_black       pop_hisp       pop_nhpi      pop_other    pop_overlap        pop_two      pop_white         pr_dem 
         1.017          1.019          1.014          1.019          1.050          1.016          1.008          1.016 
pre_16_dem_cli pre_16_rep_tru pre_20_dem_bid pre_20_rep_tru sos_18_dem_whi sos_18_rep_ham      total_vap uss_16_dem_dix 
         1.013          1.012          1.017          1.009          1.012          1.017          1.006          1.035 
uss_16_rep_sco uss_20_dem_har uss_20_rep_gra       vap_aian      vap_asian      vap_black       vap_hisp       vap_nhpi 
         1.013          1.017          1.009          1.026          1.024          1.017          1.031          1.010 
     vap_other        vap_two      vap_white 
         1.018          1.014          1.009 
• R-hat ≤ 1.05: 2316
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2316
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       887 (44.3%)    100.0%        1.09 1,248 ( 99%) 
Split 2     1,019 (51.0%)     97.6%        1.13 1,003 ( 79%) 
Split 3     1,166 (58.3%)     96.1%        1.04 1,028 ( 81%) 
Split 4     1,233 (61.7%)     94.4%        0.92 1,058 ( 84%) 
Split 5     1,255 (62.7%)     91.4%        0.92 1,066 ( 84%) 
Split 6     1,373 (68.7%)     89.6%        0.82 1,103 ( 87%) 
Split 7     1,405 (70.3%)     86.5%        0.77 1,120 ( 89%) 
Split 8     1,426 (71.3%)     85.6%        0.73 1,141 ( 90%) 
Split 9     1,459 (73.0%)     83.8%        0.70 1,124 ( 89%) 
Split 10    1,489 (74.4%)     82.1%        0.65 1,142 ( 90%) 
Split 11    1,516 (75.8%)     80.4%        0.62 1,143 ( 90%) 
Split 12    1,536 (76.8%)     76.2%        0.59 1,177 ( 93%) 
Split 13    1,559 (78.0%)     74.3%        0.59 1,134 ( 90%) 
Split 14    1,634 (81.7%)     73.3%        0.52 1,166 ( 92%) 
Split 15    1,645 (82.2%)     72.8%        0.52 1,179 ( 93%) 
Split 16    1,657 (82.9%)     69.4%        0.49 1,188 ( 94%) 
Split 17    1,670 (83.5%)     67.6%        0.48 1,211 ( 96%) 
Split 18    1,698 (84.9%)     66.3%        0.46 1,185 ( 94%) 
Split 19    1,719 (86.0%)     64.6%        0.44 1,207 ( 95%) 
Split 20    1,731 (86.6%)     62.5%        0.43 1,208 ( 96%) 
Split 21    1,735 (86.7%)     60.1%        0.42 1,178 ( 93%) 
Split 22    1,744 (87.2%)     56.9%        0.41 1,211 ( 96%) 
Split 23    1,776 (88.8%)     56.7%        0.38 1,206 ( 95%) 
Split 24    1,784 (89.2%)     56.2%        0.38 1,215 ( 96%) 
Split 25    1,802 (90.1%)     55.8%        0.36 1,223 ( 97%) 
Split 26    1,824 (91.2%)     53.1%        0.34 1,264 (100%) 
Split 27    1,816 (90.8%)     50.4%        0.34 1,219 ( 96%) 
Split 28    1,818 (90.9%)     49.9%        0.33 1,205 ( 95%) 
Split 29    1,828 (91.4%)     47.7%        0.33 1,222 ( 97%) 
Split 30    1,830 (91.5%)     47.7%        0.33 1,202 ( 95%) 
Split 31    1,843 (92.1%)     46.4%        0.30 1,207 ( 95%) 
Split 32    1,846 (92.3%)     42.6%        0.30 1,241 ( 98%) 
Split 33    1,864 (93.2%)     42.8%        0.28 1,214 ( 96%) 
Split 34    1,860 (93.0%)     41.6%        0.29 1,200 ( 95%) 
Split 35    1,866 (93.3%)     40.7%        0.28 1,227 ( 97%) 
Split 36    1,873 (93.7%)     40.2%        0.27 1,194 ( 94%) 
Split 37    1,884 (94.2%)     39.0%        0.26 1,214 ( 96%) 
Split 38    1,890 (94.5%)     36.6%        0.25 1,221 ( 97%) 
Split 39    1,902 (95.1%)     37.1%        0.24 1,193 ( 94%) 
Split 40    1,904 (95.2%)     34.6%        0.24 1,201 ( 95%) 
Split 41    1,906 (95.3%)     33.6%        0.23 1,215 ( 96%) 
Split 42    1,915 (95.8%)     32.8%        0.22 1,211 ( 96%) 
Split 43    1,918 (95.9%)     31.2%        0.22 1,185 ( 94%) 
Split 44    1,924 (96.2%)     31.1%        0.21 1,202 ( 95%) 
Split 45    1,931 (96.6%)     30.0%        0.20 1,106 ( 87%) 
Resample    1,931 (96.6%)       NA%          NA 1,846 (146%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      54.0%                16
MS Step 2      51.9%                32
MS Step 3      51.2%                32
MS Step 4      50.2%                32
MS Step 5      50.0%                32
MS Step 6      49.3%                48
MS Step 7      48.2%                48
MS Step 8      47.8%                48
MS Step 9      47.3%                48
MS Step 10     47.1%                48
MS Step 11     47.1%                48
MS Step 12     46.5%                48
MS Step 13     45.6%                48
MS Step 14     45.3%                48
MS Step 15     45.0%                48
MS Step 16     44.2%                48
MS Step 17     43.8%                48
MS Step 18     43.1%                48
MS Step 19     43.1%                48
MS Step 20     42.2%                48
MS Step 21     42.1%                48
MS Step 22     41.5%                48
MS Step 23     40.9%                48
MS Step 24     40.3%                48
MS Step 25     40.1%                48
MS Step 26     39.3%                48
MS Step 27     38.9%                48
MS Step 28     38.5%                48
MS Step 29     37.8%                48
MS Step 30     37.3%                48
MS Step 31     36.7%                48
MS Step 32     36.3%                48
MS Step 33     35.7%                48
MS Step 34     35.8%                48
MS Step 35     34.9%                48
MS Step 36     34.3%                48
MS Step 37     34.0%                48
MS Step 38     33.5%                48
MS Step 39     32.8%                48
MS Step 40     32.6%                64
MS Step 41     31.9%                64
MS Step 42     31.7%                64
MS Step 43     31.1%                64
MS Step 44     30.7%                64
MS Step 45     30.1%                64

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.

```
## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
