### PR TITLE
1990 New Hampshire Congressional Districts

### DIFF
--- a/analyses/NH_cd_1990/01_prep_NH_cd_1990.R
+++ b/analyses/NH_cd_1990/01_prep_NH_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `NH_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NH_cd_1990}")
+
+path_data <- download_redistricting_file("NH", "data-raw/NH", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NH_1990/shp_vtd.rds"
+perim_path <- "data-out/NH_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NH} shapefile")
+    # read in redistricting data
+    nh_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(state = as.character(state)) |> # FIX (ensures state is character variable across datasets)
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$NH)
+
+    nh_shp <- nh_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nh_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nh_shp <- rmapshaper::ms_simplify(nh_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nh_shp$adj <- redist.adjacency(nh_shp)
+
+    write_rds(nh_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nh_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NH} shapefile")
+}

--- a/analyses/NH_cd_1990/02_setup_NH_cd_1990.R
+++ b/analyses/NH_cd_1990/02_setup_NH_cd_1990.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `NH_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NH_cd_1990}")
+
+map <- redist_map(nh_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = nh_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NH_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NH_1990/NH_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NH_cd_1990/03_sim_NH_cd_1990.R
+++ b/analyses/NH_cd_1990/03_sim_NH_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `NH_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NH_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NH_1990/NH_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NH_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NH_1990/NH_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/NH_cd_1990/doc_NH_cd_1990.md
+++ b/analyses/NH_cd_1990/doc_NH_cd_1990.md
@@ -1,0 +1,23 @@
+# 1990 New Hampshire Congressional Districts
+
+## Redistricting requirements
+In New Hampshire, we consult [Forgette et al.](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. preserve political subdivisions as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for New Hampshire comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for New Hampshire across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In New Hampshire, we consult [Forgette et al.](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. preserve political subdivisions as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for New Hampshire comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for New Hampshire across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="511" height="770" alt="Screenshot 2026-01-10 at 1 19 30 PM" src="https://github.com/user-attachments/assets/6d7f84aa-be7c-4bb1-9e5a-25dd75568276" />

```
SMC: 5,000 sampled plans of 2 districts on 267 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.085 to 0.687
✖ WARNING: Low plan diversity

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_asian      pop_aian     pop_white     pop_black 
        1.000         1.000         1.000         1.000         1.000         1.001         1.000         1.000         1.001 
     pop_hisp     pop_other      vap_hisp      vap_aian     vap_other     vap_white     vap_black     vap_asian county_splits 
        1.001         1.001         1.001         1.000         1.001         1.001         1.001         1.000         1.000 
  muni_splits           ndv           nrv       ndshare 
        1.001         1.000         1.001         1.001 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,986 (99.3%)      4.5%        0.17 1,245 ( 98%)      4 
Resample    1,947 (97.3%)       NA%        0.17 1,855 (147%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,987 (99.4%)      4.5%        0.16 1,283 (101%)      4 
Resample    1,952 (97.6%)       NA%        0.16 1,865 (148%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,987 (99.3%)      4.4%        0.16 1,268 (100%)      4 
Resample    1,950 (97.5%)       NA%        0.16 1,883 (149%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,986 (99.3%)      3.7%        0.17 1,290 (102%)      5 
Resample    1,947 (97.3%)       NA%        0.17 1,871 (148%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,986 (99.3%)      4.6%        0.17 1,276 (101%)      4 
Resample    1,947 (97.4%)       NA%        0.17 1,865 (148%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with
`hist(plans_diversity(plans), breaks=24)`. Consider weakening or removing constraints, or increasing the population tolerance. If the
acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko
