### PR TITLE
2020 Michigan State House/Senate Districts

### DIFF
--- a/analyses/MI_leg_2020/01_prep_MI_leg_2020.R
+++ b/analyses/MI_leg_2020/01_prep_MI_leg_2020.R
@@ -1,0 +1,90 @@
+###############################################################################
+# Download and prepare data for `MI_leg_2020` analysis
+# © ALARM Project, January 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MI_leg_2020}")
+
+path_data <- download_redistricting_file("MI", "data-raw/MI", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MI_2020/shp_vtd.rds"
+perim_path <- "data-out/MI_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MI} shapefile")
+    # read in redistricting data
+    mi_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$MI)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MI", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("MI"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("MI", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("MI"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("MI", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("MI"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    mi_shp <- mi_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    mi_shp <- mi_shp |>
+        left_join(y = leg_from_baf(state = "MI"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mi_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mi_shp <- rmapshaper::ms_simplify(mi_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mi_shp$adj <- adjacency(mi_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(mi_shp$adj, mi_shp$ssd_2020)
+    ccm(mi_shp$adj, mi_shp$shd_2020)
+
+    mi_shp <- mi_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(mi_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mi_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MI} shapefile")
+}

--- a/analyses/MI_leg_2020/02_setup_MI_leg_2020.R
+++ b/analyses/MI_leg_2020/02_setup_MI_leg_2020.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `MI_leg_2020`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MI_leg_2020}")
+
+map_ssd <- redist_map(mi_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = mi_shp$adj)
+
+map_shd <- redist_map(mi_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = mi_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "MI_SSD_2020"
+attr(map_shd, "analysis_name") <- "MI_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/MI_2020/MI_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/MI_2020/MI_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MI_leg_2020/02_setup_MI_leg_2020.R
+++ b/analyses/MI_leg_2020/02_setup_MI_leg_2020.R
@@ -13,10 +13,10 @@ map_shd <- redist_map(mi_shp, pop_tol = 0.05,
 # make pseudo counties with default settings
 map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-        pop_muni = get_target(map_ssd)))
+        pop_muni = 3.5*get_target(map_ssd)))
 map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-        pop_muni = get_target(map_shd)))
+        pop_muni = 3.5*get_target(map_shd)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/MI_leg_2020/03_sim_MI_shd_2020.R
+++ b/analyses/MI_leg_2020/03_sim_MI_shd_2020.R
@@ -1,0 +1,53 @@
+###############################################################################
+# Simulate plans for `MI_shd_2020` SHD
+# © ALARM Project, January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MI_shd_2020}")
+
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 15
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 2e3, runs = 5, ncores = 15L,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MI_2020/MI_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MI_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MI_2020/MI_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/MI_leg_2020/03_sim_MI_shd_2020.R
+++ b/analyses/MI_leg_2020/03_sim_MI_shd_2020.R
@@ -8,9 +8,7 @@ cli_process_start("Running simulations for {.pkg MI_shd_2020}")
 
 set.seed(2020)
 
-# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 15
-
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 40
 plans <- redist_smc(
     map_shd,
     nsims = 2e3, runs = 5, ncores = 15L,

--- a/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
+++ b/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
@@ -1,0 +1,52 @@
+###############################################################################
+# Simulate plans for `MI_ssd_2020` SSD
+# © ALARM Project,January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MI_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5, ncores = 15L,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MI_2020/MI_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MI_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MI_2020/MI_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
+++ b/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Simulate plans for `MI_ssd_2020` SSD
-# © ALARM Project,January 2026
+# © ALARM Project, January 2026
 ###############################################################################
 
 # Run the simulation -----
@@ -8,7 +8,7 @@ cli_process_start("Running simulations for {.pkg MI_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3)
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 10
 
 plans <- redist_smc(
     map_ssd,

--- a/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
+++ b/analyses/MI_leg_2020/03_sim_MI_ssd_2020.R
@@ -10,14 +10,22 @@ set.seed(2020)
 
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 10
 
+# Municipality splits constraint
+map_ssd <- map_ssd |>
+  mutate(muni_constr = if_else(is.na(muni), county, county_muni))
+
+constr <- redist_constr(map_ssd)
+constr <- add_constr_total_splits(constr, strength = 0.5, admin = muni_constr)
+
 plans <- redist_smc(
-    map_ssd,
-    nsims = 2e3, runs = 5, ncores = 15L,
-    counties = pseudo_county,
-    sampling_space = "linking_edge",
-    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-    split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = TRUE
+  map_ssd,
+  nsims = 2e3, runs = 5, ncores = 15L,
+  counties = pseudo_county,
+  constraints = constr,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
 )
 
 plans <- plans |>

--- a/analyses/MI_leg_2020/doc_MI_leg_2020.md
+++ b/analyses/MI_leg_2020/doc_MI_leg_2020.md
@@ -1,0 +1,28 @@
+# 2020 Michigan State House/Senate Districts
+
+## Redistricting requirements
+In Michigan, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous [NCSL 184]
+2. have equal populations
+3. be not favoring any incumbent [NCSL 185]
+4. be not favoring any political party [NCSL 185]
+5. be geographically compact
+6. generally follow county and municipal boundaries, minimizing splits where feasible [NCSL 184]
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Michigan's lower house across 5 independent runs of the SMC algorithm.
+To ensure chain convergence for this 110-district simulation, we tune the MCMC parameters such that each run of merge-split should accept 52 changes, on average.
+
+We sample 10,000 districting plans for Michigan's upper house across 5 independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.

--- a/analyses/MI_leg_2020/doc_MI_leg_2020.md
+++ b/analyses/MI_leg_2020/doc_MI_leg_2020.md
@@ -21,8 +21,10 @@ Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Michigan's lower house across 5 independent runs of the SMC algorithm.
-To ensure chain convergence for this 110-district simulation, we tune the MCMC parameters such that each run of merge-split should accept 52 changes, on average.
+We generated an ensemble of plans for the Kansas State House using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
+We tuned the MCMC parameters so that each run accepted about 82 merge-split proposals on average.
+We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_shd)`.
 
-We sample 10,000 districting plans for Michigan's upper house across 5 independent runs of the SMC algorithm.
-No special techniques were needed to produce the sample.
+We generated an ensemble of plans for the Kansas State Senate using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
+We tuned the MCMC parameters so that each run accepted about 24 merge-split proposals on average.
+We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_ssd)`.

--- a/analyses/MI_leg_2020/doc_MI_leg_2020.md
+++ b/analyses/MI_leg_2020/doc_MI_leg_2020.md
@@ -28,3 +28,4 @@ We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 *
 We generated an ensemble of plans for the Kansas State Senate using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
 We tuned the MCMC parameters so that each run accepted about 24 merge-split proposals on average.
 We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_ssd)`.
+We added a soft total municipality-splits constraint during sampling using `add_constr_total_splits()` with `strength = 0.5` and `admin = muni_constr`.

--- a/analyses/MI_leg_2020/doc_MI_leg_2020.md
+++ b/analyses/MI_leg_2020/doc_MI_leg_2020.md
@@ -21,11 +21,12 @@ Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files]
 No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
-We generated an ensemble of plans for the Kansas State House using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
-We tuned the MCMC parameters so that each run accepted about 82 merge-split proposals on average.
-We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_shd)`.
 
-We generated an ensemble of plans for the Kansas State Senate using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
+We generated an ensemble of plans for the Michigan State House using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
+We tuned the MCMC parameters so that each run accepted about 82 merge-split proposals on average.
+We used a pseudo-county constraint to limit county and municipality splits while preserving population balance and contiguity.
+
+We generated an ensemble of plans for the Michigan State Senate using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
 We tuned the MCMC parameters so that each run accepted about 24 merge-split proposals on average.
-We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_ssd)`.
-We added a soft total municipality-splits constraint during sampling using `add_constr_total_splits()` with `strength = 0.5` and `admin = muni_constr`.
+We used a pseudo-county constraint to limit county and municipality splits while preserving population balance and contiguity.
+We also added a soft municipality-splits constraint to encourage the simulated plans to better respect municipal boundaries where feasible.


### PR DESCRIPTION
# 2020 Michigan State House/Senate Districts

## Redistricting requirements
In Michigan, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous [NCSL 184]
2. have equal populations
3. be not favoring any incumbent [NCSL 185]
4. be not favoring any political party [NCSL 185]
5. be geographically compact
6. generally follow county and municipal boundaries, minimizing splits where feasible [NCSL 184]


### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Michigan comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We generated an ensemble of plans for the Kansas State House using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
We tuned the MCMC parameters so that each run accepted about 82 merge-split proposals on average.
We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_shd)`.

We generated an ensemble of plans for the Kansas State Senate using the merge-split SMC sampler. We ran 5 independent chains with 2,000 simulated plans per run.
We tuned the MCMC parameters so that each run accepted about 24 merge-split proposals on average.
We constructed pseudo-counties using `pick_county_muni()` with `pop_muni = 3.5 * get_target(map_ssd)`.
We added a soft total municipality-splits constraint during sampling using `add_constr_total_splits()` with `strength = 0.5` and `admin = muni_constr`.


## Validation
### SSD

<img width="3000" height="5400" alt="validation_20260428_1928" src="https://github.com/user-attachments/assets/fe3a320f-3fd6-4778-a624-fe5b579be661" />


```
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.016               1.022               1.016               1.018 
             arv_18              arv_20      atg_18_dem_nes      atg_18_rep_leo 
              1.020               1.020               1.020               1.019 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.040               1.004               1.028               1.008 
              e_dem               e_dvs                egap      gov_18_dem_whi 
              1.008               1.021               1.008               1.022 
     gov_18_rep_sch         muni_splits             ndshare                 ndv 
              1.020               1.002               1.022               1.018 
                nrv               pbias            plan_dev            pop_aian 
              1.020               1.006               1.000               1.022 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.015               1.022               1.016               1.026 
          pop_other         pop_overlap             pop_two           pop_white 
              1.029               1.003               1.019               1.010 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.009               1.016               1.018               1.016 
     pre_20_rep_tru      sos_18_dem_ben      sos_18_rep_lan total_county_splits 
              1.019               1.020               1.019               1.005 
  total_muni_splits           total_vap      uss_18_dem_sta      uss_18_rep_jam 
              1.006               1.003               1.021               1.020 
     uss_20_dem_pet      uss_20_rep_jam            vap_aian           vap_asian 
              1.016               1.021               1.019               1.016 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.024               1.014               1.032               1.030 
            vap_two           vap_white 
              1.021               1.009 
• R-hat ≤ 1.05: 2028
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2028
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       655 (32.7%)    100.0%        1.41 1,283 (101%) 
Split 2       754 (37.7%)     98.3%        1.70   886 ( 70%) 
Split 3       818 (40.9%)     96.3%        1.76   899 ( 71%) 
Split 4       930 (46.5%)     94.4%        1.68   948 ( 75%) 
Split 5       958 (47.9%)     93.7%        1.67   953 ( 75%) 
Split 6     1,052 (52.6%)     90.7%        1.59   969 ( 77%) 
Split 7     1,025 (51.2%)     88.3%        1.63 1,008 ( 80%) 
Split 8     1,119 (55.9%)     86.9%        1.55 1,001 ( 79%) 
Split 9     1,166 (58.3%)     86.3%        1.50 1,018 ( 81%) 
Split 10    1,160 (58.0%)     82.8%        1.45 1,026 ( 81%) 
Split 11    1,213 (60.7%)     81.2%        1.43 1,028 ( 81%) 
Split 12    1,203 (60.2%)     79.2%        1.43 1,045 ( 83%) 
Split 13    1,220 (61.0%)     77.5%        1.45 1,054 ( 83%) 
Split 14    1,234 (61.7%)     75.3%        1.43 1,061 ( 84%) 
Split 15    1,226 (61.3%)     73.7%        1.39 1,029 ( 81%) 
Split 16    1,258 (62.9%)     73.0%        1.39 1,037 ( 82%) 
Split 17    1,245 (62.3%)     68.3%        1.37 1,060 ( 84%) 
Split 18    1,214 (60.7%)     70.3%        1.42 1,068 ( 84%) 
Split 19    1,259 (62.9%)     66.0%        1.36 1,060 ( 84%) 
Split 20    1,253 (62.7%)     63.7%        1.31 1,082 ( 86%) 
Split 21    1,258 (62.9%)     63.2%        1.26 1,036 ( 82%) 
Split 22    1,242 (62.1%)     61.3%        1.32 1,059 ( 84%) 
Split 23    1,279 (63.9%)     59.8%        1.22 1,053 ( 83%) 
Split 24    1,218 (60.9%)     57.7%        1.29 1,079 ( 85%) 
Split 25    1,245 (62.3%)     57.9%        1.30 1,042 ( 82%) 
Split 26    1,239 (62.0%)     57.3%        1.32 1,054 ( 83%) 
Split 27    1,243 (62.2%)     55.9%        1.28 1,051 ( 83%) 
Split 28    1,206 (60.3%)     53.7%        1.25 1,058 ( 84%) 
Split 29    1,237 (61.9%)     51.9%        1.20 1,002 ( 79%) 
Split 30    1,215 (60.7%)     52.2%        1.20 1,026 ( 81%) 
Split 31    1,232 (61.6%)     51.1%        1.12 1,046 ( 83%) 
Split 32    1,258 (62.9%)     49.6%        1.06 1,013 ( 80%) 
Split 33    1,284 (64.2%)     49.4%        1.05 1,081 ( 86%) 
Split 34    1,303 (65.2%)     46.5%        0.99 1,056 ( 84%) 
Split 35    1,325 (66.2%)     45.1%        0.96 1,037 ( 82%) 
Split 36    1,363 (68.2%)     41.1%        0.92 1,037 ( 82%) 
Split 37    1,503 (75.2%)     37.3%        0.71 1,038 ( 82%) 
Resample    1,503 (75.2%)       NA%          NA 1,546 (122%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      42.8%                23
MS Step 2      39.3%                69
MS Step 3      38.5%                69
MS Step 4      38.7%                69
MS Step 5      38.3%                69
MS Step 6      38.4%                69
MS Step 7      37.5%                69
MS Step 8      37.5%                69
MS Step 9      37.3%                69
MS Step 10     36.9%                69
MS Step 11     36.9%                69
MS Step 12     36.4%                69
MS Step 13     35.8%                69
MS Step 14     35.2%                69
MS Step 15     35.1%                69
MS Step 16     35.0%                69
MS Step 17     35.0%                69
MS Step 18     34.5%                69
MS Step 19     34.6%                69
MS Step 20     34.1%                69
MS Step 21     33.8%                69
MS Step 22     33.3%                69
MS Step 23     33.1%                69
MS Step 24     33.0%                92
MS Step 25     32.6%                92
MS Step 26     32.3%                92
MS Step 27     31.9%                92
MS Step 28     31.9%                92
MS Step 29     31.6%                92
MS Step 30     31.6%                92
MS Step 31     31.3%                92
MS Step 32     31.1%                92
MS Step 33     31.1%                92
MS Step 34     31.2%                92
MS Step 35     31.2%                92
MS Step 36     30.9%                92
MS Step 37     31.1%                92
```
### SHD

<img width="3000" height="5400" alt="validation_20260428_0714" src="https://github.com/user-attachments/assets/1dac3d86-345f-4536-9674-810feae65e8b" />


```
Largest R-hat values for ordered summary statistics:
            adv_16              adv_18              adv_20              arv_16 
              1.026               1.015               1.012               1.019 
             arv_18              arv_20      atg_18_dem_nes      atg_18_rep_leo 
              1.039               1.027               1.014               1.037 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.019               1.002               1.007               1.016 
              e_dem               e_dvs                egap      gov_18_dem_whi 
              1.022               1.017               1.023               1.012 
     gov_18_rep_sch         muni_splits             ndshare                 ndv 
              1.037               1.009               1.017               1.013 
                nrv               pbias            plan_dev            pop_aian 
              1.032               1.001               1.001               1.020 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.031               1.037               1.010               1.009 
          pop_other         pop_overlap             pop_two           pop_white 
              1.021               1.011               1.016               1.045 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.013               1.026               1.019               1.013 
     pre_20_rep_tru      sos_18_dem_ben      sos_18_rep_lan total_county_splits 
              1.020               1.013               1.041               1.037 
  total_muni_splits           total_vap      uss_18_dem_sta      uss_18_rep_jam 
              1.006               1.004               1.016               1.039 
     uss_20_dem_pet      uss_20_rep_jam            vap_aian           vap_asian 
              1.011               1.035               1.019               1.030 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.025               1.013               1.006               1.016 
            vap_two           vap_white 
              1.011               1.038 

• R-hat ≤ 1.05: 5862
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 5862
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1        847 (42.4%)    100.0%       1.086 1,241 ( 98%) 
Split 2      1,041 (52.1%)     99.6%       1.094 1,013 ( 80%) 
Split 3      1,065 (53.2%)     98.7%       1.050 1,022 ( 81%) 
Split 4      1,172 (58.6%)     98.6%       0.981 1,044 ( 83%) 
Split 5      1,292 (64.6%)     97.6%       0.895 1,083 ( 86%) 
Split 6      1,293 (64.6%)     96.6%       0.868 1,070 ( 85%) 
Split 7      1,354 (67.7%)     95.5%       0.778 1,073 ( 85%) 
Split 8      1,377 (68.9%)     95.2%       0.772 1,109 ( 88%) 
Split 9      1,444 (72.2%)     95.0%       0.723 1,129 ( 89%) 
Split 10     1,476 (73.8%)     93.2%       0.695 1,144 ( 90%) 
Split 11     1,505 (75.3%)     92.0%       0.651 1,124 ( 89%) 
Split 12     1,531 (76.5%)     91.1%       0.635 1,159 ( 92%) 
Split 13     1,562 (78.1%)     91.0%       0.607 1,172 ( 93%) 
Split 14     1,587 (79.3%)     89.1%       0.587 1,182 ( 93%) 
Split 15     1,576 (78.8%)     89.1%       0.581 1,148 ( 91%) 
Split 16     1,653 (82.7%)     88.8%       0.512 1,186 ( 94%) 
Split 17     1,626 (81.3%)     88.4%       0.513 1,198 ( 95%) 
Split 18     1,660 (83.0%)     86.8%       0.495 1,150 ( 91%) 
Split 19     1,680 (84.0%)     85.7%       0.476 1,188 ( 94%) 
Split 20     1,687 (84.4%)     84.7%       0.461 1,202 ( 95%) 
Split 21     1,703 (85.2%)     83.7%       0.446 1,201 ( 95%) 
Split 22     1,710 (85.5%)     84.8%       0.437 1,196 ( 95%) 
Split 23     1,726 (86.3%)     82.6%       0.431 1,202 ( 95%) 
Split 24     1,744 (87.2%)     81.8%       0.396 1,216 ( 96%) 
Split 25     1,746 (87.3%)     81.3%       0.405 1,189 ( 94%) 
Split 26     1,756 (87.8%)     80.0%       0.390 1,189 ( 94%) 
Split 27     1,764 (88.2%)     78.9%       0.378 1,205 ( 95%) 
Split 28     1,770 (88.5%)     78.5%       0.372 1,197 ( 95%) 
Split 29     1,795 (89.8%)     77.0%       0.352 1,253 ( 99%) 
Split 30     1,784 (89.2%)     75.7%       0.362 1,241 ( 98%) 
Split 31     1,805 (90.3%)     76.0%       0.341 1,246 ( 99%) 
Split 32     1,824 (91.2%)     76.5%       0.316 1,213 ( 96%) 
Split 33     1,818 (90.9%)     75.9%       0.330 1,240 ( 98%) 
Split 34     1,827 (91.4%)     73.0%       0.328 1,205 ( 95%) 
Split 35     1,827 (91.3%)     73.0%       0.319 1,210 ( 96%) 
Split 36     1,844 (92.2%)     72.8%       0.303 1,216 ( 96%) 
Split 37     1,836 (91.8%)     70.2%       0.304 1,242 ( 98%) 
Split 38     1,850 (92.5%)     71.6%       0.297 1,228 ( 97%) 
Split 39     1,853 (92.6%)     70.6%       0.292 1,240 ( 98%) 
Split 40     1,866 (93.3%)     69.6%       0.275 1,232 ( 97%) 
Split 41     1,874 (93.7%)     67.9%       0.268 1,214 ( 96%) 
Split 42     1,866 (93.3%)     68.0%       0.276 1,256 ( 99%) 
Split 43     1,868 (93.4%)     66.1%       0.270 1,234 ( 98%) 
Split 44     1,883 (94.2%)     65.6%       0.252 1,230 ( 97%) 
Split 45     1,878 (93.9%)     66.5%       0.262 1,236 ( 98%) 
Split 46     1,887 (94.4%)     64.5%       0.254 1,246 ( 99%) 
Split 47     1,885 (94.2%)     63.0%       0.253 1,268 (100%) 
Split 48     1,883 (94.1%)     63.7%       0.255 1,238 ( 98%) 
Split 49     1,891 (94.5%)     62.5%       0.248 1,237 ( 98%) 
Split 50     1,899 (95.0%)     60.8%       0.238 1,241 ( 98%) 
Split 51     1,898 (94.9%)     62.0%       0.233 1,248 ( 99%) 
Split 52     1,906 (95.3%)     61.1%       0.229 1,242 ( 98%) 
Split 53     1,906 (95.3%)     59.0%       0.230 1,245 ( 98%) 
Split 54     1,908 (95.4%)     58.1%       0.225 1,236 ( 98%) 
Split 55     1,912 (95.6%)     58.8%       0.221 1,255 ( 99%) 
Split 56     1,908 (95.4%)     56.1%       0.222 1,228 ( 97%) 
Split 57     1,916 (95.8%)     56.0%       0.214 1,235 ( 98%) 
Split 58     1,920 (96.0%)     54.9%       0.211 1,247 ( 99%) 
Split 59     1,927 (96.4%)     56.5%       0.198 1,260 (100%) 
Split 60     1,926 (96.3%)     55.1%       0.198 1,234 ( 98%) 
Split 61     1,928 (96.4%)     52.7%       0.196 1,270 (100%) 
Split 62     1,931 (96.5%)     53.1%       0.192 1,230 ( 97%) 
Split 63     1,928 (96.4%)     52.9%       0.198 1,252 ( 99%) 
Split 64     1,933 (96.6%)     52.0%       0.192 1,261 (100%) 
Split 65     1,935 (96.7%)     53.3%       0.187 1,244 ( 98%) 
Split 66     1,938 (96.9%)     52.9%       0.183 1,246 ( 99%) 
Split 67     1,940 (97.0%)     51.9%       0.177 1,253 ( 99%) 
Split 68     1,944 (97.2%)     49.9%       0.172 1,246 ( 99%) 
Split 69     1,937 (96.9%)     47.6%       0.182 1,266 (100%) 
Split 70     1,943 (97.2%)     50.0%       0.173 1,254 ( 99%) 
Split 71     1,945 (97.3%)     48.0%       0.170 1,245 ( 98%) 
Split 72     1,947 (97.3%)     47.3%       0.170 1,232 ( 97%) 
Split 73     1,948 (97.4%)     47.7%       0.165 1,260 (100%) 
Split 74     1,950 (97.5%)     46.0%       0.163 1,258 (100%) 
Split 75     1,952 (97.6%)     46.3%       0.159 1,255 ( 99%) 
Split 76     1,949 (97.5%)     45.6%       0.163 1,258 (100%) 
Split 77     1,951 (97.6%)     44.9%       0.159 1,255 ( 99%) 
Split 78     1,953 (97.6%)     45.8%       0.160 1,227 ( 97%) 
Split 79     1,955 (97.8%)     43.5%       0.154 1,253 ( 99%) 
Split 80     1,958 (97.9%)     44.4%       0.151 1,256 ( 99%) 
Split 81     1,958 (97.9%)     42.9%       0.149 1,228 ( 97%) 
Split 82     1,960 (98.0%)     40.5%       0.144 1,241 ( 98%) 
Split 83     1,959 (97.9%)     41.9%       0.149 1,258 (100%) 
Split 84     1,961 (98.1%)     42.4%       0.142 1,267 (100%) 
Split 85     1,961 (98.1%)     41.5%       0.143 1,258 (100%) 
Split 86     1,962 (98.1%)     40.7%       0.142 1,236 ( 98%) 
Split 87     1,963 (98.2%)     40.0%       0.140 1,242 ( 98%) 
Split 88     1,962 (98.1%)     39.0%       0.142 1,241 ( 98%) 
Split 89     1,966 (98.3%)     37.6%       0.133 1,242 ( 98%) 
Split 90     1,966 (98.3%)     40.2%       0.132 1,254 ( 99%) 
Split 91     1,967 (98.4%)     36.8%       0.131 1,215 ( 96%) 
Split 92     1,966 (98.3%)     37.9%       0.134 1,236 ( 98%) 
Split 93     1,969 (98.5%)     36.9%       0.127 1,244 ( 98%) 
Split 94     1,968 (98.4%)     37.1%       0.129 1,273 (101%) 
Split 95     1,968 (98.4%)     36.5%       0.130 1,269 (100%) 
Split 96     1,968 (98.4%)     36.7%       0.129 1,239 ( 98%) 
Split 97     1,970 (98.5%)     36.9%       0.124 1,242 ( 98%) 
Split 98     1,970 (98.5%)     36.3%       0.126 1,257 ( 99%) 
Split 99     1,975 (98.8%)     34.7%       0.113 1,259 (100%) 
Split 100    1,974 (98.7%)     34.6%       0.117 1,230 ( 97%) 
Split 101    1,974 (98.7%)     32.6%       0.118 1,223 ( 97%) 
Split 102    1,976 (98.8%)     33.2%       0.112 1,214 ( 96%) 
Split 103    1,977 (98.8%)     33.8%       0.112 1,248 ( 99%) 
Split 104    1,977 (98.9%)     33.0%       0.109 1,227 ( 97%) 
Split 105    1,977 (98.9%)     33.2%       0.110 1,248 ( 99%) 
Split 106    1,978 (98.9%)     32.1%       0.108 1,228 ( 97%) 
Split 107    1,980 (99.0%)     31.3%       0.105 1,190 ( 94%) 
Split 108    1,984 (99.2%)     30.9%       0.091 1,189 ( 94%) 
Split 109    1,985 (99.2%)     30.0%       0.089 1,115 ( 88%) 
Resample     1,985 (99.2%)       NA%          NA 1,946 (154%) 


Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1       49.4%                77
MS Step 2       48.6%               231
MS Step 3       48.8%               231
MS Step 4       48.8%               231
MS Step 5       48.6%               231
MS Step 6       48.9%               231
MS Step 7       48.9%               231
MS Step 8       48.9%               231
MS Step 9       48.9%               231
MS Step 10      48.8%               231
MS Step 11      48.8%               231
MS Step 12      48.7%               231
MS Step 13      48.7%               231
MS Step 14      48.6%               231
MS Step 15      48.6%               231
MS Step 16      48.7%               231
MS Step 17      48.3%               231
MS Step 18      48.3%               231
MS Step 19      48.2%               231
MS Step 20      48.2%               231
MS Step 21      48.1%               231
MS Step 22      48.1%               231
MS Step 23      48.1%               231
MS Step 24      47.8%               231
MS Step 25      47.8%               231
MS Step 26      47.6%               231
MS Step 27      47.7%               231
MS Step 28      47.6%               231
MS Step 29      47.3%               231
MS Step 30      47.3%               231
MS Step 31      47.3%               231
MS Step 32      47.1%               231
MS Step 33      47.0%               231
MS Step 34      46.9%               231
MS Step 35      46.5%               231
MS Step 36      46.2%               231
MS Step 37      46.3%               231
MS Step 38      46.1%               231
MS Step 39      46.1%               231
MS Step 40      46.0%               231
MS Step 41      45.8%               231
MS Step 42      45.8%               231
MS Step 43      45.3%               231
MS Step 44      45.2%               231
MS Step 45      45.1%               231
MS Step 46      44.9%               231
MS Step 47      44.9%               231
MS Step 48      44.7%               231
MS Step 49      44.6%               231
MS Step 50      44.4%               231
MS Step 51      44.1%               231
MS Step 52      44.0%               231
MS Step 53      43.8%               231
MS Step 54      43.7%               231
MS Step 55      43.4%               231
MS Step 56      43.2%               231
MS Step 57      43.2%               231
MS Step 58      43.1%               231
MS Step 59      42.9%               231
MS Step 60      42.8%               231
MS Step 61      42.4%               231
MS Step 62      42.3%               231
MS Step 63      42.1%               231
MS Step 64      41.9%               231
MS Step 65      41.8%               231
MS Step 66      41.6%               231
MS Step 67      41.5%               231
MS Step 68      41.1%               231
MS Step 69      40.9%               231
MS Step 70      40.8%               231
MS Step 71      40.5%               231
MS Step 72      40.5%               231
MS Step 73      40.1%               231
MS Step 74      39.9%               231
MS Step 75      39.6%               231
MS Step 76      39.4%               231
MS Step 77      39.2%               231
MS Step 78      39.2%               231
MS Step 79      38.9%               231
MS Step 80      38.6%               231
MS Step 81      38.4%               231
MS Step 82      38.2%               231
MS Step 83      38.1%               231
MS Step 84      37.8%               231
MS Step 85      37.5%               231
MS Step 86      37.3%               231
MS Step 87      37.3%               231
MS Step 88      36.9%               231
MS Step 89      36.8%               231
MS Step 90      36.5%               231
MS Step 91      36.2%               231
MS Step 92      36.2%               231
MS Step 93      35.9%               231
MS Step 94      35.7%               231
MS Step 95      35.7%               231
MS Step 96      35.2%               231
MS Step 97      34.9%               231
MS Step 98      34.7%               231
MS Step 99      34.6%               231
MS Step 100     34.3%               231
MS Step 101     34.3%               231
MS Step 102     33.9%               231
MS Step 103     33.7%               231
MS Step 104     33.5%               231
MS Step 105     33.3%               231
MS Step 106     33.1%               308
MS Step 107     32.8%               308
MS Step 108     32.6%               308
MS Step 109     32.5%               308
```
## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny 