### PR TITLE
1990 Oregon Congressional Districts

### DIFF
--- a/analyses/OR_cd_1990/01_prep_OR_cd_1990.R
+++ b/analyses/OR_cd_1990/01_prep_OR_cd_1990.R
@@ -1,0 +1,86 @@
+###############################################################################
+# Download and prepare data for `OR_cd_1990` analysis
+# © ALARM Project, January 2026
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(baf)
+  library(cli)
+  library(here)
+  library(tigris)
+  library(ggplot2)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OR_cd_1990}")
+
+path_data <- download_redistricting_file("OR", "data-raw/OR", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OR_1990/shp_vtd.rds"
+perim_path <- "data-out/OR_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong OR} shapefile")
+  # read in redistricting data
+  or_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+    mutate(state = as.character(state)) |>
+    join_vtd_shapefile(year = 1990) |>
+    st_transform(EPSG$OR)
+  
+  or_shp <- or_shp |>
+    rename(muni = place) |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, cd_1980, .after = county)
+  
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = or_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+  
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+
+  # create adjacency graph
+  or_shp$adj <- redist.adjacency(or_shp)
+  
+  # Disconnect counties not connected by state or federal highways
+  disconn_cty <- function(adj, cty1, cty2) {
+    v1 <- which(or_shp$county == cty1)
+    if (length(v1) == 0) stop(cty1, " not found")
+    v2 <- which(or_shp$county == cty2)
+    if (length(v2) == 0) stop(cty2, " not found")
+    vs <- tidyr::crossing(v1, v2)
+    remove_edge(adj, vs$v1, vs$v2)
+  }
+  
+  or_shp$adj <- or_shp$adj %>%
+    disconn_cty("015", "033") %>%  # Curry – Josephine
+    disconn_cty("053", "041") %>%  # Polk – Lincoln
+    disconn_cty("003", "039") %>%  # Benton – Lane
+    disconn_cty("047", "031") %>%  # Marion – Jefferson
+    disconn_cty("047", "065") %>%  # Marion – Wasco
+    disconn_cty("063", "001") %>%  # Wallowa – Baker
+    disconn_cty("049", "023") %>%  # Morrow – Grant
+    disconn_cty("013", "023") %>%  # Crook – Grant
+    disconn_cty("017", "025") %>%  # Deschutes – Harney
+    disconn_cty("017", "043")      # Deschutes – Linn
+  
+  write_rds(or_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  or_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong OR} shapefile")
+}

--- a/analyses/OR_cd_1990/02_setup_OR_cd_1990.R
+++ b/analyses/OR_cd_1990/02_setup_OR_cd_1990.R
@@ -1,0 +1,24 @@
+#############################################################################
+# Set up redistricting simulation for `OR_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_1990}")
+
+map <- redist_map(or_shp, pop_tol = 0.005,
+                  existing_plan = cd_1990, adj = or_shp$adj)
+
+# make pseudo counties with default settings
+map <- map |>
+  mutate(
+    pseudo_county = pick_county_muni(
+      map, counties = county, munis = muni,
+      pop_muni = get_target(map)
+    )
+  )
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "OR_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/OR_1990/OR_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OR_cd_1990/03_sim_OR_cd_1990.R
+++ b/analyses/OR_cd_1990/03_sim_OR_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `OR_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OR_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
+
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OR_1990/OR_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OR_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OR_1990/OR_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+  
+  validate_analysis(plans, map)
+  summary(plans)
+}

--- a/analyses/OR_cd_1990/doc_OR_cd_1990.md
+++ b/analyses/OR_cd_1990/doc_OR_cd_1990.md
@@ -1,0 +1,28 @@
+# 1990 Oregon Congressional Districts
+
+## Redistricting requirements
+In Oregon, districts must, under [Or. Rev. Stat. § 188.010](https://oregon.public.law/statutes/ors_188.010):
+
+1. be contiguous
+1. be of equal population
+1. utilize existing geographic or political boundaries
+1. not divide communities of common interest
+1. be connected by transportation links
+
+Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+We apply a county/municipality constraint, as described below.
+To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway. 
+
+## Data Sources
+Data for New Hampshire comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+As described above, counties lacking state or federal highway links were manually disconnected. Given the stability of major highway connectivity over time, we apply the same county disconnections as in prior analyses.
+The full list of these counties can be found in the `01_prep_OR_cd_1990.R` file.
+
+## Simulation Notes
+We sample 10,000 districting plans for Oregon across 5 independent runs of the SMC algorithm.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Oregon, districts must, under [Or. Rev. Stat. § 188.010](https://oregon.public.law/statutes/ors_188.010):

1. be contiguous
1. be of equal population
1. utilize existing geographic or political boundaries
1. not divide communities of common interest
1. be connected by transportation links

Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.
To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway. 

## Data Sources
Data for Oregon comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
As described above, counties lacking state or federal highway links were manually disconnected. Given the stability of major highway connectivity over time, we apply the same county disconnections as in prior analyses.
The full list of these counties can be found in the `01_prep_OR_cd_1990.R` file.

## Simulation Notes
We sample 10,000 districting plans for Oregon across 5 independent runs of the SMC algorithm.
To balance county and municipality splits, we create pseudocounties for use in the county constraint.

## Validation
<img width="3000" height="4500" alt="validation_20260118_0017" src="https://github.com/user-attachments/assets/9c7db4d4-2881-46e3-8f55-374731c57e45" />

```
✔ Preparing OR shapefile ... done
SMC: 5,000 sampled plans of 5 districts on 727 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:          
• `weight_type` = optimal
• `seq_alpha` = 1        
• `pop_temper` = 0       
Plan diversity 80% range: 0.44 to 0.82
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv 
        1.001         1.005         1.001         1.001         1.006         1.005 
          nrv      plan_dev      pop_aian     pop_asian     pop_black      pop_hisp 
        1.005         1.003         1.003         1.004         1.003         1.004 
    pop_other   pop_overlap     pop_white     total_vap      vap_aian     vap_asian 
        1.003         1.003         1.005         1.002         1.004         1.004 
    vap_black      vap_hisp     vap_other     vap_white 
        1.003         1.003         1.004         1.003 
• R-hat ≤ 1.05: 110      
• 1.05 < R-hat ≤ 1.1: 0  
• R-hat > 1.1: 0         
• Total R-hats: 110      
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       855 (42.8%)      9.2%        0.93 1,233 ( 98%)      5 
Split 2       788 (39.4%)      9.3%        0.78   981 ( 78%)      4 
Split 3       763 (38.1%)     10.6%        0.76   967 ( 76%)      3 
Split 4     1,604 (80.2%)      5.1%        0.48   909 ( 72%)      2 
Resample    1,604 (80.2%)       NA%          NA 1,622 (128%)     NA 

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       815 (40.8%)      8.0%        0.92 1,201 ( 95%)      6 
Split 2       778 (38.9%)      9.3%        0.79   941 ( 74%)      4 
Split 3       820 (41.0%)     10.7%        0.75   966 ( 76%)      3 
Split 4     1,651 (82.6%)      4.7%        0.44   957 ( 76%)      2 
Resample    1,651 (82.6%)       NA%          NA 1,661 (131%)     NA 

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       873 (43.6%)      9.0%        0.92 1,179 ( 93%)      5 
Split 2       758 (37.9%)     12.1%        0.80   974 ( 77%)      3 
Split 3       911 (45.5%)     16.0%        0.76   959 ( 76%)      2 
Split 4     1,603 (80.2%)      4.7%        0.48   956 ( 76%)      2 
Resample    1,603 (80.2%)       NA%          NA 1,624 (128%)     NA 

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       809 (40.5%)      7.8%        0.94 1,169 ( 92%)      6 
Split 2       854 (42.7%)      7.4%        0.79   945 ( 75%)      5 
Split 3       845 (42.2%)      8.2%        0.73   975 ( 77%)      4 
Split 4     1,618 (80.9%)      3.3%        0.48   936 ( 74%)      3 
Resample    1,618 (80.9%)       NA%          NA 1,636 (129%)     NA 

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       884 (44.2%)      9.2%        0.92 1,198 ( 95%)      5 
Split 2       817 (40.8%)     12.4%        0.74   975 ( 77%)      3 
Split 3       798 (39.9%)      6.1%        0.75 1,001 ( 79%)      5 
Split 4     1,650 (82.5%)      3.5%        0.46   902 ( 71%)      3 
Resample    1,650 (82.5%)       NA%          NA 1,637 (129%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large
std. devs. of the log weights (more than 3 or so), and low numbers of unique plans. R-hat
values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko 