### PR TITLE
1990 New Mexico Congressional Districts

### DIFF
--- a/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
@@ -39,7 +39,7 @@ if (!file.exists(here(shp_path))) {
   # manually set state to NM
   nm_shp = mutate(nm_shp, state = "NM") |>
     st_as_sf()
-  nm_shp = st_transform(nm_shp, EPSG$ID)
+  nm_shp = st_transform(nm_shp, EPSG$NM)
 
   nm_shp <- nm_shp |>
     mutate(county = coalesce(county.x, county.y)) |>
@@ -71,3 +71,4 @@ if (!file.exists(here(shp_path))) {
   nm_shp <- read_rds(here(shp_path))
   cli_alert_success("Loaded {.strong NM} shapefile")
 }
+

--- a/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
@@ -50,15 +50,12 @@ if (!file.exists(here(shp_path))) {
     mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
     relocate(muni, county_muni, cd_1980, .after = county)
 
-  # TODO any additional columns or data you want to add should go here
-
   # Create perimeters in case shapes are simplified
   redistmetrics::prep_perims(shp = nm_shp,
                              perim_path = here(perim_path)) |>
     invisible()
 
   # simplifies geometry for faster processing, plotting, and smaller shapefiles
-  # TODO feel free to delete if this dependency isn't available
   if (requireNamespace("rmapshaper", quietly = TRUE)) {
     nm_shp <- rmapshaper::ms_simplify(nm_shp, keep = 0.05,
                                       keep_shapes = TRUE) |>

--- a/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
@@ -1,0 +1,78 @@
+###############################################################################
+# Download and prepare data for `NM_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NM_cd_1990}")
+
+path_data <- download_redistricting_file("NM", "data-raw/NM", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NM_1990/shp_vtd.rds"
+perim_path <- "data-out/NM_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong NM} shapefile")
+  # read in redistricting data
+  tract_path = "data-raw/NM/35_tracts.gpkg"
+  raw_data <- read_csv(here(path_data), col_types = cols(GEOID = "c"))
+  raw_data$state = as.character(raw_data$state)
+  shapefile <- st_read(tract_path, quiet = TRUE) |>
+    rename(state_shp = state)
+  nm_shp <- raw_data |>
+    left_join(shapefile, by = "GEOID")
+  # manually set state to NM
+  nm_shp = mutate(nm_shp, state = "NM") |>
+    st_as_sf()
+  nm_shp = st_transform(nm_shp, EPSG$ID)
+
+  nm_shp <- nm_shp |>
+    mutate(county = coalesce(county.x, county.y)) |>
+    select(-county.x, -county.y)
+
+  nm_shp <- nm_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+
+  # TODO any additional columns or data you want to add should go here
+
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = nm_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  # TODO feel free to delete if this dependency isn't available
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    nm_shp <- rmapshaper::ms_simplify(nm_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+
+  # create adjacency graph
+  nm_shp$adj <- redist.adjacency(nm_shp)
+
+  # TODO any custom adjacency graph edits here
+
+  write_rds(nm_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  nm_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong NM} shapefile")
+}

--- a/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/01_prep_NM_cd_1990.R
@@ -65,8 +65,6 @@ if (!file.exists(here(shp_path))) {
   # create adjacency graph
   nm_shp$adj <- redist.adjacency(nm_shp)
 
-  # TODO any custom adjacency graph edits here
-
   write_rds(nm_shp, here(shp_path), compress = "gz")
   cli_process_done()
 } else {

--- a/analyses/NM_cd_1990/02_setup_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/02_setup_NM_cd_1990.R
@@ -4,14 +4,8 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg NM_cd_1990}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(nm_shp, pop_tol = 0.005,
     existing_plan = cd_1990, adj = nm_shp$adj)
-
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,

--- a/analyses/NM_cd_1990/02_setup_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/02_setup_NM_cd_1990.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NM_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NM_cd_1990}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(nm_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = nm_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map |>
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NM_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NM_1990/NM_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
@@ -37,8 +37,6 @@ plans <- match_numbers(plans, "cd_1990")
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
-
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NM_1990/NM_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
@@ -54,7 +52,6 @@ save_summary_stats(plans, "data-out/NM_1990/NM_cd_1990_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
@@ -5,18 +5,6 @@
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NM_cd_1990}")
-
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(1990)
 plans <- redist_smc(map,
                     nsims = 2000,

--- a/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
+++ b/analyses/NM_cd_1990/03_sim_NM_cd_1990.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Simulate plans for `NM_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NM_cd_1990}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(1990)
+plans <- redist_smc(map,
+                    nsims = 2000,
+                    runs = 10,
+                    counties = pseudo_county,
+                    pop_temper = 0.05,
+                    seq_alpha  = 0.9,
+)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NM_1990/NM_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NM_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NM_1990/NM_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/NM_cd_1990/doc_NM_cd_1990.md
+++ b/analyses/NM_cd_1990/doc_NM_cd_1990.md
@@ -1,0 +1,25 @@
+# 1990 New Mexico Congressional Districts
+
+## Redistricting requirements
+In New Mexico, we consult [A GUIDE TO STATE AND CONGRESSIONAL REDISTRICTING IN NEW MEXICO](https://www.nmlegis.gov/Redistricting/Documents/134250.pdf) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. satisfy the Voting Rights Act
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for New Mexico comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for New Mexico across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/NM_cd_1990/doc_NM_cd_1990.md
+++ b/analyses/NM_cd_1990/doc_NM_cd_1990.md
@@ -11,7 +11,7 @@ In New Mexico, we consult [A GUIDE TO STATE AND CONGRESSIONAL REDISTRICTING IN N
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for New Mexico comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).


### PR DESCRIPTION
# 1990 New Mexico Congressional Districts

## Redistricting requirements
In New Mexico, we consult [A GUIDE TO STATE AND CONGRESSIONAL REDISTRICTING IN NEW MEXICO](https://www.nmlegis.gov/Redistricting/Documents/134250.pdf) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. satisfy the Voting Rights Act


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for New Mexico comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for New Mexico across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="5400" alt="validation_20251212_1425" src="https://github.com/user-attachments/assets/cca5c8a6-8c88-41ed-8c6b-62d6988d2cb0" />

```
SMC: 10,000 sampled plans of 3 districts on 390 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.9
`pop_temper`=0.05

Plan diversity 80% range: 0.16 to 0.68
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
        pop_overlap           total_vap            plan_dev           comp_edge         comp_polsby     comp_bbox_reock 
              1.001               1.002               1.002               1.000               1.000               1.002 
          pop_other           pop_white           pop_black            pop_hisp            pop_aian           pop_asian 
              1.001               1.001               1.001               1.000               1.001               1.002 
           vap_hisp            vap_aian           vap_other           vap_white           vap_black           vap_asian 
              1.001               1.001               1.001               1.001               1.001               1.001 
      county_splits total_county_splits         muni_splits   total_muni_splits                 ndv                 nrv 
              1.001               1.001               1.001               1.001               1.001               1.002 
            ndshare 
              1.002 

Sampling diagnostics for SMC run 1 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,849 (92.4%)      5.2%        0.35 1,259 (100%)      7 
Split 2     1,511 (75.6%)      3.0%        0.51 1,155 ( 91%)      5 
Resample    1,382 (69.1%)       NA%        0.50 1,603 (127%)     NA 

Sampling diagnostics for SMC run 2 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,846 (92.3%)      5.2%        0.35 1,286 (102%)      7 
Split 2     1,498 (74.9%)      3.0%        0.50 1,139 ( 90%)      5 
Resample    1,446 (72.3%)       NA%        0.50 1,636 (129%)     NA 

Sampling diagnostics for SMC run 3 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,854 (92.7%)      7.7%        0.35 1,258 (100%)      5 
Split 2     1,513 (75.6%)      3.8%        0.50 1,165 ( 92%)      4 
Resample    1,465 (73.3%)       NA%        0.49 1,625 (129%)     NA 

Sampling diagnostics for SMC run 4 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,842 (92.1%)      5.3%        0.36 1,251 ( 99%)      7 
Split 2     1,309 (65.4%)      3.6%        0.51 1,164 ( 92%)      4 
Resample    1,109 (55.5%)       NA%        0.51 1,612 (128%)     NA 

Sampling diagnostics for SMC run 5 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,843 (92.1%)      5.3%        0.36 1,263 (100%)      7 
Split 2     1,648 (82.4%)      3.6%        0.48 1,161 ( 92%)      4 
Resample    1,596 (79.8%)       NA%        0.47 1,640 (130%)     NA 

Sampling diagnostics for SMC run 6 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,845 (92.2%)      7.6%        0.36 1,250 ( 99%)      5 
Split 2     1,435 (71.7%)      4.9%        0.52 1,145 ( 91%)      3 
Resample    1,375 (68.8%)       NA%        0.51 1,608 (127%)     NA 

Sampling diagnostics for SMC run 7 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,847 (92.4%)      6.3%        0.35 1,266 (100%)      6 
Split 2     1,240 (62.0%)      3.6%        0.52 1,158 ( 92%)      4 
Resample      957 (47.8%)       NA%        0.52 1,568 (124%)     NA 

Sampling diagnostics for SMC run 8 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,841 (92.1%)      7.5%        0.36 1,241 ( 98%)      5 
Split 2     1,625 (81.3%)      4.7%        0.49 1,173 ( 93%)      3 
Resample    1,544 (77.2%)       NA%        0.49 1,649 (130%)     NA 

Sampling diagnostics for SMC run 9 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,840 (92.0%)      5.2%        0.36 1,237 ( 98%)      7 
Split 2     1,523 (76.2%)      3.7%        0.52 1,176 ( 93%)      4 
Resample    1,405 (70.2%)       NA%        0.51 1,592 (126%)     NA 

Sampling diagnostics for SMC run 10 of 10 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,848 (92.4%)      5.2%        0.36 1,248 ( 99%)      7 
Split 2     1,623 (81.1%)      3.4%        0.50 1,154 ( 91%)      4 
Resample    1,554 (77.7%)       NA%        0.50 1,598 (126%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with
`hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing constraints, or increasing the population tolerance. If the
acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko