### PR TITLE
1990 Colorado Congressional Districts

### DIFF
--- a/analyses/CO_cd_1990/01_prep_CO_cd_1990.R
+++ b/analyses/CO_cd_1990/01_prep_CO_cd_1990.R
@@ -1,0 +1,61 @@
+###############################################################################
+# Download and prepare data for `CO_cd_1990` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CO_cd_1990}")
+
+path_data <- download_redistricting_file("CO", "data-raw/CO", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CO_1990/shp_vtd.rds"
+perim_path <- "data-out/CO_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CO} shapefile")
+    # read in redistricting data
+    co_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$CO)
+
+    co_shp <- co_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = co_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        co_shp <- rmapshaper::ms_simplify(co_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    co_shp$adj <- redist.adjacency(co_shp)
+
+    write_rds(co_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    co_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CO} shapefile")
+}

--- a/analyses/CO_cd_1990/02_setup_CO_cd_1990.R
+++ b/analyses/CO_cd_1990/02_setup_CO_cd_1990.R
@@ -1,0 +1,20 @@
+###############################################################################
+# Set up redistricting simulation for `CO_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CO_cd_1990}")
+
+map <- redist_map(co_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = co_shp$adj)
+
+# make pseudo counties with default settings
+map <- map |>
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "CO_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/CO_1990/CO_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CO_cd_1990/03_sim_CO_cd_1990.R
+++ b/analyses/CO_cd_1990/03_sim_CO_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `CO_cd_1990`
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CO_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CO_1990/CO_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CO_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CO_1990/CO_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/CO_cd_1990/doc_CO_cd_1990.md
+++ b/analyses/CO_cd_1990/doc_CO_cd_1990.md
@@ -1,0 +1,26 @@
+# 1990 Colorado Congressional Districts
+
+## Redistricting requirements
+In Colorado, we consult [Colorado Redistricting Cases: the 1990s](https://www.senate.mn/departments/scr/REDIST/Redsum/cosum.htm) and [Forgette et al.](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations, subject to permissible deviations
+1. be geographically compact, recognizing that compactness is a threshold requirement rather than an absolute rule
+1. preserve county and municipality boundaries as much as possible, allowing splits only when justified by competing redistricting criteria
+1. avoid dividing identified communities of interest, except where such divisions are necessary and explicitly justified
+1. consider alternative configurations when political subdivisions are split, ensuring that any split reflects a reasoned choice rather than inadvertence
+1. comply with Section 2 of the Voting Rights Act, including the creation of minority-opportunity districts where required, even if doing so necessitates additional subdivision splits
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Colorado comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Colorado across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000. 
+We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.


### PR DESCRIPTION
## Redistricting requirements
In Colorado, we consult [Colorado Redistricting Cases: the 1990s](https://www.senate.mn/departments/scr/REDIST/Redsum/cosum.htm) and [Forgette et al.](http://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations, subject to permissible deviations
1. be geographically compact, recognizing that compactness is a threshold requirement rather than an absolute rule
1. preserve county and municipality boundaries as much as possible, allowing splits only when justified by competing redistricting criteria
1. avoid dividing identified communities of interest, except where such divisions are necessary and explicitly justified
1. consider alternative configurations when political subdivisions are split, ensuring that any split reflects a reasoned choice rather than inadvertence
1. comply with Section 2 of the Voting Rights Act, including the creation of minority-opportunity districts where required, even if doing so necessitates additional subdivision splits

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for Colorado comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Colorado across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.

## Validation

<img width="504" height="750" alt="Screenshot 2025-12-21 at 8 11 04 PM" src="https://github.com/user-attachments/assets/2949b604-4120-499a-a59d-8d4000610fff" />

```
SMC: 5,000 sampled plans of 6 districts on 979 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.39 to 0.77

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_asian      pop_aian     pop_white     pop_black 
        1.010         1.003         1.004         1.006         1.006         1.006         1.007         1.014         1.004 
     pop_hisp     pop_other      vap_hisp      vap_aian     vap_other     vap_white     vap_black     vap_asian county_splits 
        1.004         1.004         1.003         1.004         1.004         1.003         1.003         1.005         1.005 
  muni_splits           ndv           nrv       ndshare 
        1.005         1.006         1.006         1.003 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,918 (95.9%)      7.3%        0.43 1,271 (101%)      7 
Split 2     1,869 (93.4%)     11.9%        0.51 1,222 ( 97%)      4 
Split 3     1,831 (91.5%)     14.6%        0.58 1,213 ( 96%)      3 
Split 4     1,790 (89.5%)     12.9%        0.64 1,169 ( 92%)      3 
Split 5     1,786 (89.3%)      3.1%        0.68 1,068 ( 84%)      4 
Resample    1,300 (65.0%)       NA%        0.67 1,453 (115%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,918 (95.9%)      7.4%        0.43 1,280 (101%)      7 
Split 2     1,867 (93.3%)      9.4%        0.51 1,244 ( 98%)      5 
Split 3     1,816 (90.8%)     11.0%        0.61 1,216 ( 96%)      4 
Split 4     1,787 (89.3%)     12.9%        0.65 1,160 ( 92%)      3 
Split 5     1,747 (87.3%)      5.9%        0.71 1,083 ( 86%)      2 
Resample    1,096 (54.8%)       NA%        0.68 1,400 (111%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,914 (95.7%)      7.1%        0.45 1,260 (100%)      7 
Split 2     1,871 (93.6%)      9.7%        0.51 1,221 ( 97%)      5 
Split 3     1,825 (91.2%)     14.8%        0.59 1,234 ( 98%)      3 
Split 4     1,803 (90.1%)     17.9%        0.62 1,170 ( 93%)      2 
Split 5     1,752 (87.6%)      6.0%        0.69 1,065 ( 84%)      2 
Resample    1,133 (56.6%)       NA%        0.68 1,425 (113%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,914 (95.7%)      7.4%        0.44 1,278 (101%)      7 
Split 2     1,872 (93.6%)      9.3%        0.50 1,246 ( 99%)      5 
Split 3     1,822 (91.1%)     14.2%        0.60 1,203 ( 95%)      3 
Split 4     1,765 (88.2%)     18.2%        0.65 1,154 ( 91%)      2 
Split 5     1,719 (86.0%)      6.0%        0.71 1,046 ( 83%)      2 
Resample      934 (46.7%)       NA%        0.69 1,386 (110%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,918 (95.9%)      8.5%        0.43 1,255 ( 99%)      6 
Split 2     1,871 (93.6%)     11.6%        0.51 1,253 ( 99%)      4 
Split 3     1,827 (91.4%)     14.3%        0.59 1,236 ( 98%)      3 
Split 4     1,768 (88.4%)      8.0%        0.65 1,185 ( 94%)      5 
Split 5     1,761 (88.0%)      2.5%        0.71 1,041 ( 82%)      5 
Resample    1,210 (60.5%)       NA%        0.69 1,432 (113%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko