### PR TITLE
2020 Nebraska State House/Senate Districts

### DIFF
--- a/analyses/NE_leg_2020/01_prep_NE_leg_2020.R
+++ b/analyses/NE_leg_2020/01_prep_NE_leg_2020.R
@@ -1,0 +1,98 @@
+###############################################################################
+# Download and prepare data for `NE_leg_2020` analysis
+# © ALARM Project, March 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NE_leg_2020}")
+
+path_data <- download_redistricting_file("NE", "data-raw/NE", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NE_2020/shp_vtd.rds"
+perim_path <- "data-out/NE_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NE} shapefile")
+    # read in redistricting data
+    ne_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$NE)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NE", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("NE"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("NE", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("NE"), vtd),
+            ssd_2010 = as.integer(sldu))
+
+    ne_shp <- ne_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county)
+
+    # add the enacted plan
+    d_ssd_2020 <- baf::baf("NE", year = 2023, geographies = "ssd")$SSD2022 |>
+        dplyr::rename(BLOCKID = GEOID, ssd_20 = SLDUST)
+
+    vtd_baf <- baf::baf("NE", year = 2023, geographies = "VTD")[[1]] |>
+        mutate(
+            GEOID = paste0(stringr::str_sub(BLOCKID, 1, 2), COUNTYFP, DISTRICT)
+        ) |>
+        select(BLOCKID, GEOID)
+
+    d_enacted <- d_ssd_2020 |>
+        dplyr::left_join(vtd_baf, by = "BLOCKID") |>
+        dplyr::group_by(GEOID) |>
+        dplyr::summarise(ssd_2020 = Mode(ssd_20), .groups = "drop")
+
+    ne_shp <- ne_shp |>
+        left_join(d_enacted, by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ne_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ne_shp <- rmapshaper::ms_simplify(ne_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ne_shp$adj <- adjacency(ne_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(ne_shp$adj, ne_shp$ssd_2020)
+
+    ne_shp <- ne_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(ne_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ne_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NE} shapefile")
+}

--- a/analyses/NE_leg_2020/02_setup_NE_leg_2020.R
+++ b/analyses/NE_leg_2020/02_setup_NE_leg_2020.R
@@ -1,0 +1,32 @@
+###############################################################################
+# Set up redistricting simulation for `NE_leg_2020`
+# © ALARM Project, March 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NE_leg_2020}")
+
+map_ssd <- redist_map(ne_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = ne_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+
+map_ssd <- mutate(map_ssd,
+    core_id = redist.identify.cores(map_ssd$adj, map_ssd$ssd_2010, boundary = 2),
+    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(ssd_2010)), # lump all non-core precincts in to "Other"
+    core_id = if_else(as.logical(is_county_split(core_id_lump, county)), # break off counties which are split by core border
+        str_c(county, "_", core_id),
+        as.character(core_id))) |>
+    select(-core_id_lump)
+
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+map_cores <- merge_by(map_ssd, core_id, drop_geom = TRUE)
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "NE_SSD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/NE_2020/NE_leg_2020_map_ssd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
+++ b/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
@@ -48,26 +48,25 @@ save_summary_stats(plans, "data-out/NE_2020/NE_ssd_2020_stats.csv")
 cli_process_done()
 
 if (interactive()) {
-  library(ggplot2)
-  library(patchwork)
-  validate_analysis(plans, map_ssd)
-  summary(plans)
+    library(ggplot2)
+    library(patchwork)
+    validate_analysis(plans, map_ssd)
+    summary(plans)
 
-  # cores preservation plot -----
-  plans_nocores <- redist_smc(
-    map_ssd,
-    nsims = 200,
-    runs = 2,
-    counties = map_ssd$pseudo_county
-  )
+    # cores preservation plot -----
+    plans_nocores <- redist_smc(
+        map_ssd,
+        nsims = 200,
+        runs = 2,
+        counties = map_ssd$pseudo_county
+    )
 
-  d_overl <- bind_rows(
-    with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
-    no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
-    .id = "run"
-  )
+    d_overl <- bind_rows(
+        with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
+        no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
+        .id = "run"
+    )
 
-  ggplot(d_overl, aes(reorder(district, pop_overlap), pop_overlap, color = run)) +
-    geom_boxplot(coef = 1e6)
+    ggplot(d_overl, aes(reorder(district, pop_overlap), pop_overlap, color = run)) +
+        geom_boxplot(coef = 1e6)
 }
-

--- a/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
+++ b/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
@@ -10,7 +10,7 @@ set.seed(2020)
 
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
 
-constr <- redist_constr(map_cores) %>%
+constr <- redist_constr(map_cores) |>
     add_constr_total_splits(strength = 1.7, admin = map_cores$county)
 
 plans <- redist_smc(
@@ -22,7 +22,7 @@ plans <- redist_smc(
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),
     verbose = TRUE
-) %>% pullback(map_ssd)
+) |> pullback(map_ssd)
 
 plans <- plans |>
     group_by(chain) |>
@@ -48,9 +48,26 @@ save_summary_stats(plans, "data-out/NE_2020/NE_ssd_2020_stats.csv")
 cli_process_done()
 
 if (interactive()) {
-    library(ggplot2)
-    library(patchwork)
+  library(ggplot2)
+  library(patchwork)
+  validate_analysis(plans, map_ssd)
+  summary(plans)
 
-    validate_analysis(plans, map_ssd)
-    summary(plans)
+  # cores preservation plot -----
+  plans_nocores <- redist_smc(
+    map_ssd,
+    nsims = 200,
+    runs = 2,
+    counties = map_ssd$pseudo_county
+  )
+
+  d_overl <- bind_rows(
+    with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
+    no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
+    .id = "run"
+  )
+
+  ggplot(d_overl, aes(reorder(district, pop_overlap), pop_overlap, color = run)) +
+    geom_boxplot(coef = 1e6)
 }
+

--- a/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
+++ b/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
@@ -1,0 +1,56 @@
+###############################################################################
+# Simulate plans for `NE_ssd_2020` SSD
+# © ALARM Project, March 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NE_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
+
+constr <- redist_constr(map_cores) %>%
+    add_constr_total_splits(strength = 1.7, admin = map_cores$county)
+
+plans <- redist_smc(
+    map_cores,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+) %>% pullback(map_ssd)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NE_2020/NE_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NE_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NE_2020/NE_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/NE_leg_2020/doc_NE_leg_2020.md
+++ b/analyses/NE_leg_2020/doc_NE_leg_2020.md
@@ -1,0 +1,27 @@
+# 2020 Nebraska State House/Senate Districts
+
+## Redistricting requirements
+In Nebraska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous [NCSL 184] 
+2. have equal populations [NCSL 24] 
+3. be geographically compacts [NCSL 184] 
+4. preserve county and municipality boundaries as much as possible
+5. preserve cores of prior districts  [NCSL 185]
+6. be not favoring any incumbent [NCSL 185]
+7. be not favoring any political party [NCSL 185]
+
+Nebraska has a unicameral legislature, and thus only one set of state legislative districts is drawn. Accordingly, we simulate a single legislative plan using the 03_sim_NE_ssd.R script.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Nebraska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.
+
+## Simulation Notes
+We sample 10,000 districting plans for Nebraska's unicameral legislature across 5 independent runs of the SMC algorithm.
+No special techniques were needed to produce the sample.

--- a/analyses/NE_leg_2020/doc_NE_leg_2020.md
+++ b/analyses/NE_leg_2020/doc_NE_leg_2020.md
@@ -6,7 +6,7 @@ In Nebraska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org
 1. be contiguous [NCSL 184] 
 2. have equal populations [NCSL 24] 
 3. be geographically compacts [NCSL 184] 
-4. preserve county and municipality boundaries as much as possible
+4. preserve county and municipality boundaries as much as possible [NCSL 184] 
 5. preserve cores of prior districts  [NCSL 185]
 6. be not favoring any incumbent [NCSL 185]
 7. be not favoring any political party [NCSL 185]


### PR DESCRIPTION
## Redistricting requirements
In Nebraska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous [NCSL 184] 
2. have equal populations [NCSL 24] 
3. be geographically compacts [NCSL 184] 
4. preserve county and municipality boundaries as much as possible [NCSL 184] 
5. preserve cores of prior districts  [NCSL 185]
6. be not favoring any incumbent [NCSL 185]
7. be not favoring any political party [NCSL 185]

Nebraska has a unicameral legislature, and thus only one set of state legislative districts is drawn. Accordingly, we simulate a single legislative plan using the 03_sim_NE_ssd.R script.

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Nebraska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.

## Simulation Notes
We sample 10,000 districting plans for Nebraska's unicameral legislature across 5 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/edd25039-9dbb-4292-8e64-bac5a6db5082" />
<img width="1010" height="557" alt="image" src="https://github.com/user-attachments/assets/86b72ba6-b419-4404-8744-59d5edc7c04d" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 49 districts on 1,402 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 48
• `mh_accept_per_smc` = 37
• `pair_rule` = uniform
Plan diversity 80% range: 0.72 to 0.83
35 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20      atg_18_rep_pet 
              1.013               1.014               1.018               1.013               1.017               1.016               1.006 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits               e_dem               e_dvs                egap 
              1.007               1.001               1.010               1.003               1.005               1.021               1.004 
     gov_18_dem_kri      gov_18_rep_ric         muni_splits             ndshare                 ndv                 nrv               pbias 
              1.010               1.015               1.011               1.019               1.016               1.015               1.010 
           plan_dev            pop_aian           pop_asian           pop_black            pop_hisp            pop_nhpi           pop_other 
              1.001               1.018               1.014               1.019               1.011               1.011               1.009 
        pop_overlap             pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.011               1.020               1.009               1.005               1.013               1.013               1.017 
     pre_20_rep_tru      sos_18_dem_dan      sos_18_rep_evn total_county_splits   total_muni_splits           total_vap      uss_18_dem_ray 
              1.021               1.014               1.017               1.002               1.007               1.003               1.014 
     uss_18_rep_fis      uss_20_dem_jan      uss_20_rep_sas            vap_aian           vap_asian           vap_black            vap_hisp 
              1.013               1.011               1.014               1.014               1.012               1.025               1.011 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.008               1.009               1.015               1.008 
• R-hat ≤ 1.05: 2562
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2562
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       818 (40.9%)    100.0%        1.40 1,276 (101%) 
Split 2       725 (36.3%)     98.2%        1.88   948 ( 75%) 
Split 3       781 (39.0%)     95.9%        1.71   846 ( 67%) 
Split 4       907 (45.3%)     93.9%        1.54   894 ( 71%) 
Split 5       968 (48.4%)     92.0%        1.39   955 ( 76%) 
Split 6     1,130 (56.5%)     87.6%        1.14   954 ( 75%) 
Split 7     1,191 (59.5%)     85.8%        1.09 1,065 ( 84%) 
Split 8     1,288 (64.4%)     84.9%        1.02 1,080 ( 85%) 
Split 9     1,376 (68.8%)     82.6%        0.90 1,095 ( 87%) 
Split 10    1,417 (70.9%)     79.4%        0.82 1,122 ( 89%) 
Split 11    1,483 (74.1%)     76.7%        0.77 1,113 ( 88%) 
Split 12    1,528 (76.4%)     75.3%        0.75 1,141 ( 90%) 
Split 13    1,588 (79.4%)     72.5%        0.70 1,138 ( 90%) 
Split 14    1,647 (82.3%)     72.3%        0.57 1,142 ( 90%) 
Split 15    1,652 (82.6%)     68.1%        0.60 1,207 ( 95%) 
Split 16    1,682 (84.1%)     66.7%        0.55 1,187 ( 94%) 
Split 17    1,718 (85.9%)     65.1%        0.52 1,172 ( 93%) 
Split 18    1,743 (87.2%)     63.0%        0.55 1,207 ( 95%) 
Split 19    1,761 (88.0%)     60.0%        0.48 1,209 ( 96%) 
Split 20    1,768 (88.4%)     60.2%        0.45 1,218 ( 96%) 
Split 21    1,774 (88.7%)     57.0%        0.44 1,201 ( 95%) 
Split 22    1,792 (89.6%)     55.9%        0.45 1,211 ( 96%) 
Split 23    1,808 (90.4%)     54.7%        0.46 1,195 ( 95%) 
Split 24    1,833 (91.7%)     53.6%        0.41 1,201 ( 95%) 
Split 25    1,837 (91.9%)     49.9%        0.38 1,229 ( 97%) 
Split 26    1,858 (92.9%)     48.9%        0.37 1,222 ( 97%) 
Split 27    1,853 (92.6%)     47.0%        0.34 1,211 ( 96%) 
Split 28    1,847 (92.4%)     45.6%        0.45 1,243 ( 98%) 
Split 29    1,861 (93.1%)     45.0%        0.35 1,224 ( 97%) 
Split 30    1,874 (93.7%)     42.8%        0.32 1,218 ( 96%) 
Split 31    1,892 (94.6%)     42.1%        0.30 1,241 ( 98%) 
Split 32    1,895 (94.7%)     41.5%        0.33 1,226 ( 97%) 
Split 33    1,895 (94.7%)     40.2%        0.28 1,231 ( 97%) 
Split 34    1,893 (94.7%)     37.4%        0.31 1,236 ( 98%) 
Split 35    1,896 (94.8%)     35.7%        0.29 1,229 ( 97%) 
Split 36    1,909 (95.4%)     34.2%        0.25 1,214 ( 96%) 
Split 37    1,915 (95.8%)     33.3%        0.23 1,232 ( 97%) 
Split 38    1,912 (95.6%)     34.0%        0.24 1,218 ( 96%) 
Split 39    1,915 (95.7%)     32.2%        0.26 1,212 ( 96%) 
Split 40    1,922 (96.1%)     30.7%        0.26 1,226 ( 97%) 
Split 41    1,919 (95.9%)     27.7%        0.26 1,216 ( 96%) 
Split 42    1,926 (96.3%)     29.3%        0.24 1,220 ( 97%) 
Split 43    1,928 (96.4%)     27.4%        0.24 1,186 ( 94%) 
Split 44    1,931 (96.5%)     27.2%        0.22 1,203 ( 95%) 
Split 45    1,943 (97.1%)     26.0%        0.21 1,191 ( 94%) 
Split 46    1,946 (97.3%)     25.2%        0.25 1,175 ( 93%) 
Split 47    1,955 (97.8%)     24.0%        0.17 1,150 ( 91%) 
Split 48    1,958 (97.9%)     22.5%        0.21 1,037 ( 82%) 
Resample    1,958 (97.9%)       NA%          NA 1,884 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      44.3%                37
MS Step 2      42.1%               111
MS Step 3      41.6%               111
MS Step 4      41.8%               111
MS Step 5      42.3%               111
MS Step 6      42.5%               111
MS Step 7      43.3%               111
MS Step 8      43.6%               111
MS Step 9      44.3%               111
MS Step 10     44.7%               111
MS Step 11     45.5%               111
MS Step 12     45.5%               111
MS Step 13     45.3%               111
MS Step 14     45.9%               111
MS Step 15     45.7%               111
MS Step 16     46.0%               111
MS Step 17     46.0%               111
MS Step 18     45.8%               111
MS Step 19     45.9%               111
MS Step 20     45.9%               111
MS Step 21     45.2%               111
MS Step 22     45.1%               111
MS Step 23     44.8%               111
MS Step 24     44.6%               111
MS Step 25     44.0%               111
MS Step 26     43.7%               111
MS Step 27     43.3%               111
MS Step 28     43.0%               111
MS Step 29     42.8%               111
MS Step 30     42.5%               111
MS Step 31     41.9%               111
MS Step 32     41.1%               111
MS Step 33     40.9%               111
MS Step 34     40.5%               111
MS Step 35     40.0%               111
MS Step 36     39.5%               111
MS Step 37     39.0%               111
MS Step 38     38.3%               111
MS Step 39     38.1%               111
MS Step 40     37.4%               111
MS Step 41     37.0%               111
MS Step 42     36.8%               111
MS Step 43     36.0%               111
MS Step 44     35.7%               111
MS Step 45     35.1%               111
MS Step 46     34.7%               111
MS Step 47     34.5%               111
MS Step 48     33.8%               111
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited