### PR TITLE
1990 Missouri Congressional Districts

### DIFF
--- a/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Download and prepare data for `MO_cd_1990` analysis
+# © ALARM Project, January 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MO_cd_1990}")
+
+path_data <- download_redistricting_file("MO", "data-raw/MO", year = 1990)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MO_1990/shp_vtd.rds"
+perim_path <- "data-out/MO_1990/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MO} shapefile")
+    # read in redistricting data
+    mo_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) |>
+        mutate(state = as.character(state)) |> # FIX (ensures state is character variable across datasets)
+        join_vtd_shapefile(year = 1990) |>
+        st_transform(EPSG$MO)
+
+    mo_shp <- mo_shp |>
+        rename(muni = place) |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, cd_1980, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mo_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mo_shp <- rmapshaper::ms_simplify(mo_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mo_shp$adj <- redist.adjacency(mo_shp)
+
+    write_rds(mo_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mo_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MO} shapefile")
+}

--- a/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
@@ -54,6 +54,37 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     mo_shp$adj <- redist.adjacency(mo_shp)
 
+    ###############################################################################
+    # Logit-shift ndv/nrv to match 1990 LEIP county results
+    ###############################################################################
+
+    # 1. Load the LEIP county CSV as `leip_cty` ----
+    leip_cty <- read_csv(
+      here("data-raw/baseline_voteshare_leip_92.csv"),
+      show_col_types = FALSE
+    )
+
+    # 2. Add county_fips column based on VTD GEOID ----
+    mo_shp <- mo_shp |>
+      mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
+
+    names(al_shp)
+
+    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    mo_shp <- mo_shp |>
+      group_by(county_fips) |>
+      group_split() |>
+      lapply(function(x) {
+        meds <- leip_cty |>
+          filter(county == x$county_fips[1])
+        target <- meds$dshare_92[1]
+
+        if (is.na(target)) return(x)
+
+        logit_shift_baseline(x, ndv = ndv, nrv = nrv, target = target)
+      }) |>
+      bind_rows()
+
     write_rds(mo_shp, here(shp_path), compress = "gz")
     cli_process_done()
 } else {

--- a/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
@@ -68,7 +68,7 @@ if (!file.exists(here(shp_path))) {
     mo_shp <- mo_shp |>
       mutate(county_fips = stringr::str_sub(GEOID, 1, 5))
 
-    names(al_shp)
+    names(mo_shp)
 
     # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
     mo_shp <- mo_shp |>

--- a/analyses/MO_cd_1990/02_setup_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/02_setup_MO_cd_1990.R
@@ -1,0 +1,15 @@
+###############################################################################
+# Set up redistricting simulation for `MO_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MO_cd_1990}")
+
+map <- redist_map(mo_shp, pop_tol = 0.005,
+    existing_plan = cd_1990, adj = mo_shp$adj)
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "MO_1990"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/MO_1990/MO_cd_1990_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MO_cd_1990/03_sim_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/03_sim_MO_cd_1990.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `MO_cd_1990`
+# © ALARM Project, January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MO_cd_1990}")
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 5e3, runs = 5, counties = county)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MO_1990/MO_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MO_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MO_1990/MO_cd_1990_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots for custom constraints -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/MO_cd_1990/03_sim_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/03_sim_MO_cd_1990.R
@@ -6,8 +6,14 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MO_cd_1990}")
 
+constr <- redist_constr(map) %>%
+    add_constr_grp_hinge(+8, vap_black, vap, 0.47) %>%
+    add_constr_grp_hinge(-8, vap_black, vap, 0.15) %>%
+    add_constr_grp_hinge(-4, vap_black, vap, 0.10)
+
 set.seed(1990)
-plans <- redist_smc(map, nsims = 5e3, runs = 5, counties = county)
+plans <- redist_smc(map, nsims = 5e3, runs = 5, counties = county,
+    constraints = constr)
 
 plans <- plans |>
     group_by(chain) |>

--- a/analyses/MO_cd_1990/doc_MO_cd_1990.md
+++ b/analyses/MO_cd_1990/doc_MO_cd_1990.md
@@ -10,7 +10,7 @@ In Missouri, we consult [Forgette et al.](https://www.jstor.org/stable/40421634)
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting one majority-minority district to comply with VRA requirements and match the number in the enacted plan.
 
 ## Data Sources
 Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

--- a/analyses/MO_cd_1990/doc_MO_cd_1990.md
+++ b/analyses/MO_cd_1990/doc_MO_cd_1990.md
@@ -1,0 +1,23 @@
+# 1990 Missouri Congressional Districts
+
+## Redistricting requirements
+In Missouri, we consult [Forgette et al.](https://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:
+
+1. be contiguous
+1. have equal populations
+1. be geographically compact
+1. preserve county and municipality boundaries as much as possible
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+
+## Data Sources
+Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 25,000 districting plans for Missouri across 5 independent runs of the SMC algorithm to aid with convergence.
+We then thinned the number of samples to 5,000. 


### PR DESCRIPTION
## Redistricting requirements
In Missouri, we consult [Forgette et al.](https://www.jstor.org/stable/40421634) and impose the following constraints. In our simulations, districts must:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible


### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constraint targeting one majority-minority district to comply with VRA requirements and match the number in the enacted plan.

## Data Sources
Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 25,000 districting plans for Missouri across 5 independent runs of the SMC algorithm to aid with convergence.
We then thinned the number of samples to 5,000. 

## Validation

<img width="429" height="769" alt="Screenshot 2026-01-24 at 2 01 14 PM" src="https://github.com/user-attachments/assets/15b852d6-4fc7-409e-9510-e5514c30456c" />

```
SMC: 5,000 sampled plans of 9 districts on 1,248 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`est_label_mult`=1 • `pop_temper`=0

Plan diversity 80% range: 0.60 to 0.79

R-hat values for summary statistics:
        pop_overlap           total_vap            plan_dev           comp_edge         comp_polsby     comp_bbox_reock 
              1.012               1.014               1.004               1.002               1.009               1.014 
          pop_asian            pop_aian           pop_white           pop_black            pop_hisp           pop_other 
              1.008               1.012               1.006               1.007               1.010               1.010 
           vap_hisp            vap_aian           vap_other           vap_white           vap_black           vap_asian 
              1.009               1.013               1.003               1.008               1.004               1.015 
      county_splits total_county_splits         muni_splits   total_muni_splits                 ndv                 nrv 
              1.003               1.003               1.014               1.011               1.011               1.012 
            ndshare 
              1.010 

Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,989 (79.8%)     11.3%        0.33 3,195 (101%)      6 
Split 2     3,823 (76.5%)     15.0%        0.56 2,906 ( 92%)      4 
Split 3     3,744 (74.9%)     13.0%        0.66 2,923 ( 92%)      4 
Split 4     3,731 (74.6%)     15.6%        0.74 2,895 ( 92%)      3 
Split 5     3,709 (74.2%)     13.9%        0.77 2,832 ( 90%)      3 
Split 6     3,532 (70.6%)     18.2%        0.80 2,772 ( 88%)      2 
Split 7     3,707 (74.1%)     15.2%        0.76 2,715 ( 86%)      2 
Split 8     3,135 (62.7%)      5.2%        0.74 2,484 ( 79%)      2 
Resample    1,222 (24.4%)       NA%        1.45 2,422 ( 77%)     NA 

Sampling diagnostics for SMC run 2 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,990 (79.8%)     11.4%        0.33 3,175 (100%)      6 
Split 2     3,833 (76.7%)     14.8%        0.58 2,947 ( 93%)      4 
Split 3     3,792 (75.8%)     10.8%        0.67 2,934 ( 93%)      5 
Split 4     3,780 (75.6%)     15.2%        0.75 2,841 ( 90%)      3 
Split 5     3,726 (74.5%)     20.4%        0.77 2,857 ( 90%)      2 
Split 6     3,627 (72.5%)     18.2%        0.78 2,791 ( 88%)      2 
Split 7     3,658 (73.2%)     15.0%        0.76 2,735 ( 87%)      2 
Split 8     3,170 (63.4%)      3.4%        0.73 2,527 ( 80%)      3 
Resample    1,267 (25.3%)       NA%        1.41 2,454 ( 78%)     NA 

Sampling diagnostics for SMC run 3 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,993 (79.9%)     11.4%        0.33 3,152 (100%)      6 
Split 2     3,838 (76.8%)     15.2%        0.57 2,963 ( 94%)      4 
Split 3     3,760 (75.2%)     17.8%        0.68 2,921 ( 92%)      3 
Split 4     3,695 (73.9%)     22.0%        0.74 2,885 ( 91%)      2 
Split 5     3,657 (73.1%)     14.0%        0.78 2,861 ( 91%)      3 
Split 6     3,649 (73.0%)      9.5%        0.78 2,820 ( 89%)      4 
Split 7     3,704 (74.1%)     10.0%        0.75 2,745 ( 87%)      3 
Split 8     3,412 (68.2%)      4.8%        0.70 2,486 ( 79%)      2 
Resample    1,657 (33.1%)       NA%        1.36 2,620 ( 83%)     NA 

Sampling diagnostics for SMC run 4 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,996 (79.9%)      9.9%        0.33 3,152 (100%)      7 
Split 2     3,855 (77.1%)     11.9%        0.55 2,927 ( 93%)      5 
Split 3     3,812 (76.2%)     13.0%        0.66 2,923 ( 92%)      4 
Split 4     3,726 (74.5%)     15.3%        0.74 2,917 ( 92%)      3 
Split 5     3,675 (73.5%)     20.1%        0.81 2,848 ( 90%)      2 
Split 6     3,640 (72.8%)     12.5%        0.81 2,783 ( 88%)      3 
Split 7     3,701 (74.0%)     15.4%        0.76 2,765 ( 87%)      2 
Split 8     3,407 (68.1%)      5.1%        0.74 2,480 ( 78%)      2 
Resample    1,532 (30.6%)       NA%        1.31 2,582 ( 82%)     NA 

Sampling diagnostics for SMC run 5 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     3,981 (79.6%)     11.6%        0.32 3,138 ( 99%)      6 
Split 2     3,851 (77.0%)     11.8%        0.57 2,944 ( 93%)      5 
Split 3     3,816 (76.3%)     12.9%        0.64 2,911 ( 92%)      4 
Split 4     3,744 (74.9%)     15.4%        0.75 2,898 ( 92%)      3 
Split 5     3,674 (73.5%)     14.1%        0.81 2,817 ( 89%)      3 
Split 6     3,510 (70.2%)     18.8%        0.86 2,740 ( 87%)      2 
Split 7     3,698 (74.0%)     15.0%        0.76 2,730 ( 86%)      2 
Split 8     3,226 (64.5%)      5.3%        0.71 2,536 ( 80%)      2 
Resample    1,358 (27.2%)       NA%        1.40 2,467 ( 78%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or
so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko

Below is the BVAP performance plot with the logit shift in place:
<img width="1044" height="788" alt="Rplot" src="https://github.com/user-attachments/assets/b1c249ac-1152-41e3-a939-09db72bca621" />

Below is the BVAP performance plot without the logit shift in place:
<img width="870" height="844" alt="MO_BVAP_no_logit" src="https://github.com/user-attachments/assets/a8a39c41-b9a8-4d2d-81ab-ca2375bf2353" />
