### PR TITLE
2000 Maryland Congressional Districts Update

### DIFF
--- a/analyses/MD_cd_2000/01_prep_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/01_prep_MD_cd_2000.R
@@ -1,23 +1,24 @@
 ###############################################################################
 # Download and prepare data for MD_cd_2000 analysis
-# © ALARM Project, October 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
 suppressMessages({
-  library(dplyr)
-  library(readr)
-  library(sf)
-  library(redist)
-  library(geomander)
-  library(baf)
-  library(cli)
-  library(here)
-  devtools::load_all() # load utilities
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
 })
 
 # Download necessary files for analysis -----
 cli_process_start("Downloading files for {.pkg MD_cd_2000}")
 path_data <- download_redistricting_file("MD", "data-raw/MD", year = 2000)
+
 cli_process_done()
 
 # Compile raw data into a final shapefile for analysis -----
@@ -25,99 +26,100 @@ shp_path <- "data-out/MD_2000/shp_vtd.rds"
 perim_path <- "data-out/MD_2000/perim.rds"
 
 if (!file.exists(here(shp_path))) {
-  cli_process_start("Preparing {.strong MD} shapefile")
-  # read in redistricting data
-  md_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
-    # If the state is not at the VTD-level, swap in a `tinytiger::tt_*` function
-    join_vtd_shapefile(year = 2000) %>%
-    st_transform(EPSG$MD)
-  
-  md_shp <- md_shp %>%
-    rename(muni = place) %>%
-    mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
-    relocate(muni, county_muni, cd_1990, .after = county)
-  
-  # ensure valid geoms; keep all polygons 
-  suppressMessages(sf::sf_use_s2(FALSE))
-  md_shp <- sf::st_zm(md_shp, drop = TRUE, what = "ZM")
-  md_shp <- sf::st_make_valid(md_shp)
-  
-  write_rds(md_shp, here(shp_path), compress = "gz")
-  cli_process_done()
+    cli_process_start("Preparing {.strong MD} shapefile")
+    # read in redistricting data
+    md_shp <- read_csv(here(path_data), col_types = cols(GEOID = "c")) %>%
+        join_vtd_shapefile(year = 2000) %>%
+        st_transform(EPSG$MD)
+
+    md_shp <- md_shp %>%
+        rename(muni = place) %>%
+        mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, cd_1990, .after = county)
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        md_shp <- rmapshaper::ms_simplify(md_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
+
+    md_shp <- md_shp %>%
+        fix_geo_assignment(muni)
+
+    # compute merge groups
+    md_shp$merge_group <- contiguity_merges(md_shp)
+
+    # create adjacency graph
+    md_shp$adj <- redist.adjacency(md_shp)
+
+    # Identify Bay units
+    bay_ids <- c("24003ZZZZZZ", "24005ZZZZZZ", "24009ZZZZZZ",
+        "24029ZZZZZZ", "24037ZZZZZZ", "24041ZZZZZZ")
+
+    # For each Bay unit, remove edges to its neighbors using subtract_edge()
+    for (bid in bay_ids) {
+        if (!(bid %in% md_shp$GEOID)) next
+        i <- match(bid, md_shp$GEOID)
+        nbr_idx    <- md_shp$adj[[i]] + 1L
+        nbr_geoids <- md_shp$GEOID[nbr_idx]
+
+        for (nid in nbr_geoids) {
+            md_shp$adj <- geomander::subtract_edge(
+                md_shp$adj, bid, nid, ids = md_shp$GEOID
+            )
+        }
+    }
+
+    # connect an island
+    isle_u <- "2403702-001"
+    isle_v <- "2403709-001"
+    u <- match(isle_u, md_shp$GEOID)
+    v <- match(isle_v, md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    # Connect bay precincts
+    u <- match("24029ZZZZZZ", md_shp$GEOID)
+    v <- match("2402906-001", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    u <- match("24005ZZZZZZ", md_shp$GEOID)
+    v <- match("2400515-019", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    u <- match("24003ZZZZZZ", md_shp$GEOID)
+    v <- match("2400306-024", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    u <- match("24009ZZZZZZ", md_shp$GEOID)
+    v <- match("2400902-002", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    u <- match("24037ZZZZZZ", md_shp$GEOID)
+    v <- match("2403701-001", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    u <- match("24041ZZZZZZ", md_shp$GEOID)
+    v <- match("2404105-001", md_shp$GEOID)
+    if (!is.na(u) && !is.na(v)) {
+        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    }
+
+    write_rds(md_shp, here(shp_path), compress = "gz")
+    cli_process_done()
 } else {
-  md_shp <- read_rds(here(shp_path))
-  cli_alert_success("Loaded {.strong MD} base shapefile (unchanged geometry)")
+    md_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MD} shapefile")
 }
-
-# Build adjacency on full layer, then edit via subtract_edge()
-cli_process_start("Building full adjacency and editing edges (no shape edits)")
-
-# Build adjacency once on the full layer
-md_shp$adj <- redist.adjacency(md_shp)
-attr(md_shp$adj, "zero_indexed") <- TRUE
-
-# Identify Bay units
-bay_ids <- c("24003ZZZZZZ","24005ZZZZZZ","24009ZZZZZZ",
-             "24029ZZZZZZ","24037ZZZZZZ","24041ZZZZZZ")
-
-# For each Bay unit, remove edges to its neighbors using subtract_edge()
-for (bid in bay_ids) {
-  if (!(bid %in% md_shp$GEOID)) next
-  i <- match(bid, md_shp$GEOID)
-  nbr_idx    <- md_shp$adj[[i]] + 1L        
-  nbr_geoids <- md_shp$GEOID[nbr_idx]
-  
-  for (nid in nbr_geoids) {
-    md_shp$adj <- geomander::subtract_edge(
-      md_shp$adj, bid, nid, ids = md_shp$GEOID
-    )
-  }
-}
-
-# connect an island
-isle_u <- "2403702-001"
-isle_v <- "2403709-001"
-u <- match(isle_u, md_shp$GEOID)
-v <- match(isle_v, md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-# Connect bay precincts
-u <- match("24029ZZZZZZ", md_shp$GEOID)
-v <- match("2402906-001", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-u <- match("24005ZZZZZZ", md_shp$GEOID)
-v <- match("2400515-019", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-u <- match("24003ZZZZZZ", md_shp$GEOID)
-v <- match("2400306-024", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-u <- match("24009ZZZZZZ", md_shp$GEOID)
-v <- match("2400902-002", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-u <- match("24037ZZZZZZ", md_shp$GEOID)
-v <- match("2403701-001", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-u <- match("24041ZZZZZZ", md_shp$GEOID)
-v <- match("2404105-001", md_shp$GEOID)
-if (!is.na(u) && !is.na(v)) {
-  md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-}
-
-cli_process_done()

--- a/analyses/MD_cd_2000/01_prep_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/01_prep_MD_cd_2000.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Download and prepare data for MD_cd_2000 analysis
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 suppressMessages({
@@ -12,6 +12,7 @@ suppressMessages({
     library(baf)
     library(cli)
     library(here)
+    library(stringr)
     devtools::load_all() # load utilities
 })
 
@@ -37,6 +38,12 @@ if (!file.exists(here(shp_path))) {
         mutate(muni = as.character(muni), county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
         relocate(muni, county_muni, cd_1990, .after = county)
 
+    redistmetrics::prep_perims(
+        shp = md_shp,
+        perim_path = here(perim_path)
+    ) %>%
+    invisible()
+
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         md_shp <- rmapshaper::ms_simplify(md_shp, keep = 0.05,
@@ -57,64 +64,40 @@ if (!file.exists(here(shp_path))) {
     bay_ids <- c("24003ZZZZZZ", "24005ZZZZZZ", "24009ZZZZZZ",
         "24029ZZZZZZ", "24037ZZZZZZ", "24041ZZZZZZ")
 
-    # For each Bay unit, remove edges to its neighbors using subtract_edge()
+    # Remove all existing edges from each Bay unit
     for (bid in bay_ids) {
         if (!(bid %in% md_shp$GEOID)) next
         i <- match(bid, md_shp$GEOID)
-        nbr_idx    <- md_shp$adj[[i]] + 1L
-        nbr_geoids <- md_shp$GEOID[nbr_idx]
-
-        for (nid in nbr_geoids) {
-            md_shp$adj <- geomander::subtract_edge(
+        nbr_ids <- md_shp$GEOID[md_shp$adj[[i]] + 1L]
+        
+        for (nid in nbr_ids) {
+            md_shp$adj <- subtract_edge(
                 md_shp$adj, bid, nid, ids = md_shp$GEOID
             )
         }
     }
-
-    # connect an island
-    isle_u <- "2403702-001"
-    isle_v <- "2403709-001"
-    u <- match(isle_u, md_shp$GEOID)
-    v <- match(isle_v, md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
+    
     # Connect bay precincts
-    u <- match("24029ZZZZZZ", md_shp$GEOID)
-    v <- match("2402906-001", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
-    u <- match("24005ZZZZZZ", md_shp$GEOID)
-    v <- match("2400515-019", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
-    u <- match("24003ZZZZZZ", md_shp$GEOID)
-    v <- match("2400306-024", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
-    u <- match("24009ZZZZZZ", md_shp$GEOID)
-    v <- match("2400902-002", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
-    u <- match("24037ZZZZZZ", md_shp$GEOID)
-    v <- match("2403701-001", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
-    }
-
-    u <- match("24041ZZZZZZ", md_shp$GEOID)
-    v <- match("2404105-001", md_shp$GEOID)
-    if (!is.na(u) && !is.na(v)) {
-        md_shp$adj <- add_edge(md_shp$adj, u, v, zero = TRUE)
+    edge_additions <- tribble(
+        ~from,          ~to,
+        "2403702-001",  "2403709-001",  
+        "24029ZZZZZZ",  "2402906-001",
+        "24005ZZZZZZ",  "2400515-019",
+        "24003ZZZZZZ",  "2400306-024",
+        "24009ZZZZZZ",  "2400902-002",
+        "24037ZZZZZZ",  "2403701-001",
+        "24041ZZZZZZ",  "2404105-001"
+    )
+  
+    for (k in seq_len(nrow(edge_additions))) {
+        u <- edge_additions$from[[k]]
+        v <- edge_additions$to[[k]]
+    
+        if (u %in% md_shp$GEOID && v %in% md_shp$GEOID) {
+            md_shp$adj <- add_edge(
+                md_shp$adj, u, v, ids = md_shp$GEOID
+            )
+        }
     }
 
     write_rds(md_shp, here(shp_path), compress = "gz")

--- a/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
@@ -15,7 +15,6 @@ map_merged <- map %>%
 attr(map, "analysis_name") <- "MD_2000"
 
 map$state <- "MD"
-map_merged$state <- "MD"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/MD_2000/MD_cd_2000_map.rds", compress = "xz")

--- a/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
@@ -1,27 +1,21 @@
 ###############################################################################
 # Set up redistricting simulation for `MD_cd_2000`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg MD_cd_2000}")
 
 map <- redist_map(md_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = md_shp$adj)
 
-map <- map %>% merge_by(merge_group, drop_geom = FALSE)
-
-# Extract merged geometry as sf
-merged_sf <- sf::st_as_sf(map)
-
-redistmetrics::prep_perims(
-    shp = merged_sf,
-    perim_path = here(perim_path)
-) %>%
-    invisible()
+# Merged map: use this only for simulation
+map_merged <- map %>%
+  merge_by(merge_group, drop_geom = FALSE)
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MD_2000"
 
 map$state <- "MD"
+map_merged$state <- "MD"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/MD_2000/MD_cd_2000_map.rds", compress = "xz")

--- a/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/02_setup_MD_cd_2000.R
@@ -1,53 +1,28 @@
 ###############################################################################
 # Set up redistricting simulation for `MD_cd_2000`
-# © ALARM Project, October 2025
+# © ALARM Project, February 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg MD_cd_2000}")
 
 map <- redist_map(md_shp, pop_tol = 0.005,
-                  existing_plan = cd_2000, adj = md_shp$adj)
+    existing_plan = cd_2000, adj = md_shp$adj)
+
+map <- map %>% merge_by(merge_group, drop_geom = FALSE)
+
+# Extract merged geometry as sf
+merged_sf <- sf::st_as_sf(map)
+
+redistmetrics::prep_perims(
+    shp = merged_sf,
+    perim_path = here(perim_path)
+) %>%
+    invisible()
 
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "MD_2000"
-
-# Compute and attach perimeters for compactness stats; save for reproducibility
-perim_df <- redistmetrics::prep_perims(map)
-attr(map, "perim_df") <- perim_df
-dir.create(here("data-out/MD_2000"), recursive = TRUE, showWarnings = FALSE)
-saveRDS(perim_df, here("data-out/MD_2000/perim.rds"))
 
 map$state <- "MD"
 
 # Output the redist_map object. Do not edit this path.
 write_rds(map, "data-out/MD_2000/MD_cd_2000_map.rds", compress = "xz")
 cli_process_done()
-
-# Define helper function before it is called
-check_valid <- function(pref_n, plans_matrix) {
-  
-  pref_sep <- data.frame(unit = 1, geometry = sf::st_cast(pref_n[1, ]$geometry, "POLYGON"))
-  
-  for (i in 2:nrow(pref_n))
-  {
-    pref_sep <- rbind(pref_sep, data.frame(unit = i, geometry = sf::st_cast(pref_n[i, ]$geometry, "POLYGON")))
-  }
-  
-  pref_sep <- sf::st_as_sf(pref_sep)
-  pref_sep_adj <- redist::redist.adjacency(pref_sep)
-  
-  mainland <- pref_sep[which(unlist(lapply(pref_sep_adj, length)) > 0), ]
-  mainland_adj <- redist::redist.adjacency(mainland)
-  mainland$component <- geomander::check_contiguity(adj = mainland_adj)$component
-  
-  checks <- vector(length = ncol(plans_matrix))
-  mainland_plans <- plans_matrix[mainland$unit, ]
-  
-  for (k in 1:ncol(plans_matrix))
-  {
-    
-    checks[k] <- max(check_contiguity(mainland_adj, mainland_plans[, k])$component) == 1
-  }
-  
-  return(checks)
-  
-}

--- a/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Simulate plans for `MD_cd_2000`
-# © ALARM Project, February 2026
+# © ALARM Project, March 2026
 ###############################################################################
 
 # Run the simulation -----
@@ -8,11 +8,12 @@ cli_process_start("Running simulations for {.pkg MD_cd_2000}")
 
 set.seed(2000)
 plans <- redist_smc(
-    map,
+    map_merged,
     nsims = 3e3,
     runs = 5,
     counties = county
-)
+) %>%
+pullback(map)
 
 plans <- plans %>%
     group_by(chain) %>%

--- a/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
+++ b/analyses/MD_cd_2000/03_sim_MD_cd_2000.R
@@ -1,92 +1,47 @@
 ###############################################################################
 # Simulate plans for `MD_cd_2000`
-# © ALARM Project, October 2025
+# © ALARM Project, February 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg MD_cd_2000}")
 
 set.seed(2000)
-plans <- redist_smc(map, nsims = 45000, runs = 10, counties = county)
+plans <- redist_smc(
+    map,
+    nsims = 3e3,
+    runs = 5,
+    counties = county
+)
 
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
 plans <- match_numbers(plans, "cd_2000")
 
-cli_process_done() 
-
-# Screen for contiguity
-cli_process_start("Screening for contiguity") 
-
-pmat <- redist::get_plans_matrix(plans) 
-valid <- check_valid(pref_n = map, plans_matrix = pmat) 
-
-cli_alert_info("{sum(valid)} of {length(valid)} draws passed contiguity.") 
-
-# Keep only contiguous draws
-keep_draws <- which(valid) 
-n_dropped <- length(valid) - length(keep_draws) 
-
-if (n_dropped > 0) 
-  cli_alert_warning("Dropping {n_dropped} non-contiguous draws.") 
-if (length(keep_draws) == 0) {
-  cli_abort("No draws passed the contiguity screen. Consider revisiting adjacency or constraints.") 
-} 
-
-# Tag each draw with validity
-pairs <- plans %>% 
-  dplyr::distinct(chain, draw) %>%
-  dplyr::mutate(valid = valid)
-
-# Filter to valid plans only
-plans <- plans %>%
-  dplyr::semi_join(dplyr::filter(pairs, valid), by = c("chain", "draw"))
-
-# Thin simulation results to 5000.
-burn <- 500
-n_total <- 5000
-
-plans <- plans %>% dplyr::arrange(chain, draw)
-
-ids <- plans %>%
-  dplyr::distinct(chain, draw) %>%
-  dplyr::group_by(chain) %>%
-  dplyr::mutate(r = dplyr::row_number(),
-                n_in_chain = dplyr::n()) %>%
-  dplyr::filter(r > pmin(burn, n_in_chain)) %>%   
-  dplyr::ungroup()
-
-n_runs   <- dplyr::n_distinct(ids$chain)
-keep_each <- min(floor(n_total / n_runs),
-                 ids %>% dplyr::count(chain, name = "m") %>% dplyr::pull(m) %>% min())
-
-# take a contiguous tail: last keep_each draws per chain
-keep_ids <- ids %>%
-  dplyr::group_by(chain) %>%
-  dplyr::slice_max(order_by = draw, n = keep_each, with_ties = FALSE) %>%
-  dplyr::ungroup() %>%
-  dplyr::select(chain, draw)
-
-plans <- plans %>% dplyr::semi_join(keep_ids, by = c("chain","draw"))
-
-cli_alert_success("Burn-in: dropped up to {burn}/chain; kept {keep_each} tail draws per chain (total {keep_each * n_runs}).")
-
-# add the enacted plan as a named reference plan
-plans <- redist::add_reference(plans, ref_plan = map$cd_2000, name = "cd_2000")
-
-# Save the filtered redist_plans object. Do not edit this path. 
-write_rds(plans, here("data-out/MD_2000/MD_cd_2000_plans.rds"), compress = "xz") 
-cli_process_done() 
-
-# Compute summary statistics ----- 
-cli_process_start("Computing summary statistics for {.pkg MD_cd_2000}") 
-
-plans <- add_summary_stats(plans, map) 
-
-plans <- plans %>%
-  dplyr::mutate(
-    pop_overlap = dplyr::if_else(.data$draw == "cd_2000" & is.na(.data$pop_overlap),
-                                 1, .data$pop_overlap)
-  )
-
-# Output the summary statistics. Do not edit this path. 
-save_summary_stats(plans, "data-out/MD_2000/MD_cd_2000_stats.csv") 
 cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MD_2000/MD_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MD_cd_2000}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MD_2000/MD_cd_2000_stats.csv")
+
+cli_process_done()
+
+# validation plots
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/MD_cd_2000/doc_MD_cd_2000.md
+++ b/analyses/MD_cd_2000/doc_MD_cd_2000.md
@@ -22,4 +22,5 @@ We used a helper function to identify 35 discontiguity merge-groups, involving 1
 
 ## Simulation Notes
 We sample 15,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.
-After the simulation, we filtered out plans with discontiguous districts and thinned the remaining sample to 5,000 plans.
+We then thinned the number of samples to 5,000. 
+No special techniques were needed to produce the sample.

--- a/analyses/MD_cd_2000/doc_MD_cd_2000.md
+++ b/analyses/MD_cd_2000/doc_MD_cd_2000.md
@@ -17,8 +17,9 @@ We enforce a maximum population deviation of 0.5%.
 Data for ``Maryland`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-We edited the adjacency graph so that districts cannot traverse the Bay. All polygons were preserved, but Bay units were isolated within the adjacency. Specifically, we identified the Bay precincts, removed all of their existing adjacency links, and then reconnected each Bay precinct to a selected same-side neighbor to prevent cross-Bay connections. In other words, Bay precincts on the east side were linked to one chosen east-side neighbor, and those on the west side were linked to one chosen west-side neighbor. One isolated island precinct was manually connected to its nearest neighbor. Additionally, we used a helper function to exclude simulated plans containing discontiguous districts.
+We edited the adjacency graph so that districts cannot traverse the Bay. Specifically, we identified the Bay precincts, removed all of their existing adjacency links, and then reconnected each Bay precinct to a selected same-side neighbor to prevent cross-Bay connections.
+We used a helper function to identify 35 discontiguity merge-groups, involving 139 precincts (8.2% of all VTDs), which were merged prior to simulation.
 
 ## Simulation Notes
-We sample 450,000 districting plans for ``Maryland`` across 10 independent runs of the SMC algorithm.
-After the simulation, we filtered out plans with discontiguous districts and then thinned the remaining sample to 5,000 plans.
+We sample 15,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.
+After the simulation, we filtered out plans with discontiguous districts and thinned the remaining sample to 5,000 plans.

--- a/analyses/MD_cd_2000/doc_MD_cd_2000.md
+++ b/analyses/MD_cd_2000/doc_MD_cd_2000.md
@@ -18,7 +18,7 @@ Data for ``Maryland`` comes from the [ALARM Project's update](https://dataverse.
 
 ## Pre-processing Notes
 We edited the adjacency graph so that districts cannot traverse the Bay. Specifically, we identified the Bay precincts, removed all of their existing adjacency links, and then reconnected each Bay precinct to a selected same-side neighbor to prevent cross-Bay connections.
-We used a helper function to identify 35 discontiguity merge-groups, involving 139 precincts (8.2% of all VTDs), which were merged prior to simulation.
+Because Maryland contains an unusually large number of discontiguous precincts, we used a helper function to identify 35 merge-groups involving 139 precincts (8.2% of all VTDs). These units were merged prior to simulation.
 
 ## Simulation Notes
 We sample 15,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.


### PR DESCRIPTION
# 2000 Maryland Congressional Districts

## Redistricting requirements
In ``Maryland``, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts should:

1. be contiguous
1. have equal populations
1. be geographically compact
1. preserve county and municipality boundaries as much as possible
1. not dilute minority voting strengths
1. give due regard to natural boundaries

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.

## Data Sources
Data for ``Maryland`` comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
We edited the adjacency graph so that districts cannot traverse the Bay. Specifically, we identified the Bay precincts, removed all of their existing adjacency links, and then reconnected each Bay precinct to a selected same-side neighbor to prevent cross-Bay connections.
Because Maryland contains an unusually large number of discontiguous precincts, we used a helper function to identify 35 merge-groups involving 139 precincts (8.2% of all VTDs). These units were merged prior to simulation.

## Simulation Notes
We sample 15,000 districting plans for ``Maryland`` across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 5,000. 
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="4500" alt="validation_20260315_1153" src="https://github.com/user-attachments/assets/527ccd8e-4460-4f97-9bd3-13aa98214c8e" />

```
✔ Preparing NJ shapefile ... done
SMC: 5,000 sampled plans of 8 districts on 1,691 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.28 to 0.59
Largest R-hat values for ordered summary statistics:
    comp_edge   comp_polsby county_splits   muni_splits       ndshare           ndv           nrv      plan_dev      pop_aian 
        1.005         1.016         1.004         1.007         1.014         1.027         1.026         1.002         1.015 
    pop_asian     pop_black      pop_hisp      pop_nhpi     pop_other   pop_overlap       pop_two     pop_white     total_vap 
        1.014         1.023         1.018         1.013         1.008         1.011         1.013         1.014         1.008 
     vap_aian     vap_asian     vap_black      vap_hisp      vap_nhpi     vap_other       vap_two     vap_white 
        1.012         1.013         1.022         1.014         1.011         1.010         1.015         1.017 
• R-hat ≤ 1.05: 208
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 208
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       934 (31.1%)     12.7%        1.04 1,935 (102%)      6 
Split 2     1,442 (48.1%)     12.6%        0.73 1,394 ( 74%)      5 
Split 3     1,244 (41.5%)     14.6%        0.76 1,571 ( 83%)      4 
Split 4     1,432 (47.7%)     15.9%        0.57 1,508 ( 80%)      3 
Split 5     1,445 (48.2%)     12.9%        0.55 1,668 ( 88%)      3 
Split 6     1,479 (49.3%)     10.5%        0.62 1,553 ( 82%)      3 
Split 7     2,928 (97.6%)      3.5%        0.16 1,372 ( 72%)      3 
Resample    2,928 (97.6%)       NA%          NA 2,817 (149%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3
or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny
