### PR TITLE
1990 Wisconsin Congressional Districts

### DIFF
--- a/analyses/WI_cd_1990/01_prep_WI_cd_1990.R
+++ b/analyses/WI_cd_1990/01_prep_WI_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `WI_cd_1990` analysis
+# © ALARM Project, January 2026
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WI_cd_1990}")
+
+path_data <- download_redistricting_file("WI", "data-raw/WI", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WI_1990/shp_vtd.rds"
+perim_path <- "data-out/WI_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong WI} shapefile")
+  # read in redistricting data
+  wi_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(state = as.character(state)) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$WI)
+  
+  wi_shp <- wi_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = wi_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    wi_shp <- rmapshaper::ms_simplify(wi_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+  
+  # create adjacency graph
+  wi_shp$adj <- redist.adjacency(wi_shp)
+  
+  write_rds(wi_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  wi_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong WI} shapefile")
+}

--- a/analyses/WI_cd_1990/02_setup_WI_cd_1990.R
+++ b/analyses/WI_cd_1990/02_setup_WI_cd_1990.R
@@ -1,0 +1,20 @@
+###############################################################################
+# Set up redistricting simulation for `WI_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WI_cd_1990}")
+
+map <- redist_map(wi_shp, pop_tol = 0.005,
+                  existing_plan = cd_1990, adj = wi_shp$adj)
+
+# make pseudo counties with default settings
+map <- map %>%
+  mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+                                          pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "WI_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/WI_1990/WI_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WI_cd_1990/03_sim_WI_cd_1990.R
+++ b/analyses/WI_cd_1990/03_sim_WI_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `WI_cd_1990`
+# © ALARM Project, August 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WI_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
+
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WI_1990/WI_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WI_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WI_1990/WI_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+}

--- a/analyses/WI_cd_1990/doc_WI_cd_1990.md
+++ b/analyses/WI_cd_1990/doc_WI_cd_1990.md
@@ -1,0 +1,24 @@
+# 1990 Wisconsin Congressional Districts
+
+## Redistricting requirements
+In Wisconsin, there are no specific legal requirements.
+We impose the following constraints. 
+In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%.
+We add a pseudocounty constraint as described below.
+
+## Data Sources
+Data for Wisconsin comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Wisconsin across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+We create pseudocounties for use in the county constraint to match norms in the state of having low county and municipality splits, despite no rules regarding this.


### PR DESCRIPTION
## Redistricting requirements
In Wisconsin, there are no specific legal requirements.
We impose the following constraints. 
In our simulations, districts must:

1. be contiguous
1. have equal populations

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%.
We add a pseudocounty constraint as described below.

## Data Sources
Data for Wisconsin comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Wisconsin across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
We create pseudocounties for use in the county constraint to match norms in the state of having low county and municipality splits, despite no rules regarding this.

## Validation
<img width="3000" height="4500" alt="validation_20260112_1250" src="https://github.com/user-attachments/assets/4bce5308-6ebe-47b1-b4d3-40b08201568f" />

```
✔ Preparing WI shapefile ... done
SMC: 5,000 sampled plans of 9 districts on 1,354 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.67 to 0.90
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv 
        1.005         1.029         1.018         1.005         1.041         1.037         1.026 
     plan_dev      pop_aian     pop_asian     pop_black      pop_hisp     pop_other   pop_overlap 
        1.012         1.028         1.024         1.022         1.029         1.025         1.020 
    pop_white     total_vap      vap_aian     vap_asian     vap_black      vap_hisp     vap_other 
        1.022         1.016         1.023         1.029         1.031         1.025         1.038 
    vap_white 
        1.030 
• R-hat ≤ 1.05: 198
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 198
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       842 (42.1%)     11.5%        1.13 1,245 ( 98%)      6 
Split 2       881 (44.1%)     15.2%        0.93   948 ( 75%)      4 
Split 3       824 (41.2%)     19.2%        0.83   960 ( 76%)      3 
Split 4       800 (40.0%)     16.8%        0.81 1,014 ( 80%)      3 
Split 5       773 (38.7%)     14.4%        0.79   990 ( 78%)      3 
Split 6       745 (37.3%)     12.5%        0.80   996 ( 79%)      3 
Split 7       727 (36.4%)     14.7%        0.80   950 ( 75%)      2 
Split 8     1,732 (86.6%)      5.4%        0.41   873 ( 69%)      2 
Resample    1,732 (86.6%)       NA%          NA 1,666 (132%)     NA 

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       784 (39.2%)     11.5%        1.14 1,203 ( 95%)      6 
Split 2       815 (40.7%)     15.9%        0.93   906 ( 72%)      4 
Split 3       827 (41.3%)     18.0%        0.84   984 ( 78%)      3 
Split 4       753 (37.6%)     16.9%        0.82   996 ( 79%)      3 
Split 5       898 (44.9%)     21.0%        0.76   955 ( 76%)      2 
Split 6       780 (39.0%)     18.6%        0.79 1,011 ( 80%)      2 
Split 7       833 (41.7%)      9.8%        0.69   926 ( 73%)      3 
Split 8     1,795 (89.8%)      5.0%        0.37   920 ( 73%)      2 
Resample    1,795 (89.8%)       NA%          NA 1,735 (137%)     NA 

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       786 (39.3%)     10.2%        1.12 1,246 ( 99%)      7 
Split 2       860 (43.0%)     12.9%        0.94   916 ( 72%)      5 
Split 3       935 (46.8%)     14.5%        0.82   993 ( 79%)      4 
Split 4       838 (41.9%)     17.4%        0.79 1,040 ( 82%)      3 
Split 5     1,000 (50.0%)     21.2%        0.74 1,025 ( 81%)      2 
Split 6       762 (38.1%)     13.3%        0.74 1,010 ( 80%)      3 
Split 7       718 (35.9%)     14.8%        0.73   946 ( 75%)      2 
Split 8     1,806 (90.3%)      5.1%        0.34   890 ( 70%)      2 
Resample    1,806 (90.3%)       NA%          NA 1,752 (139%)     NA 

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       801 (40.0%)     10.3%        1.14 1,228 ( 97%)      7 
Split 2       781 (39.0%)     12.6%        0.94   908 ( 72%)      5 
Split 3       794 (39.7%)     14.6%        0.85   954 ( 75%)      4 
Split 4       750 (37.5%)     17.1%        0.81   990 ( 78%)      3 
Split 5       904 (45.2%)     15.0%        0.77   987 ( 78%)      3 
Split 6       695 (34.8%)     13.0%        0.76 1,016 ( 80%)      3 
Split 7       887 (44.4%)     15.8%        0.81   947 ( 75%)      2 
Split 8     1,751 (87.5%)      2.8%        0.43   860 ( 68%)      4 
Resample    1,751 (87.5%)       NA%          NA 1,693 (134%)     NA 

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       800 (40.0%)     11.4%        1.11 1,195 ( 95%)      6 
Split 2       814 (40.7%)     15.9%        0.95   920 ( 73%)      4 
Split 3       916 (45.8%)     18.3%        0.83   959 ( 76%)      3 
Split 4       835 (41.7%)     23.8%        0.82 1,026 ( 81%)      2 
Split 5       838 (41.9%)     21.2%        0.75 1,002 ( 79%)      2 
Split 6       742 (37.1%)     18.1%        0.77   988 ( 78%)      2 
Split 7       582 (29.1%)     15.3%        0.83   948 ( 75%)      2 
Split 8     1,805 (90.2%)      5.6%        0.35   811 ( 64%)      2 
Resample    1,805 (90.2%)       NA%          NA 1,739 (138%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny 