### PR TITLE
Update logit_shift.R

### DIFF
--- a/R/logit_shift.R
+++ b/R/logit_shift.R
@@ -31,11 +31,11 @@ logit_shift_baseline <- function(d_baseline, ndv, nrv,
     return(d_baseline)
   }
 
-  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec) - log(nrv_vec), 0)
+  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec + 0.5) - log(nrv_vec + 0.5), 0)
 
   res <- uniroot(function(shift) {
     stats::weighted.mean(plogis(ldvs + shift), turn) - target
-  }, interval = interval, tol = tol)
+  }, interval = interval, extendInt = "yes", tol = tol)
 
   ldvs <- ldvs + res$root
 

--- a/R/logit_shift.R
+++ b/R/logit_shift.R
@@ -31,7 +31,7 @@ logit_shift_baseline <- function(d_baseline, ndv, nrv,
     return(d_baseline)
   }
 
-  ldvs <- dplyr::if_else(turn > 0, log(ndv_vec + 0.5) - log(nrv_vec + 0.5), 0)
+  ldvs <- dplyr::if_else(turn > 0, dplyr::coalesce(log(ndv_vec) - log(nrv_vec), 0), 0)
 
   res <- uniroot(function(shift) {
     stats::weighted.mean(plogis(ldvs + shift), turn) - target


### PR DESCRIPTION
Two additional fixes on top of the interval parameter:

1. Contiguity correction (+0.5) - Precincts with zero votes for one party produce log(0)=-Inf, making plogis() return exactly 0 or 1 regardless of the shift. This locks those precincts in place so uniroot can never reach the target. 
2. extendInt = "yes" - Lets uniroot automatically widen the search interval when the initial bounds don't bracket the root, rather than erroring out.
