### PR TITLE
1990 Arizona Congressional Districts

### DIFF
--- a/analyses/AZ_cd_1990/01_prep_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/01_prep_AZ_cd_1990.R
@@ -1,0 +1,78 @@
+###############################################################################
+# Download and prepare data for `AZ_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AZ_cd_1990}")
+
+path_data <- download_redistricting_file("AZ", "data-raw/AZ", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AZ_1990/shp_vtd.rds"
+perim_path <- "data-out/AZ_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AZ} shapefile")
+    # read in redistricting data
+    tract_path = "data-raw/AZ/04_tracts.gpkg"
+    raw_data <- read_csv(here(path_data), col_types = cols(GEOID = "c"))
+    raw_data$state = as.character(raw_data$state)
+    shapefile <- st_read(tract_path, quiet = TRUE) |>
+      rename(state_shp = state)
+    az_shp <- raw_data |>
+      left_join(shapefile, by = "GEOID")
+    # manually set state to AZ
+    az_shp = mutate(az_shp, state = "AZ") |>
+      st_as_sf()
+    az_shp = st_transform(az_shp, EPSG$ID)
+
+    az_shp <- az_shp |>
+      mutate(county = coalesce(county.x, county.y)) |>
+      select(-county.x, -county.y)
+
+    az_shp <- az_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # TODO any additional columns or data you want to add should go here
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = az_shp,
+                               perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    # TODO feel free to delete if this dependency isn't available
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        az_shp <- rmapshaper::ms_simplify(az_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    az_shp$adj <- redist.adjacency(az_shp)
+
+    # TODO any custom adjacency graph edits here
+
+    write_rds(az_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    az_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AZ} shapefile")
+}

--- a/analyses/AZ_cd_1990/01_prep_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/01_prep_AZ_cd_1990.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Download and prepare data for `AZ_cd_1990` analysis
-# © ALARM Project, December 2025
+# © ALARM Project, July 2026
 ###############################################################################
 
 suppressMessages({
@@ -39,7 +39,7 @@ if (!file.exists(here(shp_path))) {
     # manually set state to AZ
     az_shp = mutate(az_shp, state = "AZ") |>
       st_as_sf()
-    az_shp = st_transform(az_shp, EPSG$ID)
+    az_shp = st_transform(az_shp, EPSG$AZ)
 
     az_shp <- az_shp |>
       mutate(county = coalesce(county.x, county.y)) |>
@@ -50,15 +50,12 @@ if (!file.exists(here(shp_path))) {
         mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
         relocate(muni, county_muni, cd_1980, .after = county)
 
-    # TODO any additional columns or data you want to add should go here
-
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = az_shp,
                                perim_path = here(perim_path)) |>
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
-    # TODO feel free to delete if this dependency isn't available
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         az_shp <- rmapshaper::ms_simplify(az_shp, keep = 0.05,
                                                  keep_shapes = TRUE) |>
@@ -67,8 +64,6 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     az_shp$adj <- redist.adjacency(az_shp)
-
-    # TODO any custom adjacency graph edits here
 
     write_rds(az_shp, here(shp_path), compress = "gz")
     cli_process_done()

--- a/analyses/AZ_cd_1990/02_setup_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/02_setup_AZ_cd_1990.R
@@ -1,0 +1,28 @@
+###############################################################################
+# Set up redistricting simulation for `AZ_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AZ_cd_1990}")
+
+# TODO any pre-computation (usually not necessary)
+
+map <- redist_map(az_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = az_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map <- map |>
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                            pop_muni = get_target(map)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "AZ_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/AZ_1990/AZ_cd_1990_map.rds", compress = "xz")
+cli_process_done()
+

--- a/analyses/AZ_cd_1990/02_setup_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/02_setup_AZ_cd_1990.R
@@ -1,23 +1,16 @@
 ###############################################################################
 # Set up redistricting simulation for `AZ_cd_1990`
-# © ALARM Project, December 2025
+# © ALARM Project, July 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg AZ_cd_1990}")
-
-# TODO any pre-computation (usually not necessary)
 
 map <- redist_map(az_shp, pop_tol = 0.005,
     existing_plan = cd_1990, adj = az_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map <- map |>
     mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
                                             pop_muni = get_target(map)))
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "AZ_1990"
@@ -25,4 +18,3 @@ attr(map, "analysis_name") <- "AZ_1990"
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/AZ_1990/AZ_cd_1990_map.rds", compress = "xz")
 cli_process_done()
-

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Simulate plans for `AZ_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AZ_cd_1990}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+constr_az <- redist_constr(map) %>%
+  add_constr_splits(strength = 1, admin = county_muni) %>%
+  add_constr_grp_hinge(30, vap_hisp, vap, 0.5) %>%
+  add_constr_grp_hinge(-30, vap_hisp, vap, 0.28)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AZ_1990/AZ_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AZ_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AZ_1990/AZ_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+# TODO remove this section if no custom constraints
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}
+

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -50,47 +50,45 @@ save_summary_stats(plans, "data-out/AZ_1990/AZ_cd_1990_stats.csv")
 
 cli_process_done()
 
-# Validation plots -----
+# Extra validation plots for custom constraints -----
 if (interactive()) {
-  library(ggplot2)
-  
-  validate_analysis(plans, map)
-  summary(plans)
-  
-  sampled <- subset_sampled(plans)
-  
-  print(
-    redist.plot.distr_qtys(
-      plans,
-      vap_hisp / total_vap,
-      color_thresh = NULL,
-      color = ifelse(
-        sampled$ndshare > 0.5,
-        "#3D77BB",
-        "#B25D4C"
-      ),
-      size = 0.5,
-      alpha = 0.5
-    ) +
-      scale_y_continuous("Hispanic share of VAP") +
-      labs(title = "Hispanic Performance") +
-      scale_color_manual(values = c(cd_1990 = "black"))
-  )
-  
-  perf_summary <- perf |>
-    group_by(threshold) |>
-    summarize(
-      plans_with_any = sum(n[n_hisp_perf > 0]),
-      pct_with_any = plans_with_any / sum(n),
-      plans_with_two_or_more = sum(n[n_hisp_perf >= 2]),
-      .groups = "drop"
-    ) |>
-    mutate(
-      pct_with_any = scales::percent(
-        pct_with_any,
-        accuracy = 0.01
-      )
-    )
-  
-  print(perf_summary)
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+
+    # Opportunity-district benchmarks, computed from the current data
+    enacted <- sf::st_drop_geometry(map) |>
+        group_by(cd_1990) |>
+        summarize(hvap = sum(vap_hisp)/sum(vap), hpop = sum(pop_hisp)/sum(pop))
+    enacted_hvap <- max(enacted$hvap) # 0.4344, CD 5
+    enacted_hpop <- max(enacted$hpop) # 0.4923, CD 5
+
+    # Hispanic VAP by district, against the opportunity-district benchmarks
+    plans |>
+        mutate(hvap = vap_hisp/total_vap) |>
+        redist.plot.distr_qtys(hvap, sort = "asc", geom = "boxplot",
+            color_thresh = NULL, size = 0.2) +
+        geom_hline(yintercept = 0.40, linetype = "dashed", color = "#1f6f8b") +
+        geom_hline(yintercept = enacted_hvap, linetype = "solid", color = "#b3382c") +
+        geom_hline(yintercept = 0.4477, linetype = "dotted", color = "#5a5a5a") +
+        scale_y_continuous("Percent Hispanic by VAP", labels = scales::percent) +
+        labs(x = "Districts, ordered by Hispanic VAP",
+            title = "Hispanic VAP against the 1992 court-plan benchmarks")
+
+    # Opportunity districts, defined on Hispanic VAP alone
+    plans |>
+        subset_sampled() |>
+        mutate(hvap = vap_hisp/total_vap) |>
+        group_by(draw) |>
+        summarize(max_hvap = max(hvap)) |>
+        summarize(median_max_hvap = median(max_hvap),
+            q10_max_hvap = quantile(max_hvap, 0.10),
+            q90_max_hvap = quantile(max_hvap, 0.90),
+            p_ge_0.35 = mean(max_hvap >= 0.35),
+            p_ge_0.40 = mean(max_hvap >= 0.40),
+            p_ge_enacted = mean(max_hvap >= enacted_hvap),
+            p_ge_0.4477 = mean(max_hvap >= 0.4477)) |>
+        print(width = Inf)
 }

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -8,32 +8,31 @@ cli_process_start("Running simulations for {.pkg AZ_cd_1990}")
 
 set.seed(1990)
 
-constr_seed <- redist_constr(map) %>%
-    add_constr_splits(strength = 0.25, admin = county_muni) %>%
-    add_constr_grp_hinge(120, vap_hisp, vap, 0.50, only_districts = TRUE)
-
-plans_seed <- redist_smc(map, nsims = 30000, counties = pseudo_county,
-    constraints = constr_seed, n_steps = 1)
-
-init_m <- get_plans_matrix(plans_seed)
-init_m <- init_m[, sample(ncol(init_m), 4000), drop = FALSE]
-
 constr_az <- redist_constr(map) %>%
-    add_constr_splits(strength = 0.10, admin = county_muni) %>%
-    add_constr_grp_hinge(30, vap_hisp, vap, 0.45, only_districts = TRUE) %>%
-    add_constr_grp_hinge(-30, vap_hisp, vap, 0.20, only_districts = TRUE)
+  add_constr_grp_hinge(
+    25,
+    vap_hisp,
+    vap,
+    0.32
+  )
 
-set.seed(1990)
-plans <- redist_smc(map, nsims = 4000, runs = 5, counties = pseudo_county,
-    constraints = constr_az, init_particles = init_m)
+plans <- redist_smc(
+  map,
+  nsims = 8000,
+  runs = 5,
+  constraints = constr_az
+)
 
 plans <- plans |>
-    group_by(chain) |>
-    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
-    ungroup()
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |>
+  ungroup()
+
 plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
+
+# Save plans -----
 cli_process_start("Saving {.cls redist_plans} object")
 
 # Output the redist_map object. Do not edit this path.
@@ -50,120 +49,30 @@ save_summary_stats(plans, "data-out/AZ_1990/AZ_cd_1990_stats.csv")
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
+# Validation plots -----
 if (interactive()) {
   library(ggplot2)
-  library(patchwork)
   
   validate_analysis(plans, map)
   summary(plans)
   
-  plans_sampled <- subset_sampled(plans)
+  sampled <- subset_sampled(plans)
   
-  # Hispanic VAP plot -----
-  p_hvap <- redist.plot.distr_qtys(
-    plans,
-    vap_hisp / total_vap,
-    color_thresh = NULL,
-    color = ifelse(
-      plans_sampled$ndv > plans_sampled$nrv,
-      "#3D77BB",
-      "#B25D4C"
-    ),
-    size = 0.5,
-    alpha = 0.5
-  ) +
-    scale_y_continuous(
-      name = "Percent Hispanic by VAP",
-      labels = scales::percent_format(accuracy = 1)
-    ) +
-    labs(
-      title = "Arizona 1990 Enacted Plan versus Simulations",
-      x = "Districts, ordered by Hispanic VAP"
-    ) +
-    scale_color_manual(
-      values = c(cd_1990 = "black")
-    ) +
-    theme_bw()
-  
-  print(p_hvap)
-  
-  # Share of plans containing a district above each HVAP threshold -----
-  plan_hvap <- plans_sampled |>
-    as_tibble() |>
-    mutate(
-      hvap = vap_hisp / total_vap
-    ) |>
-    group_by(chain, draw) |>
-    summarise(
-      max_hvap = max(hvap, na.rm = TRUE),
-      .groups = "drop"
-    )
-  
-  if (nrow(plan_hvap) != 5000L) {
-    warning(
-      "Expected 5,000 simulated plans, but found ",
-      nrow(plan_hvap),
-      "."
-    )
-  }
-  
-  hvap_thresholds <- tibble(
-    threshold = c(0.20, 0.30),
-    label = factor(
-      c("HVAP ≥ 20%", "HVAP ≥ 30%"),
-      levels = c("HVAP ≥ 20%", "HVAP ≥ 30%")
-    )
-  ) |>
-    rowwise() |>
-    mutate(
-      n_plans = sum(
-        plan_hvap$max_hvap >= threshold,
-        na.rm = TRUE
+  print(
+    redist.plot.distr_qtys(
+      plans,
+      vap_hisp / total_vap,
+      color_thresh = NULL,
+      color = ifelse(
+        sampled$ndshare > 0.5,
+        "#3D77BB",
+        "#B25D4C"
       ),
-      total_plans = nrow(plan_hvap),
-      proportion = n_plans / total_plans
-    ) |>
-    ungroup()
-  
-  print(hvap_thresholds)
-  
-  p_hvap_thresholds <- ggplot(
-    hvap_thresholds,
-    aes(x = label, y = proportion)
-  ) +
-    geom_col(width = 0.6) +
-    geom_text(
-      aes(
-        label = paste0(
-          scales::percent(proportion, accuracy = 0.1),
-          "\n(",
-          scales::comma(n_plans),
-          " of ",
-          scales::comma(total_plans),
-          ")"
-        )
-      ),
-      vjust = -0.3,
-      size = 4
+      size = 0.5,
+      alpha = 0.5
     ) +
-    scale_y_continuous(
-      name = "Share of simulated plans",
-      labels = scales::percent_format(accuracy = 1),
-      breaks = seq(0, 1, by = 0.2)
-    ) +
-    coord_cartesian(
-      ylim = c(0, 1.05),
-      clip = "off"
-    ) +
-    labs(
-      title = paste0(
-        "Arizona 1990: Plans Containing a District ",
-        "Above Each Hispanic-VAP Threshold"
-      ),
-      x = NULL
-    ) +
-    theme_bw()
-  
-  print(p_hvap_thresholds)
+      scale_y_continuous("Hispanic share of VAP") +
+      labs(title = "Hispanic Performance") +
+      scale_color_manual(values = c(cd_1990 = "black"))
+  )
 }

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -52,43 +52,118 @@ cli_process_done()
 
 # Extra validation plots for custom constraints -----
 if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-    validate_analysis(plans, map)
-    summary(plans)
-
-    # Opportunity-district benchmarks, computed from the current data
-    enacted <- sf::st_drop_geometry(map) |>
-        group_by(cd_1990) |>
-        summarize(hvap = sum(vap_hisp)/sum(vap), hpop = sum(pop_hisp)/sum(pop))
-    enacted_hvap <- max(enacted$hvap) # 0.4344, CD 5
-    enacted_hpop <- max(enacted$hpop) # 0.4923, CD 5
-
-    # Hispanic VAP by district, against the opportunity-district benchmarks
-    plans |>
-        mutate(hvap = vap_hisp/total_vap) |>
-        redist.plot.distr_qtys(hvap, sort = "asc", geom = "boxplot",
-            color_thresh = NULL, size = 0.2) +
-        geom_hline(yintercept = 0.40, linetype = "dashed", color = "#1f6f8b") +
-        geom_hline(yintercept = enacted_hvap, linetype = "solid", color = "#b3382c") +
-        geom_hline(yintercept = 0.4477, linetype = "dotted", color = "#5a5a5a") +
-        scale_y_continuous("Percent Hispanic by VAP", labels = scales::percent) +
-        labs(x = "Districts, ordered by Hispanic VAP",
-            title = "Hispanic VAP against the 1992 court-plan benchmarks")
-
-    # Opportunity districts, defined on Hispanic VAP alone
-    plans |>
-        subset_sampled() |>
-        mutate(hvap = vap_hisp/total_vap) |>
-        group_by(draw) |>
-        summarize(max_hvap = max(hvap)) |>
-        summarize(median_max_hvap = median(max_hvap),
-            q10_max_hvap = quantile(max_hvap, 0.10),
-            q90_max_hvap = quantile(max_hvap, 0.90),
-            p_ge_0.35 = mean(max_hvap >= 0.35),
-            p_ge_0.40 = mean(max_hvap >= 0.40),
-            p_ge_enacted = mean(max_hvap >= enacted_hvap),
-            p_ge_0.4477 = mean(max_hvap >= 0.4477)) |>
-        print(width = Inf)
+  library(ggplot2)
+  library(patchwork)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+  
+  plans_sampled <- subset_sampled(plans)
+  
+  # Hispanic VAP plot -----
+  p_hvap <- redist.plot.distr_qtys(
+    plans,
+    vap_hisp / total_vap,
+    color_thresh = NULL,
+    color = ifelse(
+      plans_sampled$ndv > plans_sampled$nrv,
+      "#3D77BB",
+      "#B25D4C"
+    ),
+    size = 0.5,
+    alpha = 0.5
+  ) +
+    scale_y_continuous(
+      name = "Percent Hispanic by VAP",
+      labels = scales::percent_format(accuracy = 1)
+    ) +
+    labs(
+      title = "Arizona 1990 Enacted Plan versus Simulations",
+      x = "Districts, ordered by Hispanic VAP"
+    ) +
+    scale_color_manual(
+      values = c(cd_1990 = "black")
+    ) +
+    theme_bw()
+  
+  print(p_hvap)
+  
+  # Share of plans containing a district above each HVAP threshold -----
+  plan_hvap <- plans_sampled |>
+    as_tibble() |>
+    mutate(
+      hvap = vap_hisp / total_vap
+    ) |>
+    group_by(chain, draw) |>
+    summarise(
+      max_hvap = max(hvap, na.rm = TRUE),
+      .groups = "drop"
+    )
+  
+  if (nrow(plan_hvap) != 5000L) {
+    warning(
+      "Expected 5,000 simulated plans, but found ",
+      nrow(plan_hvap),
+      "."
+    )
+  }
+  
+  hvap_thresholds <- tibble(
+    threshold = c(0.20, 0.30),
+    label = factor(
+      c("HVAP ≥ 20%", "HVAP ≥ 30%"),
+      levels = c("HVAP ≥ 20%", "HVAP ≥ 30%")
+    )
+  ) |>
+    rowwise() |>
+    mutate(
+      n_plans = sum(
+        plan_hvap$max_hvap >= threshold,
+        na.rm = TRUE
+      ),
+      total_plans = nrow(plan_hvap),
+      proportion = n_plans / total_plans
+    ) |>
+    ungroup()
+  
+  print(hvap_thresholds)
+  
+  p_hvap_thresholds <- ggplot(
+    hvap_thresholds,
+    aes(x = label, y = proportion)
+  ) +
+    geom_col(width = 0.6) +
+    geom_text(
+      aes(
+        label = paste0(
+          scales::percent(proportion, accuracy = 0.1),
+          "\n(",
+          scales::comma(n_plans),
+          " of ",
+          scales::comma(total_plans),
+          ")"
+        )
+      ),
+      vjust = -0.3,
+      size = 4
+    ) +
+    scale_y_continuous(
+      name = "Share of simulated plans",
+      labels = scales::percent_format(accuracy = 1),
+      breaks = seq(0, 1, by = 0.2)
+    ) +
+    coord_cartesian(
+      ylim = c(0, 1.05),
+      clip = "off"
+    ) +
+    labs(
+      title = paste0(
+        "Arizona 1990: Plans Containing a District ",
+        "Above Each Hispanic-VAP Threshold"
+      ),
+      x = NULL
+    ) +
+    theme_bw()
+  
+  print(p_hvap_thresholds)
 }

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -1,45 +1,57 @@
 ###############################################################################
 # Simulate plans for `AZ_cd_1990`
-# © ALARM Project, December 2025
+# © ALARM Project, July 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg AZ_cd_1990}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(1990)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
 
 constr_az <- redist_constr(map) %>%
-  add_constr_splits(strength = 1, admin = county_muni) %>%
-  add_constr_grp_hinge(30, vap_hisp, vap, 0.5) %>%
-  add_constr_grp_hinge(-30, vap_hisp, vap, 0.28)
+  add_constr_splits(
+    strength = 0.25,
+    admin = county_muni
+  ) %>%
+  add_constr_grp_hinge(
+    20,
+    vap_hisp,
+    vap,
+    0.32
+  ) %>%
+  add_constr_grp_hinge(
+    -20,
+    vap_hisp,
+    vap,
+    0.27
+  )
+
+plans <- redist_smc(
+  map,
+  nsims = 4000,
+  runs = 5,
+  counties = pseudo_county,
+  constraints = constr_az
+)
 
 plans <- plans |>
-    group_by(chain) |>
-    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
-    ungroup()
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |>
+  ungroup()
+
 plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
+
+# Save plans -----
 cli_process_start("Saving {.cls redist_plans} object")
 
-# TODO add any reference plans that aren't already included
+write_rds(
+  plans,
+  here("data-out/AZ_1990/AZ_cd_1990_plans.rds"),
+  compress = "xz"
+)
 
-# Output the redist_map object. Do not edit this path.
-write_rds(plans, here("data-out/AZ_1990/AZ_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
@@ -47,18 +59,54 @@ cli_process_start("Computing summary statistics for {.pkg AZ_cd_1990}")
 
 plans <- add_summary_stats(plans, map)
 
-# Output the summary statistics. Do not edit this path.
-save_summary_stats(plans, "data-out/AZ_1990/AZ_cd_1990_stats.csv")
+save_summary_stats(
+  plans,
+  "data-out/AZ_1990/AZ_cd_1990_stats.csv"
+)
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
-# TODO remove this section if no custom constraints
+# Validation plots -----
 if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-    validate_analysis(plans, map)
-    summary(plans)
+  library(ggplot2)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+  
+  sampled <- subset_sampled(plans)
+  
+  print(
+    redist.plot.distr_qtys(
+      plans,
+      vap_hisp / total_vap,
+      color_thresh = NULL,
+      color = ifelse(
+        sampled$ndshare > 0.5,
+        "#3D77BB",
+        "#B25D4C"
+      ),
+      size = 0.5,
+      alpha = 0.5
+    ) +
+      scale_y_continuous("Hispanic share of VAP") +
+      labs(title = "Hispanic Performance") +
+      scale_color_manual(values = c(cd_1990 = "black"))
+  )
+  
+  perf_summary <- perf |>
+    group_by(threshold) |>
+    summarize(
+      plans_with_any = sum(n[n_hisp_perf > 0]),
+      pct_with_any = plans_with_any / sum(n),
+      plans_with_two_or_more = sum(n[n_hisp_perf >= 2]),
+      .groups = "drop"
+    ) |>
+    mutate(
+      pct_with_any = scales::percent(
+        pct_with_any,
+        accuracy = 0.01
+      )
+    )
+  
+  print(perf_summary)
 }
-

--- a/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
+++ b/analyses/AZ_cd_1990/03_sim_AZ_cd_1990.R
@@ -8,50 +8,36 @@ cli_process_start("Running simulations for {.pkg AZ_cd_1990}")
 
 set.seed(1990)
 
-constr_az <- redist_constr(map) %>%
-  add_constr_splits(
-    strength = 0.25,
-    admin = county_muni
-  ) %>%
-  add_constr_grp_hinge(
-    20,
-    vap_hisp,
-    vap,
-    0.32
-  ) %>%
-  add_constr_grp_hinge(
-    -20,
-    vap_hisp,
-    vap,
-    0.27
-  )
+constr_seed <- redist_constr(map) %>%
+    add_constr_splits(strength = 0.25, admin = county_muni) %>%
+    add_constr_grp_hinge(120, vap_hisp, vap, 0.50, only_districts = TRUE)
 
-plans <- redist_smc(
-  map,
-  nsims = 4000,
-  runs = 5,
-  counties = pseudo_county,
-  constraints = constr_az
-)
+plans_seed <- redist_smc(map, nsims = 30000, counties = pseudo_county,
+    constraints = constr_seed, n_steps = 1)
+
+init_m <- get_plans_matrix(plans_seed)
+init_m <- init_m[, sample(ncol(init_m), 4000), drop = FALSE]
+
+constr_az <- redist_constr(map) %>%
+    add_constr_splits(strength = 0.10, admin = county_muni) %>%
+    add_constr_grp_hinge(30, vap_hisp, vap, 0.45, only_districts = TRUE) %>%
+    add_constr_grp_hinge(-30, vap_hisp, vap, 0.20, only_districts = TRUE)
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 4000, runs = 5, counties = pseudo_county,
+    constraints = constr_az, init_particles = init_m)
 
 plans <- plans |>
-  group_by(chain) |>
-  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |>
-  ungroup()
-
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_1990")
 
 cli_process_done()
-
-# Save plans -----
 cli_process_start("Saving {.cls redist_plans} object")
 
-write_rds(
-  plans,
-  here("data-out/AZ_1990/AZ_cd_1990_plans.rds"),
-  compress = "xz"
-)
-
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AZ_1990/AZ_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
 
 # Compute summary statistics -----
@@ -59,10 +45,8 @@ cli_process_start("Computing summary statistics for {.pkg AZ_cd_1990}")
 
 plans <- add_summary_stats(plans, map)
 
-save_summary_stats(
-  plans,
-  "data-out/AZ_1990/AZ_cd_1990_stats.csv"
-)
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AZ_1990/AZ_cd_1990_stats.csv")
 
 cli_process_done()
 

--- a/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
+++ b/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
@@ -1,0 +1,27 @@
+# 1990 Arizona Congressional Districts
+
+## Redistricting requirements
+Arizona law for 1990s redistricting is not publicly available. We consult the 2000 guidelines created for a bipartisan commission.
+
+In Arizona, districts must: 
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. follow the Voting Rights Act
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Arizona comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Arizona across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
+++ b/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
@@ -1,16 +1,15 @@
 # 1990 Arizona Congressional Districts
 
 ## Redistricting requirements
-Arizona law for 1990s redistricting is not publicly available. We consult the 2000 guidelines created for a bipartisan commission.
+We use the redistricting criteria established by the federal court in Arizonans for [Fair Representation v. Symington (1992), which governed Arizona’s 1990s congressional plan](https://law.justia.com/cases/federal/district-courts/FSupp/828/684/2352036/).
 
-In Arizona, districts must: 
+In Arizona, districts should: 
 
 1. be contiguous
-1. have equal populations
+1. have nearly equal populations
 1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-1. follow the Voting Rights Act
-
+1. preserve communities of interest and city and county boundaries as much as practicable; and
+1. comply with the Voting Rights Act.
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
@@ -24,4 +23,4 @@ No manual pre-processing decisions were necessary.
 ## Simulation Notes
 We sample 10,000 districting plans for Arizona across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 5,000. 
-No special techniques were needed to produce the sample.
+To preserve communities of interest and city and county boundaries, we create pseudocounties for use in the county constraint.

--- a/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
+++ b/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
@@ -13,6 +13,7 @@ In Arizona, districts should:
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
+We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
 We also use a single Hispanic VAP hinge constraint to encourage the simulation to generate a district with a comparatively high Hispanic VAP.
 
 ## Data Sources
@@ -24,3 +25,4 @@ No manual pre-processing was required.
 ## Simulation Notes
 We sample 40,000 districting plans for Arizona across five runs of the SMC algorithm.
 We retain 1,000 plans from each run, producing a final ensemble of 5,000 plans.
+We use a pseudo-county constraint to limit the county and municipality splits.

--- a/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
+++ b/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
@@ -13,14 +13,14 @@ In Arizona, districts should:
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
-To operationalize the preservation of local administrative geography, we construct pseudocounties and pass them to the `counties` argument of the SMC algorithm.
-We also use Hispanic voting-age-population hinge constraints to encourage the simulation to generate a district with a comparatively high Hispanic VAP.
+We also use a single Hispanic VAP hinge constraint to encourage the simulation to generate a district with a comparatively high Hispanic VAP.
 
 ## Data Sources
 Data for Arizona comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing was required. We use predefined pseudocounties in the county constraint and penalize splits of county–municipality units.
+No manual pre-processing was required.
 
 ## Simulation Notes
-We use a two-stage SMC procedure. First, we generate 30,000 preliminary plans under a stronger Hispanic-VAP constraint and randomly select 4,000 as initial particles. We then sample 20,000 plans across five independent runs and retain 1,000 plans from each run, producing a final ensemble of 5,000 plans.
+We sample 40,000 districting plans for Arizona across five runs of the SMC algorithm.
+We retain 1,000 plans from each run, producing a final ensemble of 5,000 plans.

--- a/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
+++ b/analyses/AZ_cd_1990/doc_AZ_cd_1990.md
@@ -13,14 +13,14 @@ In Arizona, districts should:
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
+To operationalize the preservation of local administrative geography, we construct pseudocounties and pass them to the `counties` argument of the SMC algorithm.
+We also use Hispanic voting-age-population hinge constraints to encourage the simulation to generate a district with a comparatively high Hispanic VAP.
 
 ## Data Sources
 Data for Arizona comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+No manual pre-processing was required. We use predefined pseudocounties in the county constraint and penalize splits of county–municipality units.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Arizona across 5 independent runs of the SMC algorithm.
-We then thinned the number of samples to 5,000. 
-To preserve communities of interest and city and county boundaries, we create pseudocounties for use in the county constraint.
+We use a two-stage SMC procedure. First, we generate 30,000 preliminary plans under a stronger Hispanic-VAP constraint and randomly select 4,000 as initial particles. We then sample 20,000 plans across five independent runs and retain 1,000 plans from each run, producing a final ensemble of 5,000 plans.


### PR DESCRIPTION
## Redistricting requirements
We use the redistricting criteria established by the federal court in Arizonans for [Fair Representation v. Symington (1992), which governed Arizona’s 1990s congressional plan](https://law.justia.com/cases/federal/district-courts/FSupp/828/684/2352036/).

In Arizona, districts should: 

1. be contiguous
1. have nearly equal populations
1. be geographically compact
1. preserve communities of interest and city and county boundaries as much as practicable; and
1. comply with the Voting Rights Act.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We use a pseudo-county constraint to help preserve county and municipality boundaries, as described below.
We also use a single Hispanic VAP hinge constraint to encourage the simulation to generate a district with a comparatively high Hispanic VAP.

## Data Sources
Data for Arizona comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing was required.

## Simulation Notes
We sample 40,000 districting plans for Arizona across five runs of the SMC algorithm.
We retain 1,000 plans from each run, producing a final ensemble of 5,000 plans.
We use a pseudo-county constraint to limit the county and municipality splits.

## Validation
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/b7405a79-2c60-4657-a7f2-52c42af09efb" />

```
SMC: 5,000 sampled plans of 6
                 districts on 810 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.85 to 1.05
Largest R-hat values for ordered summary statistics:

    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.031               1.004               1.010               1.007 
        muni_splits             ndshare                 ndv                 nrv 
              1.017               1.011               1.027               1.023 
           plan_dev            pop_aian           pop_asian           pop_black 
              1.010               1.016               1.020               1.029 
           pop_hisp           pop_other         pop_overlap           pop_white 
              1.020               1.031               1.011               1.027 
total_county_splits   total_muni_splits           total_vap            vap_aian 
              1.014               1.021               1.014               1.021 
          vap_asian           vap_black            vap_hisp           vap_other 
              1.024               1.034               1.021               1.030 
          vap_white 
              1.025 
• R-hat ≤ 1.05: 150
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 150
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     4,235 (52.9%)      7.0%         1.5 5,058 (100%)      6 
Split 2     4,527 (56.6%)      7.4%         1.3 3,830 ( 76%)      5 
Split 3     4,503 (56.3%)      6.1%         1.2 3,985 ( 79%)      5 
Split 4     4,058 (50.7%)      4.6%         1.1 3,984 ( 79%)      5 
Split 5     1,749 (21.9%)      1.9%         1.3 3,590 ( 71%)      4 
Resample    1,749 (21.9%)       NA%          NA 4,421 ( 87%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [X] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [X] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [X] All `TODO` lines from the template code have been removed
- [X] I have merged in the main branch and then recalculated summary statistics
- [X] I have run `enforce_style()` to format my code
- [X] The documentation copied above is up-to-date 
- [X] There are no data files in this pull request
- [X] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

## Additional Notes
Hispanic Performance Plot:
<img width="831" height="507" alt="Screenshot 2026-09-14 at 23 34 05" src="https://github.com/user-attachments/assets/536114b0-3fab-4598-9802-d8a0088f6635" />