### PR TITLE
2000 Washington Congressional Districts Update

### DIFF
--- a/analyses/WA_cd_2000/01_prep_WA_cd_2000.R
+++ b/analyses/WA_cd_2000/01_prep_WA_cd_2000.R
@@ -1,0 +1,192 @@
+###############################################################################
+# Download and prepare data for `WA_cd_2000` analysis
+# © ALARM Project, February 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WA_cd_2000}")
+
+path_data <- download_redistricting_file("WA", "data-raw/WA", year = 2000, overwrite = TRUE)
+
+# download ferry routes
+url <- "https://data.wsdot.wa.gov/geospatial/DOT_TDO/FerryRoutes/FerryRoutes.zip"
+path_ferries <- "data-raw/WA/WA_ferries.zip"
+download(url, path_ferries)
+unzip(here(path_ferries), exdir = here(dirname(path_ferries), "WA_ferries"))
+file.remove(path_ferries)
+path_ferries <- "data-raw/WA/WA_ferries/FerryRoutes/FerryRoutes.shp"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WA_2000/shp_vtd.rds"
+perim_path <- "data-out/WA_2000/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WA} shapefile")
+    # read in redistricting data
+    wa_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$WA)
+
+    wa_shp <- wa_shp %>%
+        rename(muni = place) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = wa_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wa_shp <- rmapshaper::ms_simplify(wa_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    wa_shp$adj <- redist.adjacency(wa_shp)
+
+    # for geographic links
+    # need to use 2011 data due to 1990 not being available (earliest for prisecroads)
+    d_roads <- tigris::primary_secondary_roads("53", year = 2011) %>%
+        st_transform(EPSG$WA)
+
+    d_water <- filter(tigris::fips_codes, state == "WA")$county_code %>%
+        lapply(function(cty) tigris::area_water("53", cty, year = 2011)) %>%
+        do.call(bind_rows, .) %>%
+        st_transform(EPSG$WA)
+
+    d_ferries <- read_sf(path_ferries) %>%
+        st_transform(EPSG$WA) %>%
+        st_cast("MULTILINESTRING")
+
+    # create adjacency graph
+    wa_shp <- st_make_valid(wa_shp)
+    sf::sf_use_s2(FALSE)
+    wa_shp$adj <- redist.adjacency(wa_shp)
+
+    if (is.null(wa_shp$geometry)) {
+        wa_shp$geometry <- sf::st_geometry(wa_shp)
+        sf::st_geometry(wa_shp) <- "geometry"
+    }
+
+    # disconnect water
+    d_bigwater <- filter(d_water, as.numeric(st_area(d_water)) > 1e7) %>%
+        summarize() %>% st_make_valid() %>%
+        rmapshaper::ms_simplify(keep = 0.05) %>%
+        st_snap(wa_shp$geometry, tolerance = 100) %>%
+        st_buffer(1.0)
+
+    geom_adj <- st_difference(wa_shp, d_bigwater$geometry)
+    geom_adj <- bind_rows(
+        geom_adj,
+        st_buffer(filter(wa_shp, !GEOID %in% geom_adj$GEOID), -50)
+    )
+    geom_adj <- slice(geom_adj, match(wa_shp$GEOID, geom_adj$GEOID))
+
+    adj_nowater <- redist.adjacency(wa_shp)
+    adj_0 <- redist.adjacency(geom_adj)
+    wa_shp$adj <- adj_0
+
+    # disconnect all counties
+    for (i in seq_along(wa_shp$adj)) {
+        cty_i <- wa_shp$county[i]
+        adj_i <- wa_shp$adj[[i]] + 1L
+        cty_j <- wa_shp$county[adj_i]
+        diff_cty <- which(cty_j != cty_i)
+        if (length(diff_cty) > 0) {
+            wa_shp$adj <- remove_edge(wa_shp$adj, rep(i, length(diff_cty)), adj_i[diff_cty])
+        }
+    }
+
+    # reconnect precincts across county borders by roads + ferries
+    geom_roads_ferries <- c(d_roads$geometry, d_ferries$geometry)
+    rel_roads_ferries <- st_crosses(geom_roads_ferries, wa_shp)
+
+    for (i in seq_along(rel_roads_ferries)) {
+        rel_i <- rel_roads_ferries[[i]]
+        if (length(rel_i) == 1) next
+        for (j in rel_i) {
+            adj_j <- setdiff(intersect(adj_nowater[[j]] + 1L, rel_i), wa_shp$adj[[j]] + 1L)
+            if (length(adj_j) > 0) {
+                wa_shp$adj <- add_edge(wa_shp$adj, rep(j, length(adj_j)), adj_j)
+            }
+        }
+    }
+
+    # Connect precincts
+    left_ids <- c(
+        "53033000755", "53033000756", "53033000757", "53033000758", "53033000759",
+        "53033000761", "53033000762", "53033000763", "53033000765", "53033000766",
+        "53033000767", "53033000768", "53033000769", "53033000770", "53033000771",
+        "53033000772", "53033000773", "53033000774", "53033000775", "53033000776",
+        "53033000777", "53033000778", "53033000779", "53033000780", "53033000781",
+        "53033000782", "53033000783", "53033000784", "53033000785", "53033000786",
+        "53033000787", "53033000788", "53033000789", "53033000790", "53033000791",
+        "53033000792", "53033000793", "53033000794", "53033000795", "53033000796",
+        "53033000797", "53033002465",
+        "53007WVCRWN", "53011WVVAN1", "530270WVOS1", "530310WVPTE", "530310WVPTS",
+        "53033001818", "530330WVMED", "530330WVRED", "53033WVEB11", "53033WVEB43",
+        "53033WVLW11", "53033WVLW33", "53033WVLW41", "53033WVMERI", "53033WVPS30",
+        "53033WVPS32", "53061WVEDM1", "53061WVPS38", "53061WVWOD1",
+        "53033002445", "53033002691", "53033002808", "53061000339", "53033002809"
+    )
+
+    right_ids <- c(
+        "53033WVMERI",
+        "53033000755", "53033000756", "53033000757", "53033000758", "53033000759",
+        "53033000761", "53033000762", "53033000763", "53033000765", "53033000766",
+        "53033000767", "53033000768", "53033000769", "53033000770", "53033000771",
+        "53033000772", "53033000773", "53033000774", "53033000775", "53033000776",
+        "53033000777", "53033000778", "53033000779", "53033000780", "53033000781",
+        "53033000782", "53033000783", "53033000784", "53033000785", "53033000786",
+        "53033000787", "53033000788", "53033000789", "53033000790", "53033000791",
+        "53033000792", "53033000793", "53033000794", "53033000795", "53033000796",
+        "53033000797",
+        "53007007303", "53011011675", "53027027801",
+        "53031WVPTBY", "53031WVPTBY",
+        "53033001817", "53033WVBE41", "53033009166", "53033001493", "53033001834",
+        "530330WVS37", "53033WVNPK1", "53033WVRT11", "53033000099", "53033003019",
+        "53033000514", "53029WVPUGS", "53029WVSARP", "53061000232",
+        "53033WVMERI", "53033000765", "53033000774", "53061WVPS10", "53033000795"
+    )
+
+    stopifnot(length(left_ids) == length(right_ids))
+
+    # ensure GEOID is character
+    wa_shp <- wa_shp |>
+        mutate(GEOID = as.character(GEOID))
+
+    for (k in seq_along(left_ids)) {
+        u <- match(left_ids[k], wa_shp$GEOID)
+        v <- match(right_ids[k], wa_shp$GEOID)
+
+        if (!is.na(u) && !is.na(v)) {
+            wa_shp$adj <- add_edge(wa_shp$adj, u, v, zero = TRUE)
+        }
+    }
+
+    wa_shp <- wa_shp %>%
+        fix_geo_assignment(muni)
+
+    write_rds(wa_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    wa_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WA} shapefile")
+}

--- a/analyses/WA_cd_2000/02_setup_WA_cd_2000.R
+++ b/analyses/WA_cd_2000/02_setup_WA_cd_2000.R
@@ -1,14 +1,31 @@
 ###############################################################################
 # Set up redistricting simulation for `WA_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, February 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg WA_cd_2000}")
 
-map <- redist_map(wa_shp, pop_tol = 0.005,
-    existing_plan = cd_2000, adj = wa_shp$adj)
+map <- redist_map(
+    wa_shp,
+    pop_tol = 0.005,
+    existing_plan = cd_2000,
+    adj = wa_shp$adj
+)
+
+# Create pseudo counties to avoid county/municipality splitting
+map <- map %>%
+    mutate(
+        pseudo_county = pick_county_muni(
+            map,
+            counties = county,
+            munis = muni,
+            pop_muni = get_target(map)
+        )
+    )
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "WA_2000"
+
+map$state <- "WA"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/WA_2000/WA_cd_2000_map.rds", compress = "xz")

--- a/analyses/WA_cd_2000/03_sim_WA_cd_2000.R
+++ b/analyses/WA_cd_2000/03_sim_WA_cd_2000.R
@@ -1,26 +1,24 @@
 ###############################################################################
 # Simulate plans for `WA_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg WA_cd_2000}")
 
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
-
-plans <- plans %>%
+plans <- redist_smc(map, nsims = 10000, counties = pseudo_county, runs = 5) %>%
+    match_numbers("cd_2000") %>%
     group_by(chain) %>%
     filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
     ungroup()
-plans <- match_numbers(plans, "cd_2000")
+
+plans <- match_numbers(plans, map$cd_2000)
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# Output the redist_map object. Do not edit this path.
+# Output the redist_plans object.
 write_rds(plans, here("data-out/WA_2000/WA_cd_2000_plans.rds"), compress = "xz")
 cli_process_done()
 
@@ -29,16 +27,7 @@ cli_process_start("Computing summary statistics for {.pkg WA_cd_2000}")
 
 plans <- add_summary_stats(plans, map)
 
-# Output the summary statistics. Do not edit this path.
+# Output the summary statistics.
 save_summary_stats(plans, "data-out/WA_2000/WA_cd_2000_stats.csv")
 
 cli_process_done()
-
-# Extra validation plots for custom constraints -----
-if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
-
-    validate_analysis(plans, map)
-    summary(plans)
-}

--- a/analyses/WA_cd_2000/doc_WA_cd_2000.md
+++ b/analyses/WA_cd_2000/doc_WA_cd_2000.md
@@ -1,26 +1,23 @@
 # 2000 Washington Congressional Districts
 
 ## Redistricting requirements
-In Washington, districts must:
+In Washington, according to [State Constitution, Article II, Section 43, as adopted by Amendment 74 in 1983](https://leg.wa.gov/media/o3fg0ey1/washington-state-constitution.pdf), districts must:
 
 1. be contiguous
 1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-1. provide fair and effective representation and encourage electoral competition
-1. not be drawn to favor or discriminate against a political party or group
+1. be geographically compact and convenient
+1. respect natural, artificial, and political subdivision boundaries where reasonable
+1. not be drawn to favor or discriminate against any political party or group
 
-The above information is largely sourced from the [Washington State Redistricting Commission's Report in 2000](https://app.leg.wa.gov/oralhistory/redistricting2/2000-beyond/2000-Excerpt_from_WA_State_Redistricting_Commission-7a-2.pdf).
-
-### Algorithmic Constraints
-We enforce a maximum population deviation of 0.5%.
+### Interpretation of requirements
+We enforce a maximum population deviation of 0.5%. For contiguity, we modify the precinct adjacency graph to account for major water barriers and to allow connections across water and county boundaries via highways and Washington State Ferry routes.
 
 ## Data Sources
-Data for Washington comes from the ALARM Project's [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. We also manually connected precincts in the adjacency graph.
 
 ## Simulation Notes
-We sample 5,000 districting plans for Washington.
-No special techniques were needed to produce the sample.
+We sampled 50,000 districting plans for Washington across 5 independent runs using the SMC algorithm and thinned the samples down to 5,000.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.


### PR DESCRIPTION
## Redistricting requirements
In Washington, according to [State Constitution, Article II, Section 43, as adopted by Amendment 74 in 1983](https://leg.wa.gov/media/o3fg0ey1/washington-state-constitution.pdf), districts must:

1. be contiguous
1. have equal populations
1. be geographically compact and convenient
1. respect natural, artificial, and political subdivision boundaries where reasonable
1. not be drawn to favor or discriminate against any political party or group

### Interpretation of requirements
We enforce a maximum population deviation of 0.5%. For contiguity, we modify the precinct adjacency graph to account for major water barriers and to allow connections across water and county boundaries via highways and Washington State Ferry routes.

## Data Sources
Data for Washington comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
As described above, the adjacency graph was modified by hand to reflect Washington's contiguity requirements. We also manually connected precincts in the adjacency graph.

## Simulation Notes
We sampled 50,000 districting plans for Washington across 5 independent runs using the SMC algorithm and thinned the samples down to 5,000.
To balance county and municipality splits, we create pseudocounties for use in the county constraint, which leads to fewer municipality splits than using a county constraint.

## Validation
<img width="3000" height="4500" alt="validation_20260221_2255" src="https://github.com/user-attachments/assets/eb840ca4-306d-4373-9256-0cfe93265a29" />

```
Summary
✔ Preparing WA shapefile ... done
SMC: 5,000 sampled plans of 9 districts on 7,475 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.46 to 0.74
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare 
        1.004         1.016         1.012         1.002         1.019 
          ndv           nrv      plan_dev      pop_aian     pop_asian 
        1.016         1.020         1.012         1.009         1.016 
    pop_black      pop_hisp      pop_nhpi     pop_other   pop_overlap 
        1.018         1.015         1.010         1.024         1.008 
      pop_two     pop_white     total_vap      vap_aian     vap_asian 
        1.020         1.017         1.015         1.017         1.014 
    vap_black      vap_hisp      vap_nhpi     vap_other       vap_two 
        1.018         1.016         1.011         1.021         1.023 
    vap_white 
        1.021 
• R-hat ≤ 1.05: 234
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 234
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     2,863 (28.6%)     13.6%        1.16 6,265 ( 99%)     12 
Split 2     2,823 (28.2%)     21.4%        1.06 4,315 ( 68%)      7 
Split 3     3,024 (30.2%)     30.8%        0.97 4,444 ( 70%)      4 
Split 4     2,887 (28.9%)     18.8%        0.93 4,626 ( 73%)      7 
Split 5     3,062 (30.6%)     23.5%        0.93 4,659 ( 74%)      5 
Split 6     3,143 (31.4%)     23.3%        0.87 4,635 ( 73%)      4 
Split 7     2,198 (22.0%)     24.5%        1.02 4,528 ( 72%)      3 
Split 8     9,034 (90.3%)      9.2%        0.31 4,204 ( 67%)      2 
Resample    9,034 (90.3%)       NA%          NA 8,744 (138%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than
1%), large std. devs. of the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics should be between 1 and
1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko