### PR TITLE
1990 Pennsylvania Congressional Districts

### DIFF
--- a/analyses/PA_cd_1990/01_prep_PA_cd_1990.R
+++ b/analyses/PA_cd_1990/01_prep_PA_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `PA_cd_1990` analysis
+# © ALARM Project, November 2025
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg PA_cd_1990}")
+
+path_data <- download_redistricting_file("PA", "data-raw/PA", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/PA_1990/shp_vtd.rds"
+perim_path <- "data-out/PA_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong PA} shapefile")
+  # read in redistricting data
+  pa_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(state = as.character(state)) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$PA)
+  
+  pa_shp <- pa_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = pa_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    pa_shp <- rmapshaper::ms_simplify(pa_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  pa_shp$adj <- redist.adjacency(pa_shp)
+  
+  write_rds(pa_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  pa_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong PA} shapefile")
+}

--- a/analyses/PA_cd_1990/02_setup_PA_cd_1990.R
+++ b/analyses/PA_cd_1990/02_setup_PA_cd_1990.R
@@ -1,0 +1,17 @@
+###############################################################################
+# Set up redistricting simulation for `PA_cd_1990`
+# © ALARM Project, July 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg PA_cd_1990}")
+
+map <- redist_map(pa_shp, pop_tol = 0.005,
+                  existing_plan = cd_1990, adj = pa_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "PA_1990"
+
+map$state <- "PA"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/PA_1990/PA_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/PA_cd_1990/03_sim_PA_cd_1990.R
+++ b/analyses/PA_cd_1990/03_sim_PA_cd_1990.R
@@ -1,0 +1,53 @@
+###############################################################################
+# Simulate plans for `PA_cd_1990`
+# © ALARM Project, November 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg PA_cd_1990}")
+
+sampling_space_val <- tryCatch(getFromNamespace("LINKING_EDGE_SPACE", "redist"),
+                               error = function(e) "linking_edge")
+
+set.seed(1990)
+plans <- redist_smc(
+  map,
+  nsims = 1200, runs = 5,
+  counties = county,
+  pop_temper = 0.01, seq_alpha  = 0.90,
+  sampling_space = sampling_space_val,
+  ms_params = list(frequency = 1L, mh_accept_per_smc = 20),
+  split_params = list(splitting_schedule = "any_valid_sizes")
+)
+
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/PA_1990/PA_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg PA_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/PA_1990/PA_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+}

--- a/analyses/PA_cd_1990/doc_PA_cd_1990.md
+++ b/analyses/PA_cd_1990/doc_PA_cd_1990.md
@@ -1,0 +1,23 @@
+# 1990 Pennsylvania Congressional Districts
+
+## Redistricting requirements
+In Pennsylvania, there are no specific legal requirements.
+We impose the following constraints. 
+In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Pennsylvania comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 6,000 districting plans for Pennsylvania across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+We also used new algorithmic mergesplit parameters to improve mixing.


### PR DESCRIPTION
## Redistricting requirements
In Pennsylvania, there are no specific legal requirements.
We impose the following constraints. 
In our simulations, districts must:

1. be contiguous
1. have equal populations

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Pennsylvania comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 6,000 districting plans for Pennsylvania across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
We also used new algorithmic mergesplit parameters to improve mixing.

## Validation
<img width="3000" height="4500" alt="validation_20251213_1445" src="https://github.com/user-attachments/assets/8d37d2aa-3c3e-4fd6-8892-67f829d19c4a" />

```
✔ Preparing PA shapefile ... done
SMC with Merge-Split MCMC Steps: 5,000 sampled plans of 21 districts on 3,168
units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge
forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.01
Mergesplit Parameters:
• `total_ms_steps` = 20
• `mh_accept_per_smc` = 20
• `pair_rule` = uniform
Plan diversity 80% range: 0.63 to 0.79
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare 
        1.001         1.003         1.001         1.002         1.008 
          ndv           nrv      plan_dev      pop_aian     pop_asian 
        1.010         1.013         1.000         1.010         1.009 
    pop_black      pop_hisp     pop_other   pop_overlap     pop_white 
        1.008         1.016         1.010         1.008         1.006 
    total_vap      vap_aian     vap_asian     vap_black      vap_hisp 
        1.004         1.007         1.011         1.006         1.013 
    vap_other     vap_white 
        1.005         1.011 
• R-hat ≤ 1.05: 462
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 462
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       335 (27.9%)     99.8%        1.22   760 (100%) 
Split 2       521 (43.4%)     87.1%        1.05   512 ( 67%) 
Split 3       658 (54.8%)     74.2%        0.88   589 ( 78%) 
Split 4       674 (56.2%)     63.3%        0.77   604 ( 80%) 
Split 5       751 (62.6%)     54.2%        0.71   628 ( 83%) 
Split 6       814 (67.9%)     45.1%        0.63   653 ( 86%) 
Split 7       872 (72.7%)     40.6%        0.58   669 ( 88%) 
Split 8       914 (76.2%)     35.0%        0.53   679 ( 90%) 
Split 9       948 (79.0%)     30.5%        0.49   679 ( 90%) 
Split 10      988 (82.3%)     27.5%        0.45   684 ( 90%) 
Split 11      998 (83.2%)     24.7%        0.43   695 ( 92%) 
Split 12    1,023 (85.3%)     23.2%        0.39   701 ( 92%) 
Split 13    1,067 (88.9%)     20.9%        0.35   687 ( 91%) 
Split 14    1,080 (90.0%)     18.6%        0.32   706 ( 93%) 
Split 15    1,104 (92.0%)     16.0%        0.30   695 ( 92%) 
Split 16    1,118 (93.1%)     15.1%        0.27   695 ( 92%) 
Split 17    1,132 (94.3%)     13.2%        0.25   713 ( 94%) 
Split 18    1,145 (95.4%)     11.1%        0.22   689 ( 91%) 
Split 19    1,156 (96.3%)     11.3%        0.19   678 ( 89%) 
Split 20    1,171 (97.6%)      9.2%        0.16   656 ( 86%) 
Resample    1,171 (97.6%)       NA%          NA 1,127 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      43.8%                40
MS Step 2      41.2%                60
MS Step 3      38.6%                60
MS Step 4      36.0%                60
MS Step 5      33.3%                60
MS Step 6      30.8%                80
MS Step 7      28.7%                80
MS Step 8      26.6%                80
MS Step 9      24.8%                80
MS Step 10     22.7%               100
MS Step 11     21.3%               100
MS Step 12     20.0%               100
MS Step 13     18.5%               100
MS Step 14     17.6%               120
MS Step 15     16.4%               120
MS Step 16     15.4%               140
MS Step 17     14.6%               140
MS Step 18     13.9%               140
MS Step 19     13.3%               160
MS Step 20     12.4%               160

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       377 (31.4%)     99.9%        1.17   759 (100%) 
Split 2       574 (47.8%)     86.4%        1.00   524 ( 69%) 
Split 3       579 (48.2%)     71.7%        0.93   604 ( 80%) 
Split 4       614 (51.2%)     60.1%        0.81   614 ( 81%) 
Split 5       798 (66.5%)     54.9%        0.67   625 ( 82%) 
Split 6       830 (69.2%)     46.9%        0.62   666 ( 88%) 
Split 7       859 (71.6%)     40.4%        0.58   675 ( 89%) 
Split 8       888 (74.0%)     36.0%        0.54   671 ( 88%) 
Split 9       919 (76.6%)     32.5%        0.51   676 ( 89%) 
Split 10      975 (81.3%)     28.0%        0.45   664 ( 88%) 
Split 11    1,009 (84.1%)     23.7%        0.43   684 ( 90%) 
Split 12    1,022 (85.1%)     22.5%        0.41   684 ( 90%) 
Split 13    1,050 (87.5%)     19.3%        0.36   679 ( 90%) 
Split 14    1,061 (88.4%)     18.4%        0.35   691 ( 91%) 
Split 15    1,094 (91.2%)     15.2%        0.31   701 ( 92%) 
Split 16    1,108 (92.3%)     14.2%        0.28   696 ( 92%) 
Split 17    1,128 (94.0%)     12.9%        0.25   687 ( 91%) 
Split 18    1,142 (95.2%)     11.9%        0.23   683 ( 90%) 
Split 19    1,152 (96.0%)     12.1%        0.20   675 ( 89%) 
Split 20    1,171 (97.6%)      9.0%        0.16   646 ( 85%) 
Resample    1,171 (97.6%)       NA%          NA 1,139 (150%) 

Sampling diagnostics for Mergesplit Steps of SMC run 2 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      44.2%                40
MS Step 2      40.5%                60
MS Step 3      38.0%                60
MS Step 4      35.8%                60
MS Step 5      33.1%                60
MS Step 6      30.8%                80
MS Step 7      28.7%                80
MS Step 8      26.6%                80
MS Step 9      24.8%                80
MS Step 10     22.8%               100
MS Step 11     21.3%               100
MS Step 12     20.0%               100
MS Step 13     19.0%               120
MS Step 14     17.7%               120
MS Step 15     16.6%               120
MS Step 16     15.7%               140
MS Step 17     14.8%               140
MS Step 18     13.8%               140
MS Step 19     13.1%               160
MS Step 20     12.0%               160

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       408 (34.0%)     99.9%        1.18   743 ( 98%) 
Split 2       535 (44.6%)     87.2%        1.02   557 ( 73%) 
Split 3       628 (52.4%)     71.9%        0.90   573 ( 76%) 
Split 4       716 (59.7%)     64.2%        0.76   596 ( 79%) 
Split 5       783 (65.2%)     53.0%        0.69   643 ( 85%) 
Split 6       805 (67.1%)     46.2%        0.63   673 ( 89%) 
Split 7       832 (69.3%)     38.8%        0.62   651 ( 86%) 
Split 8       896 (74.7%)     35.8%        0.52   679 ( 90%) 
Split 9       942 (78.5%)     32.0%        0.49   688 ( 91%) 
Split 10      996 (83.0%)     27.7%        0.44   682 ( 90%) 
Split 11    1,012 (84.3%)     24.1%        0.42   700 ( 92%) 
Split 12    1,032 (86.0%)     21.7%        0.39   700 ( 92%) 
Split 13    1,063 (88.6%)     19.6%        0.35   682 ( 90%) 
Split 14    1,080 (90.0%)     17.0%        0.32   710 ( 94%) 
Split 15    1,098 (91.5%)     16.1%        0.30   704 ( 93%) 
Split 16    1,108 (92.4%)     13.7%        0.29   689 ( 91%) 
Split 17    1,130 (94.2%)     12.9%        0.25   700 ( 92%) 
Split 18    1,146 (95.5%)     11.5%        0.22   686 ( 90%) 
Split 19    1,155 (96.3%)     10.2%        0.20   661 ( 87%) 
Split 20    1,171 (97.6%)      9.0%        0.16   674 ( 89%) 
Resample    1,171 (97.6%)       NA%          NA 1,123 (148%) 

Sampling diagnostics for Mergesplit Steps of SMC run 3 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      44.0%                40
MS Step 2      41.0%                60
MS Step 3      38.5%                60
MS Step 4      35.9%                60
MS Step 5      33.3%                60
MS Step 6      31.0%                80
MS Step 7      28.6%                80
MS Step 8      26.0%                80
MS Step 9      24.6%                80
MS Step 10     23.1%               100
MS Step 11     21.3%               100
MS Step 12     20.0%               100
MS Step 13     18.7%               100
MS Step 14     17.3%               120
MS Step 15     16.2%               120
MS Step 16     15.3%               140
MS Step 17     14.5%               140
MS Step 18     13.5%               140
MS Step 19     12.7%               160
MS Step 20     11.9%               160

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       348 (29.0%)    100.0%        1.16   755 (100%) 
Split 2       519 (43.2%)     86.5%        1.05   564 ( 74%) 
Split 3       619 (51.6%)     72.8%        0.85   582 ( 77%) 
Split 4       691 (57.6%)     62.0%        0.78   629 ( 83%) 
Split 5       763 (63.6%)     52.7%        0.72   651 ( 86%) 
Split 6       799 (66.6%)     45.5%        0.65   655 ( 86%) 
Split 7       891 (74.3%)     40.8%        0.58   651 ( 86%) 
Split 8       923 (76.9%)     35.4%        0.52   687 ( 91%) 
Split 9       963 (80.3%)     29.8%        0.48   686 ( 90%) 
Split 10      969 (80.7%)     27.7%        0.47   681 ( 90%) 
Split 11      995 (82.9%)     23.6%        0.43   687 ( 91%) 
Split 12    1,022 (85.2%)     22.0%        0.40   678 ( 89%) 
Split 13    1,050 (87.5%)     19.6%        0.36   697 ( 92%) 
Split 14    1,073 (89.4%)     17.8%        0.34   681 ( 90%) 
Split 15    1,091 (90.9%)     16.4%        0.31   684 ( 90%) 
Split 16    1,114 (92.9%)     14.9%        0.28   701 ( 92%) 
Split 17    1,131 (94.3%)     13.7%        0.25   696 ( 92%) 
Split 18    1,133 (94.5%)     12.4%        0.24   674 ( 89%) 
Split 19    1,155 (96.2%)     11.9%        0.20   689 ( 91%) 
Split 20    1,169 (97.4%)      9.3%        0.16   660 ( 87%) 
Resample    1,169 (97.4%)       NA%          NA 1,126 (148%) 

Sampling diagnostics for Mergesplit Steps of SMC run 4 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      46.6%                20
MS Step 2      40.8%                60
MS Step 3      38.4%                60
MS Step 4      36.3%                60
MS Step 5      33.4%                60
MS Step 6      30.5%                60
MS Step 7      28.4%                80
MS Step 8      26.5%                80
MS Step 9      24.6%                80
MS Step 10     22.8%               100
MS Step 11     21.1%               100
MS Step 12     20.0%               100
MS Step 13     18.3%               120
MS Step 14     17.3%               120
MS Step 15     16.1%               120
MS Step 16     15.2%               140
MS Step 17     14.5%               140
MS Step 18     13.6%               140
MS Step 19     13.1%               160
MS Step 20     12.3%               160

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       460 (38.3%)    100.0%        1.19   767 (101%) 
Split 2       481 (40.1%)     85.3%        1.07   546 ( 72%) 
Split 3       574 (47.8%)     73.0%        0.94   565 ( 74%) 
Split 4       693 (57.8%)     62.9%        0.79   604 ( 80%) 
Split 5       776 (64.6%)     52.2%        0.70   657 ( 87%) 
Split 6       821 (68.4%)     45.6%        0.63   663 ( 87%) 
Split 7       860 (71.6%)     41.1%        0.59   651 ( 86%) 
Split 8       877 (73.0%)     33.1%        0.54   688 ( 91%) 
Split 9       952 (79.3%)     31.7%        0.48   670 ( 88%) 
Split 10      985 (82.1%)     28.2%        0.46   696 ( 92%) 
Split 11    1,013 (84.4%)     23.5%        0.41   690 ( 91%) 
Split 12    1,030 (85.9%)     21.1%        0.39   697 ( 92%) 
Split 13    1,053 (87.8%)     20.7%        0.36   665 ( 88%) 
Split 14    1,069 (89.1%)     18.8%        0.34   697 ( 92%) 
Split 15    1,093 (91.1%)     16.5%        0.32   693 ( 91%) 
Split 16    1,119 (93.3%)     15.1%        0.27   684 ( 90%) 
Split 17    1,132 (94.4%)     13.9%        0.25   673 ( 89%) 
Split 18    1,149 (95.7%)     11.8%        0.22   708 ( 93%) 
Split 19    1,159 (96.6%)     10.7%        0.19   654 ( 86%) 
Split 20    1,172 (97.6%)      9.8%        0.15   647 ( 85%) 
Resample    1,172 (97.6%)       NA%          NA 1,121 (148%) 

Sampling diagnostics for Mergesplit Steps of SMC run 5 of 5 (5,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      46.5%                20
MS Step 2      41.2%                60
MS Step 3      38.6%                60
MS Step 4      35.3%                60
MS Step 5      33.2%                60
MS Step 6      30.7%                80
MS Step 7      28.6%                80
MS Step 8      26.3%                80
MS Step 9      24.5%                80
MS Step 10     22.8%               100
MS Step 11     21.4%               100
MS Step 12     19.7%               100
MS Step 13     18.6%               120
MS Step 14     17.5%               120
MS Step 15     16.3%               120
MS Step 16     15.2%               140
MS Step 17     14.2%               140
MS Step 18     13.6%               160
MS Step 19     12.9%               160
MS Step 20     12.2%               160

•  Watch out for low effective samples, very low acceptance rates (less than
1%), large std. devs. of the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@philipwosull 