### PR TITLE
1990 New Jersey Congressional Districts

### DIFF
--- a/R/logit_shift.R
+++ b/R/logit_shift.R
@@ -24,11 +24,11 @@ logit_shift_baseline <- function(d_baseline, ndv, nrv,
   nrv_vec <- dplyr::pull(d_baseline, !!nrv_q)
 
   turn <- ndv_vec + nrv_vec
-  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
+  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec + 0.5) - log(nrv_vec + 0.5), 0)
 
   res <- uniroot(function(shift) {
     stats::weighted.mean(plogis(ldvs + shift), turn) - target
-  }, c(-1, 1), tol = tol)
+  }, c(-1, 1), extendInt = "yes", tol = tol)
 
   ldvs <- ldvs + res$root
 

--- a/R/logit_shift.R
+++ b/R/logit_shift.R
@@ -24,11 +24,11 @@ logit_shift_baseline <- function(d_baseline, ndv, nrv,
   nrv_vec <- dplyr::pull(d_baseline, !!nrv_q)
 
   turn <- ndv_vec + nrv_vec
-  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec + 0.5) - log(nrv_vec + 0.5), 0)
+  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
 
   res <- uniroot(function(shift) {
     stats::weighted.mean(plogis(ldvs + shift), turn) - target
-  }, c(-1, 1), extendInt = "yes", tol = tol)
+  }, c(-1, 1), tol = tol)
 
   ldvs <- ldvs + res$root
 

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -1,0 +1,66 @@
+###############################################################################
+# Download and prepare data for `NJ_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NJ_cd_1990}")
+
+path_data <- download_redistricting_file("NJ", "data-raw/NJ", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NJ_1990/shp_vtd.rds"
+perim_path <- "data-out/NJ_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NJ} shapefile")
+    # read in redistricting data
+    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$NJ)
+
+    nj_shp <- nj_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nj_shp,
+                               perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nj_shp$adj <- redist.adjacency(nj_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    write_rds(nj_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nj_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NJ} shapefile")
+}

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -43,15 +43,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
         relocate(muni, county_muni, cd_1980, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = nj_shp,
                                perim_path = here(perim_path)) |>
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
                                                  keep_shapes = TRUE) |>
@@ -60,8 +57,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     nj_shp$adj <- redist.adjacency(nj_shp)
-
-    # TODO any custom adjacency graph edits here
 
     write_rds(nj_shp, here(shp_path), compress = "gz")
     cli_process_done()

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -30,6 +30,11 @@ if (!file.exists(here(shp_path))) {
     cli_process_start("Preparing {.strong NJ} shapefile")
     # read in redistricting data
     nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(
+          state  = as.character(state),
+          county = as.character(county),
+          tract  = as.character(tract)
+        ) |>
         join_vtd_shapefile(year = 1990) |>
         st_transform(EPSG$NJ)
 

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -26,69 +26,73 @@ cli_process_done()
 shp_path <- "data-out/NJ_1990/shp_vtd.rds"
 perim_path <- "data-out/NJ_1990/perim.rds"
 
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NJ} shapefile")
+    # read in redistricting data
+    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(
+          state  = as.character(state),
+          county = as.character(county),
+          tract  = as.character(tract)
+        ) |>
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$NJ)
 
-cli_process_start("Preparing {.strong NJ} shapefile")
-# read in redistricting data
-nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
-    mutate(
-        state  = as.character(state),
-        county = as.character(county),
-        tract  = as.character(tract)
-    ) |>
-    join_vtd_shapefile(year = 1990) |>
-    st_transform(EPSG$NJ)
+    nj_shp <- nj_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
 
-nj_shp <- nj_shp |>
-    rename(muni = place) |>
-    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
-    relocate(muni, county_muni, cd_1980, .after = county)
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nj_shp,
+                               perim_path = here(perim_path)) |>
+        invisible()
 
-# Create perimeters in case shapes are simplified
-redistmetrics::prep_perims(shp = nj_shp,
-                            perim_path = here(perim_path)) |>
-    invisible()
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
 
-# simplifies geometry for faster processing, plotting, and smaller shapefiles
-if (requireNamespace("rmapshaper", quietly = TRUE)) {
-    nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
-                                                keep_shapes = TRUE) |>
-        suppressWarnings()
+    # create adjacency graph
+    nj_shp$adj <- redist.adjacency(nj_shp)
+
+
+    ###############################################################################
+    # Logit-shift ndv/nrv to match 2000 MEDSL county results
+    ###############################################################################
+
+    # 1. Load the MEDSL county CSV as `medsl_cty` ----
+    medsl_cty <- read_csv(
+        here("data-raw/baseline_voteshare_medsl_00.csv"),
+        show_col_types = FALSE
+    )
+
+    # 2. Add county_fips column based on VTD GEOID ----
+    nj_shp <- nj_shp |>
+        mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
+
+    names(nj_shp)
+
+    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    nj_shp <- nj_shp |>
+        group_by(county_fips) |>
+        group_split() |>
+        lapply(function(x) {
+            meds <- medsl_cty |>
+                filter(county == x$county_fips[1])
+            target <- meds$dshare_00[1]
+
+            if (is.na(target)) return(x)
+
+            logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+        }) |>
+        bind_rows()
+
+    write_rds(nj_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nj_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NJ} shapefile")
 }
-
-# create adjacency graph
-nj_shp$adj <- redist.adjacency(nj_shp)
-
-
-###############################################################################
-# Logit-shift ndv/nrv to match 2000 MEDSL county results
-###############################################################################
-
-# 1. Load the MEDSL county CSV as `medsl_cty` ----
-medsl_cty <- read_csv(
-    here("data-raw/baseline_voteshare_medsl_00.csv"),
-    show_col_types = FALSE
-)
-
-# 2. Add county_fips column based on VTD GEOID ----
-nj_shp <- nj_shp |>
-    mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
-
-names(nj_shp)
-
-# 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
-nj_shp <- nj_shp |>
-    group_by(county_fips) |>
-    group_split() |>
-    lapply(function(x) {
-        meds <- medsl_cty |>
-            filter(county == x$county_fips[1])
-        target <- meds$dshare_00[1]
-
-        if (is.na(target)) return(x)
-
-        logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
-    }) |>
-    bind_rows()
-
-write_rds(nj_shp, here(shp_path), compress = "gz")
-cli_process_done()

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -26,73 +26,69 @@ cli_process_done()
 shp_path <- "data-out/NJ_1990/shp_vtd.rds"
 perim_path <- "data-out/NJ_1990/perim.rds"
 
-if (!file.exists(here(shp_path))) {
-    cli_process_start("Preparing {.strong NJ} shapefile")
-    # read in redistricting data
-    nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
-        mutate(
-          state  = as.character(state),
-          county = as.character(county),
-          tract  = as.character(tract)
-        ) |>
-        join_vtd_shapefile(year = 1990) |>
-        st_transform(EPSG$NJ)
 
-    nj_shp <- nj_shp |>
-        rename(muni = place) |>
-        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
-        relocate(muni, county_muni, cd_1980, .after = county)
+cli_process_start("Preparing {.strong NJ} shapefile")
+# read in redistricting data
+nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(
+        state  = as.character(state),
+        county = as.character(county),
+        tract  = as.character(tract)
+    ) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$NJ)
 
-    # Create perimeters in case shapes are simplified
-    redistmetrics::prep_perims(shp = nj_shp,
-                               perim_path = here(perim_path)) |>
-        invisible()
+nj_shp <- nj_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
 
-    # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    if (requireNamespace("rmapshaper", quietly = TRUE)) {
-        nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) |>
-            suppressWarnings()
-    }
+# Create perimeters in case shapes are simplified
+redistmetrics::prep_perims(shp = nj_shp,
+                            perim_path = here(perim_path)) |>
+    invisible()
 
-    # create adjacency graph
-    nj_shp$adj <- redist.adjacency(nj_shp)
-
-
-    ###############################################################################
-    # Logit-shift ndv/nrv to match 2000 MEDSL county results
-    ###############################################################################
-
-    # 1. Load the MEDSL county CSV as `medsl_cty` ----
-    medsl_cty <- read_csv(
-        here("data-raw/baseline_voteshare_medsl_00.csv"),
-        show_col_types = FALSE
-    )
-
-    # 2. Add county_fips column based on VTD GEOID ----
-    nj_shp <- nj_shp |>
-        mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
-
-    names(nj_shp)
-
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
-    nj_shp <- nj_shp |>
-        group_by(county_fips) |>
-        group_split() |>
-        lapply(function(x) {
-            meds <- medsl_cty |>
-                filter(county == x$county_fips[1])
-            target <- meds$dshare_00[1]
-
-            if (is.na(target)) return(x)
-
-            logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
-        }) |>
-        bind_rows()
-
-    write_rds(nj_shp, here(shp_path), compress = "gz")
-    cli_process_done()
-} else {
-    nj_shp <- read_rds(here(shp_path))
-    cli_alert_success("Loaded {.strong NJ} shapefile")
+# simplifies geometry for faster processing, plotting, and smaller shapefiles
+if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
+                                                keep_shapes = TRUE) |>
+        suppressWarnings()
 }
+
+# create adjacency graph
+nj_shp$adj <- redist.adjacency(nj_shp)
+
+
+###############################################################################
+# Logit-shift ndv/nrv to match 2000 MEDSL county results
+###############################################################################
+
+# 1. Load the MEDSL county CSV as `medsl_cty` ----
+medsl_cty <- read_csv(
+    here("data-raw/baseline_voteshare_medsl_00.csv"),
+    show_col_types = FALSE
+)
+
+# 2. Add county_fips column based on VTD GEOID ----
+nj_shp <- nj_shp |>
+    mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
+
+names(nj_shp)
+
+# 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+nj_shp <- nj_shp |>
+    group_by(county_fips) |>
+    group_split() |>
+    lapply(function(x) {
+        meds <- medsl_cty |>
+            filter(county == x$county_fips[1])
+        target <- meds$dshare_00[1]
+
+        if (is.na(target)) return(x)
+
+        logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+    }) |>
+    bind_rows()
+
+write_rds(nj_shp, here(shp_path), compress = "gz")
+cli_process_done()

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -58,6 +58,38 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     nj_shp$adj <- redist.adjacency(nj_shp)
 
+
+    ###############################################################################
+    # Logit-shift ndv/nrv to match 2000 MEDSL county results
+    ###############################################################################
+
+    # 1. Load the MEDSL county CSV as `medsl_cty` ----
+    medsl_cty <- read_csv(
+        here("data-raw/baseline_voteshare_medsl_00.csv"),
+        show_col_types = FALSE
+    )
+
+    # 2. Add county_fips column based on VTD GEOID ----
+    nj_shp <- nj_shp |>
+        mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
+
+    names(nj_shp)
+
+    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    nj_shp <- nj_shp |>
+        group_by(county_fips) |>
+        group_split() |>
+        lapply(function(x) {
+            meds <- medsl_cty |>
+                filter(county == x$county_fips[1])
+            target <- meds$dshare_00[1]
+
+            if (is.na(target)) return(x)
+
+            logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+        }) |>
+        bind_rows()
+
     write_rds(nj_shp, here(shp_path), compress = "gz")
     cli_process_done()
 } else {

--- a/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/01_prep_NJ_cd_1990.R
@@ -31,9 +31,9 @@ if (!file.exists(here(shp_path))) {
     # read in redistricting data
     nj_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
         mutate(
-          state  = as.character(state),
-          county = as.character(county),
-          tract  = as.character(tract)
+            state  = as.character(state),
+            county = as.character(county),
+            tract  = as.character(tract)
         ) |>
         join_vtd_shapefile(year = 1990) |>
         st_transform(EPSG$NJ)
@@ -45,13 +45,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = nj_shp,
-                               perim_path = here(perim_path)) |>
+        perim_path = here(perim_path)) |>
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         nj_shp <- rmapshaper::ms_simplify(nj_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) |>
+            keep_shapes = TRUE) |>
             suppressWarnings()
     }
 

--- a/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
@@ -4,20 +4,13 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_1990}")
 
-# TODO any pre-computation (usually not necessary)
-
 map <- redist_map(nj_shp, pop_tol = 0.005,
     existing_plan = cd_1990, adj = nj_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NJ_1990"

--- a/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
@@ -1,0 +1,27 @@
+###############################################################################
+# Set up redistricting simulation for `NJ_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NJ_cd_1990}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(nj_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = nj_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map |>
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NJ_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NJ_1990/NJ_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/02_setup_NJ_cd_1990.R
@@ -10,7 +10,7 @@ map <- redist_map(nj_shp, pop_tol = 0.005,
 # make pseudo counties with default settings
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
-                                            pop_muni = get_target(map)))
+        pop_muni = get_target(map)))
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "NJ_1990"

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -6,21 +6,8 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NJ_cd_1990}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(1990)
 plans <- redist_smc(map, nsims = 1e4, runs = 5, counties = county, pop_temper = 0.015)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 plans <- plans |>
     group_by(chain) |>
@@ -30,8 +17,6 @@ plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NJ_1990/NJ_cd_1990_plans.rds"), compress = "xz")
@@ -48,7 +33,6 @@ save_summary_stats(plans, "data-out/NJ_1990/NJ_cd_1990_stats.csv")
 cli_process_done()
 
 # Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `NJ_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NJ_cd_1990}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NJ_1990/NJ_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NJ_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NJ_1990/NJ_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -18,7 +18,7 @@ cli_process_start("Running simulations for {.pkg NJ_cd_1990}")
 #  if that's the problem.
 #  - Ask for help!
 set.seed(1990)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+plans <- redist_smc(map, nsims = 1e4, runs = 5, counties = county, pop_temper = 0.015)
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
 # make sure to call `pullback()` on this plans object!
 

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -20,7 +20,7 @@ constr <- redist_constr(map) |>
     )
 
 set.seed(1990)
-plans <- redist_smc(map, nsims = 3e3, runs = 5,
+plans <- redist_smc(map, nsims = 5e3, runs = 5,
     counties = county, constraints = constr,
     split_params = list(splitting_schedule = "any_valid_sizes"),
     sampling_space = "spanning_forest",

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -6,8 +6,28 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg NJ_cd_1990}")
 
+BVAP_THRESH  <- 0.40
+DEM_THRESH   <- 0.50
+ndists <- attr(map, "ndists")
+constr <- redist_constr(map) |>
+    add_constr_min_group_frac(
+        strength = -1,
+        group_pops = list(map$vap_black, map$ndv),
+        total_pops = list(map$vap, map$nrv + map$ndv),
+        min_fracs = c(BVAP_THRESH, DEM_THRESH),
+        thresh = -.9,
+        only_nregions = seq.int(2, ndists)
+    )
+
 set.seed(1990)
-plans <- redist_smc(map, nsims = 1e4, runs = 5, counties = county, pop_temper = 0.015)
+plans <- redist_smc(map, nsims = 3e3, runs = 6,
+    counties = county, constraints = constr,
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    sampling_space = "spanning_forest",
+    ms_params = list(frequency = -5, mh_accept_per_smc = 50),
+    pop_temper = 0.01,
+    ncores = 112,
+    verbose = TRUE)
 
 plans <- plans |>
     group_by(chain) |>

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -20,7 +20,7 @@ constr <- redist_constr(map) |>
     )
 
 set.seed(1990)
-plans <- redist_smc(map, nsims = 5e3, runs = 5,
+plans <- redist_smc(map, nsims = 2e4, runs = 5,
     counties = county, constraints = constr,
     split_params = list(splitting_schedule = "any_valid_sizes"),
     sampling_space = "spanning_forest",

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -20,7 +20,7 @@ constr <- redist_constr(map) |>
     )
 
 set.seed(1990)
-plans <- redist_smc(map, nsims = 3e3, runs = 6,
+plans <- redist_smc(map, nsims = 3e3, runs = 5,
     counties = county, constraints = constr,
     split_params = list(splitting_schedule = "any_valid_sizes"),
     sampling_space = "spanning_forest",
@@ -41,6 +41,18 @@ cli_process_start("Saving {.cls redist_plans} object")
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/NJ_1990/NJ_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
+
+# read in from FASRC
+map <- readRDS(
+  here("data-out/NJ_1990/NJ_cd_1990_map.rds")
+)
+plans <- readRDS(
+  here("data-out/NJ_1990/NJ_cd_1990_plans.rds")
+)
+stats <- read_csv(
+  here("data-out/NJ_1990/NJ_cd_1990_stats.csv"),
+  show_col_types = FALSE
+)
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg NJ_cd_1990}")

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -37,6 +37,34 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-    validate_analysis(plans, map)
-    summary(plans)
+  validate_analysis(plans, map)
+  summary(plans)
+
+  redist.plot.distr_qtys(
+    plans, vap_black/total_vap,
+    color_thresh = NULL,
+    color = ifelse(
+      subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+      "#3D77BB", "#B25D4C"),
+    size = 0.5, alpha = 0.5) +
+    scale_y_continuous("Percent Black by VAP") +
+    labs(title = "Partisanship of seats by BVAP rank") +
+    scale_color_manual(values = c(cd_2000 = "black"))
+
+  # Dem seats by BVAP rank -- numeric
+  plans %>%
+    group_by(draw) %>%
+    mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+    subset_sampled() %>%
+    select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+    mutate(dem = ndv > nrv) %>%
+    group_by(bvap_rank) %>%
+    summarize(dem = mean(dem))
+
+  # Total Black districts that are performing
+  plans %>%
+    subset_sampled() %>%
+    group_by(draw) %>%
+    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+    count(n_black_perf)
 }

--- a/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
+++ b/analyses/NJ_cd_1990/03_sim_NJ_cd_1990.R
@@ -44,14 +44,14 @@ cli_process_done()
 
 # read in from FASRC
 map <- readRDS(
-  here("data-out/NJ_1990/NJ_cd_1990_map.rds")
+    here("data-out/NJ_1990/NJ_cd_1990_map.rds")
 )
 plans <- readRDS(
-  here("data-out/NJ_1990/NJ_cd_1990_plans.rds")
+    here("data-out/NJ_1990/NJ_cd_1990_plans.rds")
 )
 stats <- read_csv(
-  here("data-out/NJ_1990/NJ_cd_1990_stats.csv"),
-  show_col_types = FALSE
+    here("data-out/NJ_1990/NJ_cd_1990_stats.csv"),
+    show_col_types = FALSE
 )
 
 # Compute summary statistics -----
@@ -69,34 +69,34 @@ if (interactive()) {
     library(ggplot2)
     library(patchwork)
 
-  validate_analysis(plans, map)
-  summary(plans)
+    validate_analysis(plans, map)
+    summary(plans)
 
-  redist.plot.distr_qtys(
-    plans, vap_black/total_vap,
-    color_thresh = NULL,
-    color = ifelse(
-      subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
-      "#3D77BB", "#B25D4C"),
-    size = 0.5, alpha = 0.5) +
-    scale_y_continuous("Percent Black by VAP") +
-    labs(title = "Partisanship of seats by BVAP rank") +
-    scale_color_manual(values = c(cd_2000 = "black"))
+    redist.plot.distr_qtys(
+        plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(
+            subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+            "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Partisanship of seats by BVAP rank") +
+        scale_color_manual(values = c(cd_2000 = "black"))
 
-  # Dem seats by BVAP rank -- numeric
-  plans %>%
-    group_by(draw) %>%
-    mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
-    subset_sampled() %>%
-    select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
-    mutate(dem = ndv > nrv) %>%
-    group_by(bvap_rank) %>%
-    summarize(dem = mean(dem))
+    # Dem seats by BVAP rank -- numeric
+    plans %>%
+        group_by(draw) %>%
+        mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) %>%
+        subset_sampled() %>%
+        select(draw, district, bvap, bvap_rank, ndv, nrv) %>%
+        mutate(dem = ndv > nrv) %>%
+        group_by(bvap_rank) %>%
+        summarize(dem = mean(dem))
 
-  # Total Black districts that are performing
-  plans %>%
-    subset_sampled() %>%
-    group_by(draw) %>%
-    summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
-    count(n_black_perf)
+    # Total Black districts that are performing
+    plans %>%
+        subset_sampled() %>%
+        group_by(draw) %>%
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) %>%
+        count(n_black_perf)
 }

--- a/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
+++ b/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
@@ -10,7 +10,7 @@ In New Jersey, we consult [NCSL Redistricting Law 2000](https://web.archive.org/
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of X.X%.
+We enforce a maximum population deviation of 0.5%.
 
 ## Data Sources
 Data for New Jersey comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
@@ -19,6 +19,6 @@ Data for New Jersey comes from the [ALARM Project's update](https://dataverse.ha
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
+We sample 50,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
 No special techniques were needed to produce the sample.

--- a/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
+++ b/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
@@ -1,0 +1,24 @@
+# 1990 New Jersey Congressional Districts
+
+## Redistricting requirements
+In New Jersey, we consult [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of X.X%.
+
+## Data Sources
+Data for New Jersey comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
+++ b/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
@@ -19,6 +19,6 @@ Data for New Jersey comes from the [ALARM Project's update](https://dataverse.ha
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 50,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
+We sample 25,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
 No special techniques were needed to produce the sample.

--- a/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
+++ b/analyses/NJ_cd_1990/doc_NJ_cd_1990.md
@@ -19,6 +19,6 @@ Data for New Jersey comes from the [ALARM Project's update](https://dataverse.ha
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 25,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
+We sample 100,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
 No special techniques were needed to produce the sample.


### PR DESCRIPTION
# 1990 New Jersey Congressional Districts

## Redistricting requirements
In New Jersey, we consult [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for New Jersey comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 50,000 districting plans for New Jersey across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/6f452ab5-a7cc-4581-a17b-dfe9a5cda325" />

<img width="881" height="533" alt="image" src="https://github.com/user-attachments/assets/7e7e00c4-3356-4038-922c-6757407f2be2" />


```
SMC with Merge-Split MCMC Steps: 5,000 sampled plans of 13 districts on 1,944 units
Plans sampled on Spanning Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.01
Mergesplit Parameters:
• `total_ms_steps` = 5
• `mh_accept_per_smc` = 50
• `pair_rule` = uniform
Plan diversity 80% range: 0.34 to 0.57
Largest R-hat values for ordered summary statistics:
    comp_bbox_reock           comp_edge         comp_polsby       county_splits         muni_splits 
              1.002               1.001               1.002               1.001               1.001 
            ndshare                 ndv                 nrv            plan_dev            pop_aian 
              1.011               1.002               1.004               1.000               1.009 
          pop_asian           pop_black            pop_hisp           pop_other         pop_overlap 
              1.014               1.010               1.007               1.011               1.001 
          pop_white total_county_splits   total_muni_splits           total_vap            vap_aian 
              1.009               1.000               1.001               1.008               1.006 
          vap_asian           vap_black            vap_hisp           vap_other           vap_white 
              1.006               1.012               1.006               1.010               1.007 
• R-hat ≤ 1.05: 325
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 325
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique 
Split 1    14,203 (71.0%)      0.5%        0.69 12,591 (100%) 
Split 2     7,189 (35.9%)     97.5%        1.04 11,411 ( 90%) 
Split 3    10,435 (52.2%)     68.0%        0.78  9,346 ( 74%) 
Split 4    12,962 (64.8%)     48.6%        0.63 10,341 ( 82%) 
Split 5    14,578 (72.9%)     36.1%        0.54 10,958 ( 87%) 
Split 6    15,669 (78.3%)     27.7%        0.47 11,290 ( 89%) 
Split 7    16,488 (82.4%)     21.7%        0.42 11,358 ( 90%) 
Split 8    17,275 (86.4%)     17.6%        0.38 11,367 ( 90%) 
Split 9    17,825 (89.1%)     14.8%        0.34 11,130 ( 88%) 
Split 10   18,297 (91.5%)     12.6%        0.30 11,117 ( 88%) 
Split 11   18,790 (94.0%)     10.8%        0.26 10,881 ( 86%) 
Split 12   19,358 (96.8%)      9.2%        0.19 10,464 ( 83%) 
Resample   19,358 (96.8%)       NA%          NA 18,532 (147%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     36.4%               300
MS Step 2     37.7%               150
MS Step 3     39.2%               150
MS Step 4     40.6%               150
MS Step 5     41.9%               150

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of
the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

```
  n_black_perf    n
1            1 5000
```

```
# A tibble: 13 × 2
   bvap_rank   dem
       <dbl> <dbl>
 1         1 0.082
 2         2 0.826
 3         3 0.964
 4         4 0.993
 5         5 0.992
 6         6 0.948
 7         7 0.987
 8         8 0.999
 9         9 1    
10        10 1    
11        11 1    
12        12 1    
13        13 1    
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko