### PR TITLE
Update logit_shift.R

### DIFF
--- a/R/logit_shift.R
+++ b/R/logit_shift.R
@@ -24,6 +24,11 @@ logit_shift_baseline <- function(d_baseline, ndv, nrv,
   nrv_vec <- dplyr::pull(d_baseline, !!nrv_q)
 
   turn <- ndv_vec + nrv_vec
+
+  if (sum(turn) == 0) {
+    return(d_baseline)
+  }
+
   ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
 
   res <- uniroot(function(shift) {


### PR DESCRIPTION
When running the NC 2000 redistricting analysis, the logit-shift step failed with `f.lower = f(lower) is NA from uniroot`. This occurred because Stanly County (FIPS 37167) had zero total turnout across all precincts. 

The current code, which has an `if_else` guard, only protected against log(0) when computing individual precinct log-odds. When all turnout values are zero, `weighted.mean()` attempts to compute `sum(values * weights) / sum(weights) = 0/0`, returning NaN. This propagates through `uniroot` which cannot find a root when the function evaluates to NA at both bounds and causes the original error.

This PR adds an early return when `sum(turn) == 0`, leaving the data unchanged for counties with no votes rather than failing.