### PR TITLE
1990 Nebraska Congressional Districts

### DIFF
--- a/analyses/NE_cd_1990/01_prep_NE_cd_1990.R
+++ b/analyses/NE_cd_1990/01_prep_NE_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `NE_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NE_cd_1990}")
+
+path_data <- download_redistricting_file("NE", "data-raw/NE", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NE_1990/shp_vtd.rds"
+perim_path <- "data-out/NE_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NE} shapefile")
+    # read in redistricting data
+    ne_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(state = as.character(state)) |> # FIX (ensures state is character variable across datasets)
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$NE)
+
+    ne_shp <- ne_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ne_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ne_shp <- rmapshaper::ms_simplify(ne_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ne_shp$adj <- redist.adjacency(ne_shp)
+
+    write_rds(ne_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ne_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NE} shapefile")
+}

--- a/analyses/NE_cd_1990/02_setup_NE_cd_1990.R
+++ b/analyses/NE_cd_1990/02_setup_NE_cd_1990.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `NE_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NE_cd_1990}")
+
+map <- redist_map(ne_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = ne_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "NE_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/NE_1990/NE_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NE_cd_1990/03_sim_NE_cd_1990.R
+++ b/analyses/NE_cd_1990/03_sim_NE_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `NE_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NE_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NE_1990/NE_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NE_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NE_1990/NE_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/NE_cd_1990/doc_NE_cd_1990.md
+++ b/analyses/NE_cd_1990/doc_NE_cd_1990.md
@@ -1,0 +1,26 @@
+# 1990 Nebraska Congressional Districts
+
+## Redistricting requirements
+In Nebraska, we consult [Forgette et al. 2009](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. preserve identified communities of interest
+1. respect political subdivisions
+1. be drawn without the intention of protecting any incumbent
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Nebraska comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Nebraska across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.


### PR DESCRIPTION
## Redistricting requirements
In Nebraska, we consult [Forgette et al. 2009](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. preserve identified communities of interest
1. respect political subdivisions
1. be drawn without the intention of protecting any incumbent

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Nebraska comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Nebraska across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation

<img width="505" height="734" alt="Screenshot 2025-12-21 at 10 11 07 PM" src="https://github.com/user-attachments/assets/5bbaf0ab-818d-40ac-a58b-c12c59ae9bcd" />

```
SMC: 5,000 sampled plans of 3 districts on 446 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.30 to 0.65

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_asian      pop_aian     pop_white     pop_black 
        1.001         1.001         1.001         1.000         1.001         1.001         1.000         1.000         1.000 
     pop_hisp     pop_other      vap_hisp      vap_aian     vap_other     vap_white     vap_black     vap_asian county_splits 
        1.002         1.000         1.001         1.000         1.001         1.002         1.000         1.001         1.000 
  muni_splits           ndv           nrv       ndshare 
        1.000         1.001         1.001         1.002 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,941 (97.0%)      7.0%        0.35 1,266 (100%)      5 
Split 2     1,905 (95.3%)      4.7%        0.38 1,240 ( 98%)      3 
Resample    1,569 (78.5%)       NA%        0.42 1,676 (133%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,943 (97.1%)      7.4%        0.34 1,267 (100%)      5 
Split 2     1,916 (95.8%)      3.4%        0.36 1,222 ( 97%)      4 
Resample    1,673 (83.7%)       NA%        0.41 1,663 (132%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,942 (97.1%)      5.9%        0.34 1,265 (100%)      6 
Split 2     1,913 (95.7%)      3.5%        0.36 1,225 ( 97%)      4 
Resample    1,634 (81.7%)       NA%        0.41 1,664 (132%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,942 (97.1%)      7.7%        0.34 1,272 (101%)      5 
Split 2     1,925 (96.2%)      3.4%        0.34 1,216 ( 96%)      4 
Resample    1,723 (86.1%)       NA%        0.39 1,671 (132%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,941 (97.1%)      7.5%        0.34 1,286 (102%)      5 
Split 2     1,899 (95.0%)      3.7%        0.40 1,220 ( 97%)      4 
Resample    1,542 (77.1%)       NA%        0.43 1,660 (131%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko