### PR TITLE
1990 Minnesota Congressional Districts

### DIFF
--- a/analyses/MN_cd_1990/01_prep_MN_cd_1990.R
+++ b/analyses/MN_cd_1990/01_prep_MN_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `MN_cd_1990` analysis
+# © ALARM Project, January 2026
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MN_cd_1990}")
+
+path_data <- download_redistricting_file("MN", "data-raw/MN", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MN_1990/shp_vtd.rds"
+perim_path <- "data-out/MN_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong MN} shapefile")
+  # read in redistricting data
+  mn_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(state = as.character(state)) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$MN)
+  
+  mn_shp <- mn_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = mn_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  mn_shp$adj <- redist.adjacency(mn_shp)
+  
+  write_rds(mn_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  mn_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong MN} shapefile")
+}

--- a/analyses/MN_cd_1990/02_setup_MN_cd_1990.R
+++ b/analyses/MN_cd_1990/02_setup_MN_cd_1990.R
@@ -1,0 +1,23 @@
+###############################################################################
+# Set up redistricting simulation for `MN_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MN_cd_1990}")
+
+map <- redist_map(mn_shp, pop_tol = 0.005,
+                  existing_plan = cd_1990, adj = mn_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+  mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                          pop_muni = get_target(map)))
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MN_1990"
+
+# Add a stronger county constraint.
+constr <- redist_constr(map)
+constr <- add_constr_splits(constr, strength = 2, admin = county)
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MN_1990/MN_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
+++ b/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
@@ -1,0 +1,56 @@
+###############################################################################
+# Simulate plans for `MN_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MN_cd_1990}")
+
+sampling_space_val <- tryCatch(
+  getFromNamespace("LINKING_EDGE_SPACE", "redist"),
+  error = function(e) "linking_edge"
+)
+
+set.seed(1990)
+plans <- redist_smc(
+  map, 
+  nsims = 2e3, 
+  runs = 10, 
+  counties = pseudo_county, 
+  constraints = constr,
+  sampling_space = sampling_space_val,
+  ms_params = list(frequency = 1L, mh_accept_per_smc = 30),
+  split_params = list(splitting_schedule = "any_valid_sizes")
+  )
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MN_1990/MN_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MN_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MN_1990/MN_cd_1990_stats.csv")
+
+cli_process_done()
+
+# validation plots
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+}

--- a/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
+++ b/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
@@ -14,8 +14,8 @@ sampling_space_val <- tryCatch(
 set.seed(1990)
 plans <- redist_smc(
   map, 
-  nsims = 2e3, 
-  runs = 10, 
+  nsims = 3e3, 
+  runs = 5, 
   counties = pseudo_county, 
   constraints = constr,
   sampling_space = sampling_space_val,

--- a/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
+++ b/analyses/MN_cd_1990/03_sim_MN_cd_1990.R
@@ -19,7 +19,7 @@ plans <- redist_smc(
   counties = pseudo_county, 
   constraints = constr,
   sampling_space = sampling_space_val,
-  ms_params = list(frequency = 1L, mh_accept_per_smc = 30),
+  ms_params = list(frequency = 1L, mh_accept_per_smc = 60),
   split_params = list(splitting_schedule = "any_valid_sizes")
   )
 

--- a/analyses/MN_cd_1990/doc_MN_cd_1990.md
+++ b/analyses/MN_cd_1990/doc_MN_cd_1990.md
@@ -11,13 +11,13 @@ In Minnesota, according to [the concurrent resolution adopted in 199 and relevan
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
+We use a pseudo-county constraint to help preserve county and municipality boundaries.
 
 ## Data Sources
 Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
 No manual pre-processing decisions were necessary.
-We use a pseudo-county constraint to help preserve county and municipality boundaries.
 
 ## Simulation Notes
 We sample 15,000 districting plans for Minnesota across 5 independent runs of the SMC algorithm.

--- a/analyses/MN_cd_1990/doc_MN_cd_1990.md
+++ b/analyses/MN_cd_1990/doc_MN_cd_1990.md
@@ -1,7 +1,7 @@
 # 1990 Minnesota Congressional Districts
 
 ## Redistricting requirements
-In Minnesota, according to [the concurrent resolution adopted in 199 and relevant court orders](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+In Minnesota, according to [the concurrent resolution adopted in 1990 and relevant court orders](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
 
 1. be contiguous
 1. have equal populations

--- a/analyses/MN_cd_1990/doc_MN_cd_1990.md
+++ b/analyses/MN_cd_1990/doc_MN_cd_1990.md
@@ -1,0 +1,25 @@
+# 1990 Minnesota Congressional Districts
+
+## Redistricting requirements
+In Minnesota, according to [the concurrent resolution adopted in 199 and relevant court orders](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+1. not dilute the voting strength of racial or language minority groups
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+We use a pseudo-county constraint to help preserve county and municipality boundaries.
+
+## Simulation Notes
+We sample 15,000 districting plans for Minnesota across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+We also use new algorithmic mergesplit parameters to improve mixing.


### PR DESCRIPTION
## Redistricting requirements
In Minnesota, according to [the concurrent resolution adopted in 1990 and relevant court orders](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not dilute the voting strength of racial or language minority groups

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We use a pseudo-county constraint to help preserve county and municipality boundaries.

## Data Sources
Data for Minnesota comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 15,000 districting plans for Minnesota across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
We also use new algorithmic mergesplit parameters to improve mixing.

## Validation
<img width="3000" height="4500" alt="validation_20260111_1534" src="https://github.com/user-attachments/assets/63920e77-286a-4a90-915a-3a025d186511" />


```
SMC with Merge-Split MCMC Steps: 5,000 sampled plans of 8 districts on 1,232 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 7
• `mh_accept_per_smc` = 60
• `pair_rule` = uniform
Plan diversity 80% range: 0.67 to 0.91
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv 
        1.006         1.010         1.006         1.016         1.011         1.040         1.026 
     plan_dev      pop_aian     pop_asian     pop_black      pop_hisp     pop_other   pop_overlap 
        1.008         1.009         1.029         1.018         1.015         1.026         1.013 
    pop_white     total_vap      vap_aian     vap_asian     vap_black      vap_hisp     vap_other 
        1.012         1.012         1.014         1.030         1.019         1.017         1.018 
    vap_white 
        1.021 
• R-hat ≤ 1.05: 176
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 176
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       715 (23.8%)     82.5%         1.8 1,890 (100%) 
Split 2       756 (25.2%)     43.3%         1.7 1,154 ( 61%) 
Split 3       867 (28.9%)     24.1%         1.8 1,170 ( 62%) 
Split 4       708 (23.6%)     15.1%         2.0 1,194 ( 63%) 
Split 5       644 (21.5%)     11.7%         2.1 1,121 ( 59%) 
Split 6       719 (24.0%)     10.1%         2.0   999 ( 53%) 
Split 7       528 (17.6%)      9.4%         1.9 1,064 ( 56%) 
Resample      528 (17.6%)       NA%          NA 1,241 ( 65%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     26.2%               120
MS Step 2     19.2%               240
MS Step 3     14.8%               360
MS Step 4     12.4%               420
MS Step 5     11.6%               540
MS Step 6     11.3%               540
MS Step 7     10.4%               540

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       710 (23.7%)     83.1%         1.9 1,059 ( 56%) 
Split 2       832 (27.7%)     44.2%         1.7 1,150 ( 61%) 
Split 3       902 (30.1%)     25.5%         1.9 1,144 ( 60%) 
Split 4       776 (25.9%)     16.1%         2.0 1,140 ( 60%) 
Split 5       654 (21.8%)     12.2%         2.1 1,135 ( 60%) 
Split 6       645 (21.5%)     10.3%         2.1 1,043 ( 55%) 
Split 7       449 (15.0%)      9.7%         2.0   987 ( 52%) 
Resample      449 (15.0%)       NA%          NA 1,209 ( 64%) 

Sampling diagnostics for Mergesplit Steps of SMC run 2 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     26.2%               120
MS Step 2     19.1%               240
MS Step 3     14.9%               360
MS Step 4     12.5%               420
MS Step 5     11.7%               480
MS Step 6     11.2%               540
MS Step 7     10.6%               540

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       606 (20.2%)     83.2%         1.9 1,019 ( 54%) 
Split 2       830 (27.7%)     44.5%         1.7 1,082 ( 57%) 
Split 3       839 (28.0%)     25.2%         1.9 1,173 ( 62%) 
Split 4       728 (24.3%)     15.3%         2.0 1,157 ( 61%) 
Split 5       738 (24.6%)     12.1%         2.1 1,055 ( 56%) 
Split 6       654 (21.8%)     10.5%         1.9 1,026 ( 54%) 
Split 7       567 (18.9%)      9.8%         1.9 1,047 ( 55%) 
Resample      567 (18.9%)       NA%          NA 1,365 ( 72%) 

Sampling diagnostics for Mergesplit Steps of SMC run 3 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     26.3%               120
MS Step 2     19.2%               240
MS Step 3     14.8%               360
MS Step 4     12.7%               420
MS Step 5     11.7%               480
MS Step 6     11.1%               540
MS Step 7     10.4%               540

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       656 (21.9%)     84.0%         1.9 1,130 ( 60%) 
Split 2       795 (26.5%)     44.2%         1.8 1,109 ( 58%) 
Split 3       789 (26.3%)     24.1%         1.9 1,169 ( 62%) 
Split 4       826 (27.5%)     15.4%         2.0 1,155 ( 61%) 
Split 5       670 (22.3%)     11.6%         2.1 1,161 ( 61%) 
Split 6       625 (20.8%)     10.3%         2.0 1,006 ( 53%) 
Split 7       431 (14.4%)     10.1%         2.0   942 ( 50%) 
Resample      431 (14.4%)       NA%          NA 1,207 ( 64%) 

Sampling diagnostics for Mergesplit Steps of SMC run 4 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     26.4%               120
MS Step 2     19.4%               240
MS Step 3     14.8%               360
MS Step 4     12.5%               420
MS Step 5     11.6%               540
MS Step 6     11.2%               540
MS Step 7     10.9%               540

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       703 (23.4%)     84.1%         1.9 1,005 ( 53%) 
Split 2       836 (27.9%)     43.4%         1.7 1,122 ( 59%) 
Split 3       844 (28.1%)     24.7%         1.8 1,165 ( 61%) 
Split 4       792 (26.4%)     16.8%         2.0 1,173 ( 62%) 
Split 5       703 (23.4%)     11.9%         2.1 1,128 ( 59%) 
Split 6       530 (17.7%)     10.5%         2.1 1,051 ( 55%) 
Split 7       507 (16.9%)      9.6%         1.9 1,028 ( 54%) 
Resample      507 (16.9%)       NA%          NA 1,329 ( 70%) 

Sampling diagnostics for Mergesplit Steps of SMC run 5 of 5 (5,000 samples)
          Acc. rate MS Steps per Plan
MS Step 1     26.4%               120
MS Step 2     19.3%               240
MS Step 3     14.6%               360
MS Step 4     12.5%               420
MS Step 5     11.7%               540
MS Step 6     11.2%               540
MS Step 7     10.3%               540

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny