### PR TITLE
2020 New York State House/Senate Districts

### DIFF
--- a/analyses/NY_leg_2020/01_prep_NY_leg_2020.R
+++ b/analyses/NY_leg_2020/01_prep_NY_leg_2020.R
@@ -1,0 +1,93 @@
+###############################################################################
+# Download and prepare data for `NY_leg_2020` analysis
+# © ALARM Project, March 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NY_leg_2020}")
+
+path_data <- download_redistricting_file("NY", "data-raw/NY", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NY_2020/shp_vtd.rds"
+perim_path <- "data-out/NY_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NY} shapefile")
+    # read in redistricting data
+    ny_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$NY)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NY", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("NY"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("NY", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("NY"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("NY", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("NY"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    ny_shp <- ny_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    ny_shp <- ny_shp |>
+        left_join(y = leg_from_baf(state = "NY"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ny_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ny_shp <- rmapshaper::ms_simplify(ny_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ny_shp$adj <- adjacency(ny_shp)
+
+    nbr <- geomander::suggest_neighbors(ny_shp, adj = ny_shp$adj)
+    ny_shp$adj <- geomander::add_edge(ny_shp$adj, nbr$x, nbr$y)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(ny_shp$adj, ny_shp$ssd_2020)
+    ccm(ny_shp$adj, ny_shp$shd_2020)
+
+    ny_shp <- ny_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(ny_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ny_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NY} shapefile")
+}

--- a/analyses/NY_leg_2020/02_setup_NY_leg_2020.R
+++ b/analyses/NY_leg_2020/02_setup_NY_leg_2020.R
@@ -1,0 +1,49 @@
+###############################################################################
+# Set up redistricting simulation for `NY_leg_2020`
+# © ALARM Project, March 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NY_leg_2020}")
+
+map_ssd <- redist_map(ny_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = ny_shp$adj)
+
+map_shd <- redist_map(ny_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = ny_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+
+map_ssd <- mutate(map_ssd,
+    core_id = redist.identify.cores(map_ssd$adj, map_ssd$ssd_2010, boundary = 2),
+    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(ssd_2010)),
+    core_id = if_else(as.logical(is_county_split(core_id_lump, county)),
+        str_c(county, "_", core_id),
+        as.character(core_id))) |>
+    select(-core_id_lump)
+
+map_shd <- mutate(map_shd,
+    core_id = redist.identify.cores(map_shd$adj, map_shd$shd_2010, boundary = 2),
+    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(shd_2010)),
+    core_id = if_else(as.logical(is_county_split(core_id_lump, county)),
+        str_c(county, "_", core_id),
+        as.character(core_id))) |>
+    select(-core_id_lump)
+
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+map_cores_ssd <- merge_by(map_ssd, core_id, drop_geom = TRUE)
+map_cores_shd <- merge_by(map_shd, core_id, drop_geom = TRUE)
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "NY_SSD_2020"
+attr(map_shd, "analysis_name") <- "NY_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/NY_2020/NY_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/NY_2020/NY_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NY_leg_2020/02_setup_NY_leg_2020.R
+++ b/analyses/NY_leg_2020/02_setup_NY_leg_2020.R
@@ -18,26 +18,13 @@ map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
         pop_muni = get_target(map_shd)))
 
-map_ssd <- mutate(map_ssd,
-    core_id = redist.identify.cores(map_ssd$adj, map_ssd$ssd_2010, boundary = 2),
-    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(ssd_2010)),
-    core_id = if_else(as.logical(is_county_split(core_id_lump, county)),
-        str_c(county, "_", core_id),
-        as.character(core_id))) |>
-    select(-core_id_lump)
-
-map_shd <- mutate(map_shd,
-    core_id = redist.identify.cores(map_shd$adj, map_shd$shd_2010, boundary = 2),
-    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(shd_2010)),
-    core_id = if_else(as.logical(is_county_split(core_id_lump, county)),
-        str_c(county, "_", core_id),
-        as.character(core_id))) |>
-    select(-core_id_lump)
-
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-map_cores_ssd <- merge_by(map_ssd, core_id, drop_geom = TRUE)
-map_cores_shd <- merge_by(map_shd, core_id, drop_geom = TRUE)
+# set up core objects
+map_ssd <- map_ssd |> mutate(cores = make_cores(boundary = 1))
+
+# merge by cores and county
+map_cores_ssd <- merge_by(map_ssd, cores, county)
 
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "NY_SSD_2020"

--- a/analyses/NY_leg_2020/03_sim_NY_shd_2020.R
+++ b/analyses/NY_leg_2020/03_sim_NY_shd_2020.R
@@ -1,0 +1,82 @@
+###############################################################################
+# Simulate plans for `NY_shd_2020` SHD
+# © ALARM Project, March 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NY_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 70
+
+constr <- redist_constr(map_cores_shd) %>%
+    add_constr_total_plan_splits(admin = map_cores_shd$county, strength = 2)
+
+plans <- redist_smc(
+    map_cores_shd,
+    nsims = 2e3, runs = 5,
+    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+) |> pullback(map_shd)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NY_2020/NY_shd_2020_plans.rds"), compress = "xz")
+
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NY_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "NY_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+    # competitiveness plot -----
+    plans <- plans |> mutate(dvs_20 = group_frac(map_shd, adv_20, adv_20 + arv_20))
+    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+        lims(y = c(0.25, 0.9)) +
+        labs(title = "Competitiveness")
+
+    # cores preservation plot -----
+    plans_nocores <- redist_smc(
+        map_shd,
+        nsims = 200,
+        runs = 2,
+        counties = map_shd$pseudo_county
+    )
+
+    d_overl <- bind_rows(
+        with_cores = as_tibble(match_numbers(plans, map_shd$shd_2010)),
+        no_cores = as_tibble(match_numbers(plans_nocores, map_shd$shd_2010)),
+        .id = "run"
+    )
+
+    ggplot(d_overl |> distinct(run, draw, pop_overlap),
+        aes(x = pop_overlap, color = run, fill = run)) +
+        geom_density(alpha = 0.3)
+
+}

--- a/analyses/NY_leg_2020/03_sim_NY_shd_2020.R
+++ b/analyses/NY_leg_2020/03_sim_NY_shd_2020.R
@@ -8,22 +8,22 @@ cli_process_start("Running simulations for {.pkg NY_shd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 70
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 150
 
-constr <- redist_constr(map_cores_shd) %>%
-    add_constr_total_plan_splits(admin = map_cores_shd$county, strength = 2)
+constr <- redist_constr(map_shd) |>
+    add_constr_total_splits(strength = 1.6, admin = map_shd$county)
 
 plans <- redist_smc(
-    map_cores_shd,
+    map_shd,
     nsims = 2e3, runs = 5,
     # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-    counties = pseudo_county,
     constraints = constr,
+    counties = map_shd$shd_2010,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),
     verbose = TRUE
-) |> pullback(map_shd)
+)
 
 plans <- plans |>
     group_by(chain) |>
@@ -56,27 +56,15 @@ if (interactive()) {
     summary(plans)
 
     # competitiveness plot -----
-    plans <- plans |> mutate(dvs_20 = group_frac(map_shd, adv_20, adv_20 + arv_20))
-    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+    plans_comp <- plans |> mutate(dvs_20 = group_frac(map_shd, adv_20, adv_20 + arv_20))
+    p_comp <- redist.plot.distr_qtys(plans_comp, qty = dvs_20, geom = "boxplot") + theme_bw() +
         lims(y = c(0.25, 0.9)) +
         labs(title = "Competitiveness")
+    print(p_comp)
 
     # cores preservation plot -----
-    plans_nocores <- redist_smc(
-        map_shd,
-        nsims = 200,
-        runs = 2,
-        counties = map_shd$pseudo_county
-    )
-
-    d_overl <- bind_rows(
-        with_cores = as_tibble(match_numbers(plans, map_shd$shd_2010)),
-        no_cores = as_tibble(match_numbers(plans_nocores, map_shd$shd_2010)),
-        .id = "run"
-    )
-
-    ggplot(d_overl |> distinct(run, draw, pop_overlap),
-        aes(x = pop_overlap, color = run, fill = run)) +
-        geom_density(alpha = 0.3)
-
+    p_core <- plans |>
+        match_numbers(map_shd$shd_2010) |>
+        hist(pop_overlap)
+    print(p_core)
 }

--- a/analyses/NY_leg_2020/03_sim_NY_ssd_2020.R
+++ b/analyses/NY_leg_2020/03_sim_NY_ssd_2020.R
@@ -1,0 +1,81 @@
+###############################################################################
+# Simulate plans for `NY_ssd_2020` SSD
+# © ALARM Project, March 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NY_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 150
+
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(strength = 1.5, admin = map_ssd$county)
+
+plans <- redist_smc(
+    map_cores_ssd,
+    nsims = 2e3, runs = 5,
+    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+) |> pullback(map_ssd)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NY_2020/NY_ssd_2020_plans.rds"), compress = "xz")
+
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NY_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "NY_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    # competitiveness plot -----
+    plans <- plans |> mutate(dvs_20 = group_frac(map_ssd, adv_20, adv_20 + arv_20))
+    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+        lims(y = c(0.25, 0.9)) +
+        labs(title = "Competitiveness")
+
+    # cores preservation plot -----
+    plans_nocores <- redist_smc(
+        map_ssd,
+        nsims = 200,
+        runs = 2,
+        counties = map_ssd$pseudo_county
+    )
+
+    d_overl <- bind_rows(
+        with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
+        no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
+        .id = "run"
+    )
+
+    ggplot(d_overl |> distinct(run, draw, pop_overlap),
+        aes(x = pop_overlap, color = run, fill = run)) +
+        geom_density(alpha = 0.3)
+}

--- a/analyses/NY_leg_2020/03_sim_NY_ssd_2020.R
+++ b/analyses/NY_leg_2020/03_sim_NY_ssd_2020.R
@@ -8,10 +8,12 @@ cli_process_start("Running simulations for {.pkg NY_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 150
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 180
 
-constr <- redist_constr(map_ssd) |>
-    add_constr_total_splits(strength = 1.5, admin = map_ssd$county)
+constr <- redist_constr(map_cores_ssd) |>
+    add_constr_total_plan_splits(strength = 2.2, admin = map_cores_ssd$county) |>
+    add_constr_plan_splits(strength = 0.8, admin = map_cores_ssd$county) |>
+    add_constr_total_plan_splits(strength = 0.3, admin = map_cores_ssd$county_muni)
 
 plans <- redist_smc(
     map_cores_ssd,
@@ -56,26 +58,15 @@ if (interactive()) {
     summary(plans)
 
     # competitiveness plot -----
-    plans <- plans |> mutate(dvs_20 = group_frac(map_ssd, adv_20, adv_20 + arv_20))
-    redist.plot.distr_qtys(plans, qty = dvs_20, geom = "boxplot") + theme_bw() +
+    plans_comp <- plans |> mutate(dvs_20 = group_frac(map_ssd, adv_20, adv_20 + arv_20))
+    p_comp <- redist.plot.distr_qtys(plans_comp, qty = dvs_20, geom = "boxplot") + theme_bw() +
         lims(y = c(0.25, 0.9)) +
         labs(title = "Competitiveness")
+    print(p_comp)
 
     # cores preservation plot -----
-    plans_nocores <- redist_smc(
-        map_ssd,
-        nsims = 200,
-        runs = 2,
-        counties = map_ssd$pseudo_county
-    )
-
-    d_overl <- bind_rows(
-        with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
-        no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
-        .id = "run"
-    )
-
-    ggplot(d_overl |> distinct(run, draw, pop_overlap),
-        aes(x = pop_overlap, color = run, fill = run)) +
-        geom_density(alpha = 0.3)
+    p_core <- plans |>
+        match_numbers(map_ssd$ssd_2010) |>
+        hist(pop_overlap)
+    print(p_core)
 }

--- a/analyses/NY_leg_2020/doc_NY_leg_2020.md
+++ b/analyses/NY_leg_2020/doc_NY_leg_2020.md
@@ -1,0 +1,34 @@
+# 2020 New York State House/Senate Districts
+
+## Redistricting requirements
+In New York, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous [NCSL 186]
+2. have equal populations [NCSL 24]
+3. be geographically compact [NCSL 186]
+4. preserve county and municipality boundaries as much as possible [NCSL 186]
+5. preserve communities of interest [NCSL 186]
+6. preserve cores of prior districts [NCSL 187]
+7. be not favoring any incumbent [NCSL 187]
+8. be not favoring any political party [NCSL 187]
+9. maximize the number of politically competitive districts [NCSL 187]
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for New York comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+Islands are connected to their nearest point on land. 
+(To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.)
+
+## Simulation Notes
+We sample 10,000 districting plans for New York's lower house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+No special techniques were needed to produce the sample.
+
+We sample 10,000 districting plans for New York's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+No special techniques were needed to produce the sample.

--- a/analyses/NY_leg_2020/doc_NY_leg_2020.md
+++ b/analyses/NY_leg_2020/doc_NY_leg_2020.md
@@ -15,20 +15,19 @@ In New York, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org
 
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 5.0%.
+We enforce a maximum population deviation of 5.0%. 
+For New York's lower house, to preserve the cores of prior districts, we use the previous SHDs in the counties argument, which limits splits of prior districts during simulation.
 
 ## Data Sources
 Data for New York comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
 Islands are connected to their nearest point on land. 
-(To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.)
+For New York's upper house, to preserve the cores of prior districts, we merge precincts that are not adjacent to a district boundary under the 2010 plan. Core groups are merged within counties.
 
 ## Simulation Notes
 We sample 10,000 districting plans for New York's lower house across 5 independent runs of the SMC algorithm.
-We then thinned the number of samples to 10,000.
-No special techniques were needed to produce the sample.
+We impose a county-split constraint and increase the number of merge-split proposals per SMC step.
 
-We sample 10,000 districting plans for New York's upper house across 5 independent runs of the SMC algorithm.
-We then thinned the number of samples to 10,000.
-No special techniques were needed to produce the sample.
+We sample 10,000 districting plans for New York's upper chamber across 5 independent runs of the SMC algorithm. 
+We impose county- and municipality-split constraints and increase the number of merge-split proposals per SMC step.


### PR DESCRIPTION
## Redistricting requirements
In New York, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous [NCSL 186]
2. have equal populations [NCSL 24]
3. be geographically compact [NCSL 186]
4. preserve county and municipality boundaries as much as possible [NCSL 186]
5. preserve communities of interest [NCSL 186]
6. preserve cores of prior districts [NCSL 187]
7. be not favoring any incumbent [NCSL 187]
8. be not favoring any political party [NCSL 187]
9. maximize the number of politically competitive districts [NCSL 187]


### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for New York comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
(To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.)

## Simulation Notes
We sample 10,000 districting plans for New York's lower house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
No special techniques were needed to produce the sample.

We sample 10,000 districting plans for New York's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
No special techniques were needed to produce the sample.

## Validation

### State Senate
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/952d161b-a13b-4fca-8095-77f6c6058415" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 63 districts on 14,191 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 62
• `mh_accept_per_smc` = 171
• `pair_rule` = uniform
Plan diversity 80% range: 0.82 to 0.92
33 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.002               1.001               1.002               1.006 
             arv_18              arv_20      atg_18_dem_jam      atg_18_rep_wof 
              1.007               1.006               1.002               1.007 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.003               1.001               1.002               1.001 
              e_dem               e_dvs                egap      gov_18_dem_cuo 
              1.002               1.004               1.002               1.001 
     gov_18_rep_mol         muni_splits             ndshare                 ndv 
              1.007               1.000               1.004               1.001 
                nrv               pbias            plan_dev            pop_aian 
              1.005               1.002               1.000               1.003 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.006               1.002               1.005               1.005 
          pop_other         pop_overlap             pop_two           pop_white 
              1.003               1.010               1.005               1.003 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.006               1.002               1.006               1.002 
     pre_20_rep_tru total_county_splits   total_muni_splits           total_vap 
              1.006               1.002               1.000               1.001 
     uss_16_dem_sch      uss_16_rep_lon      uss_18_dem_gil      uss_18_rep_far 
              1.002               1.006               1.002               1.006 
           vap_aian           vap_asian           vap_black            vap_hisp 
              1.004               1.007               1.002               1.005 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.004               1.003               1.005               1.003 
• R-hat ≤ 1.05: 3243
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3243
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       379 (18.9%)    100.0%        3.15 1,272 (101%) 
Split 2       364 (18.2%)     99.3%        4.93   695 ( 55%) 
Split 3       424 (21.2%)     98.4%        4.58   675 ( 53%) 
Split 4       493 (24.7%)     97.4%        4.06   693 ( 55%) 
Split 5       577 (28.9%)     95.8%        3.91   714 ( 56%) 
Split 6       623 (31.2%)     93.2%        3.59   767 ( 61%) 
Split 7       671 (33.5%)     92.1%        3.50   802 ( 63%) 
Split 8       672 (33.6%)     91.8%        3.42   827 ( 65%) 
Split 9       729 (36.5%)     90.5%        3.39   810 ( 64%) 
Split 10      751 (37.6%)     89.2%        3.12   839 ( 66%) 
Split 11      794 (39.7%)     87.0%        3.03   864 ( 68%) 
Split 12      833 (41.7%)     86.0%        3.06   837 ( 66%) 
Split 13      887 (44.4%)     85.0%        2.97   880 ( 70%) 
Split 14      889 (44.5%)     84.2%        2.97   906 ( 72%) 
Split 15      891 (44.5%)     83.0%        2.85   893 ( 71%) 
Split 16      888 (44.4%)     81.5%        2.84   906 ( 72%) 
Split 17      901 (45.0%)     80.9%        2.71   905 ( 72%) 
Split 18      892 (44.6%)     79.4%        2.72   902 ( 71%) 
Split 19      897 (44.9%)     79.6%        2.75   883 ( 70%) 
Split 20      939 (47.0%)     78.2%        2.67   918 ( 73%) 
Split 21      942 (47.1%)     76.5%        2.59   895 ( 71%) 
Split 22      942 (47.1%)     75.8%        2.54   901 ( 71%) 
Split 23    1,004 (50.2%)     74.7%        2.40   894 ( 71%) 
Split 24      975 (48.7%)     74.4%        2.46   919 ( 73%) 
Split 25      970 (48.5%)     75.2%        2.32   920 ( 73%) 
Split 26    1,051 (52.6%)     73.9%        2.13   941 ( 74%) 
Split 27    1,052 (52.6%)     71.9%        2.12   985 ( 78%) 
Split 28    1,109 (55.5%)     73.9%        1.90   993 ( 79%) 
Split 29    1,111 (55.6%)     73.7%        1.91   995 ( 79%) 
Split 30    1,213 (60.6%)     71.7%        1.65 1,000 ( 79%) 
Split 31    1,270 (63.5%)     70.0%        1.56 1,029 ( 81%) 
Split 32    1,316 (65.8%)     70.1%        1.33 1,076 ( 85%) 
Split 33    1,392 (69.6%)     67.5%        1.19 1,065 ( 84%) 
Split 34    1,439 (72.0%)     68.4%        1.04 1,106 ( 87%) 
Split 35    1,492 (74.6%)     68.1%        0.91 1,114 ( 88%) 
Split 36    1,541 (77.1%)     66.1%        0.77 1,139 ( 90%) 
Split 37    1,580 (79.0%)     66.4%        0.73 1,164 ( 92%) 
Split 38    1,603 (80.2%)     65.2%        0.68 1,192 ( 94%) 
Split 39    1,645 (82.2%)     65.4%        0.59 1,139 ( 90%) 
Split 40    1,657 (82.8%)     64.0%        0.56 1,199 ( 95%) 
Split 41    1,681 (84.1%)     62.3%        0.52 1,201 ( 95%) 
Split 42    1,691 (84.6%)     61.2%        0.52 1,194 ( 94%) 
Split 43    1,692 (84.6%)     62.5%        0.48 1,191 ( 94%) 
Split 44    1,744 (87.2%)     60.1%        0.46 1,184 ( 94%) 
Split 45    1,754 (87.7%)     58.0%        0.44 1,211 ( 96%) 
Split 46    1,761 (88.1%)     58.2%        0.42 1,207 ( 95%) 
Split 47    1,760 (88.0%)     56.7%        0.44 1,209 ( 96%) 
Split 48    1,770 (88.5%)     53.5%        0.39 1,212 ( 96%) 
Split 49    1,789 (89.5%)     54.1%        0.38 1,231 ( 97%) 
Split 50    1,793 (89.7%)     53.7%        0.38 1,235 ( 98%) 
Split 51    1,801 (90.0%)     50.5%        0.36 1,203 ( 95%) 
Split 52    1,805 (90.2%)     50.7%        0.35 1,183 ( 94%) 
Split 53    1,812 (90.6%)     48.9%        0.35 1,207 ( 95%) 
Split 54    1,824 (91.2%)     47.8%        0.34 1,220 ( 97%) 
Split 55    1,823 (91.2%)     44.6%        0.33 1,193 ( 94%) 
Split 56    1,821 (91.0%)     45.3%        0.33 1,217 ( 96%) 
Split 57    1,829 (91.5%)     42.8%        0.32 1,222 ( 97%) 
Split 58    1,834 (91.7%)     40.4%        0.32 1,191 ( 94%) 
Split 59    1,844 (92.2%)     39.3%        0.31 1,220 ( 97%) 
Split 60    1,874 (93.7%)     39.6%        0.28 1,182 ( 93%) 
Split 61    1,869 (93.5%)     35.7%        0.28 1,191 ( 94%) 
Split 62    1,886 (94.3%)     34.2%        0.25 1,147 ( 91%) 
Resample    1,886 (94.3%)       NA%          NA 1,805 (143%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      25.0%               171
MS Step 2      24.8%               855
MS Step 3      26.1%               855
MS Step 4      27.1%               684
MS Step 5      27.8%               684
MS Step 6      28.4%               684
MS Step 7      28.7%               684
MS Step 8      28.7%               684
MS Step 9      29.1%               684
MS Step 10     29.2%               684
MS Step 11     29.1%               684
MS Step 12     29.2%               684
MS Step 13     29.3%               684
MS Step 14     29.1%               684
MS Step 15     29.0%               684
MS Step 16     29.0%               684
MS Step 17     28.9%               684
MS Step 18     28.9%               684
MS Step 19     28.7%               684
MS Step 20     28.7%               684
MS Step 21     28.6%               684
MS Step 22     28.6%               684
MS Step 23     28.7%               684
MS Step 24     28.5%               684
MS Step 25     28.5%               684
MS Step 26     28.6%               684
MS Step 27     28.6%               684
MS Step 28     28.8%               684
MS Step 29     28.9%               684
MS Step 30     29.2%               684
MS Step 31     29.4%               684
MS Step 32     29.9%               684
MS Step 33     30.1%               684
MS Step 34     30.6%               684
MS Step 35     31.0%               684
MS Step 36     31.2%               684
MS Step 37     31.7%               684
MS Step 38     32.0%               684
MS Step 39     32.2%               684
MS Step 40     32.4%               684
MS Step 41     32.6%               684
MS Step 42     32.7%               684
MS Step 43     32.9%               684
MS Step 44     32.9%               684
MS Step 45     32.9%               684
MS Step 46     32.9%               684
MS Step 47     32.9%               684
MS Step 48     32.9%               684
MS Step 49     32.8%               684
MS Step 50     32.5%               684
MS Step 51     32.4%               684
MS Step 52     32.3%               684
MS Step 53     32.1%               684
MS Step 54     31.8%               684
MS Step 55     31.6%               684
MS Step 56     31.2%               684
MS Step 57     30.9%               684
MS Step 58     30.6%               684
MS Step 59     30.2%               684
MS Step 60     29.9%               684
MS Step 61     29.6%               684
MS Step 62     29.3%               684
```

### State House
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/0baace02-2328-494e-82bf-f0aff1c6ca45" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 150 districts on 14,191 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 149
• `mh_accept_per_smc` = 120
• `pair_rule` = uniform
Plan diversity 80% range: 0.88 to 0.94
95 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.018               1.027               1.024               1.028 
             arv_18              arv_20      atg_18_dem_jam      atg_18_rep_wof 
              1.034               1.026               1.026               1.038 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.024               1.007               1.015               1.025 
              e_dem               e_dvs                egap      gov_18_dem_cuo 
              1.003               1.049               1.006               1.031 
     gov_18_rep_mol         muni_splits             ndshare                 ndv 
              1.037               1.015               1.049               1.020 
                nrv               pbias            plan_dev            pop_aian 
              1.030               1.008               1.001               1.036 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.028               1.037               1.044               1.017 
          pop_other         pop_overlap             pop_two           pop_white 
              1.033               1.012               1.027               1.048 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.015               1.027               1.033               1.024 
     pre_20_rep_tru total_county_splits   total_muni_splits           total_vap 
              1.026               1.009               1.015               1.017 
     uss_16_dem_sch      uss_16_rep_lon      uss_18_dem_gil      uss_18_rep_far 
              1.023               1.050               1.025               1.031 
           vap_aian           vap_asian           vap_black            vap_hisp 
              1.037               1.031               1.032             ❌1.057 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.030               1.029               1.014               1.049 
• R-hat ≤ 1.05: 7704
• 1.05 < R-hat ≤ 1.1: 1
• R-hat > 1.1: 0
• Total R-hats: 7705
ℹ ALERT: Chains have weakly converged.
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
          Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1        242 (12.1%)    100.0%        3.62 1,260 (100%) 
Split 2        306 (15.3%)     99.7%        3.26   533 ( 42%) 
Split 3        395 (19.8%)     98.9%        3.11   621 ( 49%) 
Split 4        577 (28.9%)     98.3%        2.83   682 ( 54%) 
Split 5        647 (32.4%)     98.0%        2.64   764 ( 60%) 
Split 6        664 (33.2%)     97.4%        2.47   794 ( 63%) 
Split 7        724 (36.2%)     96.3%        2.42   815 ( 64%) 
Split 8        789 (39.5%)     95.9%        2.28   835 ( 66%) 
Split 9        830 (41.5%)     94.2%        2.16   875 ( 69%) 
Split 10       866 (43.3%)     94.5%        2.05   910 ( 72%) 
Split 11       916 (45.8%)     93.5%        2.09   896 ( 71%) 
Split 12       948 (47.4%)     92.6%        1.97   913 ( 72%) 
Split 13     1,000 (50.0%)     92.2%        1.94   947 ( 75%) 
Split 14     1,013 (50.7%)     90.7%        1.87   971 ( 77%) 
Split 15     1,050 (52.5%)     90.4%        1.77   987 ( 78%) 
Split 16     1,098 (54.9%)     90.3%        1.75   978 ( 77%) 
Split 17     1,105 (55.3%)     88.8%        1.64 1,015 ( 80%) 
Split 18     1,118 (55.9%)     88.0%        1.63 1,007 ( 80%) 
Split 19     1,148 (57.4%)     87.1%        1.63 1,015 ( 80%) 
Split 20     1,186 (59.3%)     86.5%        1.55 1,027 ( 81%) 
Split 21     1,193 (59.7%)     86.1%        1.49 1,038 ( 82%) 
Split 22     1,209 (60.5%)     84.2%        1.47 1,050 ( 83%) 
Split 23     1,260 (63.0%)     82.5%        1.46 1,037 ( 82%) 
Split 24     1,274 (63.7%)     84.6%        1.36 1,038 ( 82%) 
Split 25     1,281 (64.0%)     83.0%        1.37 1,076 ( 85%) 
Split 26     1,293 (64.6%)     82.4%        1.33 1,065 ( 84%) 
Split 27     1,270 (63.5%)     81.0%        1.32 1,091 ( 86%) 
Split 28     1,308 (65.4%)     80.6%        1.31 1,042 ( 82%) 
Split 29     1,364 (68.2%)     80.9%        1.24 1,074 ( 85%) 
Split 30     1,367 (68.3%)     80.9%        1.20 1,103 ( 87%) 
Split 31     1,373 (68.7%)     79.0%        1.19 1,078 ( 85%) 
Split 32     1,387 (69.4%)     77.8%        1.16 1,110 ( 88%) 
Split 33     1,398 (69.9%)     77.1%        1.10 1,100 ( 87%) 
Split 34     1,383 (69.2%)     77.8%        1.11 1,104 ( 87%) 
Split 35     1,415 (70.7%)     77.0%        1.11 1,091 ( 86%) 
Split 36     1,468 (73.4%)     76.2%        1.05 1,095 ( 87%) 
Split 37     1,447 (72.4%)     76.3%        1.09 1,127 ( 89%) 
Split 38     1,435 (71.8%)     77.0%        1.02 1,112 ( 88%) 
Split 39     1,482 (74.1%)     76.0%        0.98 1,130 ( 89%) 
Split 40     1,471 (73.6%)     73.4%        0.97 1,135 ( 90%) 
Split 41     1,474 (73.7%)     74.7%        1.00 1,125 ( 89%) 
Split 42     1,499 (74.9%)     73.0%        0.95 1,130 ( 89%) 
Split 43     1,498 (74.9%)     72.3%        0.92 1,140 ( 90%) 
Split 44     1,511 (75.5%)     72.6%        0.93 1,136 ( 90%) 
Split 45     1,516 (75.8%)     70.2%        0.88 1,145 ( 91%) 
Split 46     1,536 (76.8%)     71.7%        0.90 1,145 ( 91%) 
Split 47     1,547 (77.4%)     70.5%        0.87 1,155 ( 91%) 
Split 48     1,559 (77.9%)     69.8%        0.84 1,140 ( 90%) 
Split 49     1,610 (80.5%)     70.3%        0.76 1,179 ( 93%) 
Split 50     1,586 (79.3%)     69.2%        0.79 1,163 ( 92%) 
Split 51     1,577 (78.9%)     70.5%        0.76 1,158 ( 92%) 
Split 52     1,588 (79.4%)     68.5%        0.75 1,148 ( 91%) 
Split 53     1,612 (80.6%)     68.6%        0.73 1,156 ( 91%) 
Split 54     1,599 (79.9%)     68.9%        0.76 1,161 ( 92%) 
Split 55     1,645 (82.2%)     69.2%        0.66 1,156 ( 91%) 
Split 56     1,646 (82.3%)     66.5%        0.67 1,168 ( 92%) 
Split 57     1,651 (82.6%)     67.6%        0.66 1,193 ( 94%) 
Split 58     1,672 (83.6%)     67.5%        0.63 1,186 ( 94%) 
Split 59     1,679 (83.9%)     66.4%        0.59 1,207 ( 95%) 
Split 60     1,670 (83.5%)     64.2%        0.62 1,179 ( 93%) 
Split 61     1,687 (84.3%)     65.8%        0.58 1,169 ( 92%) 
Split 62     1,696 (84.8%)     65.0%        0.58 1,195 ( 95%) 
Split 63     1,713 (85.6%)     64.7%        0.54 1,197 ( 95%) 
Split 64     1,730 (86.5%)     63.7%        0.54 1,200 ( 95%) 
Split 65     1,720 (86.0%)     64.0%        0.54 1,202 ( 95%) 
Split 66     1,719 (85.9%)     64.2%        0.52 1,171 ( 93%) 
Split 67     1,729 (86.4%)     65.8%        0.51 1,210 ( 96%) 
Split 68     1,728 (86.4%)     64.1%        0.51 1,205 ( 95%) 
Split 69     1,751 (87.6%)     62.8%        0.48 1,210 ( 96%) 
Split 70     1,770 (88.5%)     63.8%        0.45 1,215 ( 96%) 
Split 71     1,764 (88.2%)     61.2%        0.47 1,233 ( 98%) 
Split 72     1,776 (88.8%)     61.7%        0.47 1,236 ( 98%) 
Split 73     1,769 (88.5%)     62.4%        0.47 1,208 ( 96%) 
Split 74     1,773 (88.6%)     61.0%        0.43 1,213 ( 96%) 
Split 75     1,794 (89.7%)     62.2%        0.42 1,210 ( 96%) 
Split 76     1,814 (90.7%)     62.3%        0.38 1,213 ( 96%) 
Split 77     1,799 (90.0%)     61.7%        0.43 1,201 ( 95%) 
Split 78     1,807 (90.4%)     62.2%        0.41 1,242 ( 98%) 
Split 79     1,822 (91.1%)     60.1%        0.37 1,217 ( 96%) 
Split 80     1,818 (90.9%)     60.0%        0.37 1,219 ( 96%) 
Split 81     1,841 (92.1%)     61.5%        0.36 1,214 ( 96%) 
Split 82     1,833 (91.7%)     60.9%        0.37 1,208 ( 96%) 
Split 83     1,834 (91.7%)     58.9%        0.34 1,235 ( 98%) 
Split 84     1,841 (92.1%)     58.8%        0.36 1,227 ( 97%) 
Split 85     1,848 (92.4%)     58.9%        0.34 1,236 ( 98%) 
Split 86     1,847 (92.4%)     58.7%        0.34 1,215 ( 96%) 
Split 87     1,845 (92.3%)     60.1%        0.35 1,239 ( 98%) 
Split 88     1,845 (92.3%)     60.3%        0.33 1,201 ( 95%) 
Split 89     1,860 (93.0%)     56.9%        0.32 1,240 ( 98%) 
Split 90     1,865 (93.2%)     59.0%        0.31 1,240 ( 98%) 
Split 91     1,860 (93.0%)     56.6%        0.31 1,236 ( 98%) 
Split 92     1,858 (92.9%)     58.1%        0.31 1,227 ( 97%) 
Split 93     1,867 (93.4%)     56.6%        0.30 1,211 ( 96%) 
Split 94     1,873 (93.7%)     56.4%        0.29 1,238 ( 98%) 
Split 95     1,869 (93.5%)     57.2%        0.31 1,222 ( 97%) 
Split 96     1,873 (93.7%)     55.7%        0.29 1,244 ( 98%) 
Split 97     1,871 (93.5%)     55.1%        0.30 1,245 ( 98%) 
Split 98     1,874 (93.7%)     55.5%        0.29 1,228 ( 97%) 
Split 99     1,871 (93.5%)     56.9%        0.30 1,214 ( 96%) 
Split 100    1,874 (93.7%)     53.2%        0.30 1,203 ( 95%) 
Split 101    1,876 (93.8%)     54.1%        0.29 1,241 ( 98%) 
Split 102    1,877 (93.8%)     54.3%        0.28 1,220 ( 97%) 
Split 103    1,885 (94.3%)     54.6%        0.28 1,230 ( 97%) 
Split 104    1,881 (94.1%)     54.9%        0.28 1,204 ( 95%) 
Split 105    1,893 (94.7%)     53.1%        0.26 1,270 (100%) 
Split 106    1,895 (94.8%)     52.6%        0.26 1,253 ( 99%) 
Split 107    1,888 (94.4%)     52.5%        0.27 1,259 (100%) 
Split 108    1,882 (94.1%)     51.6%        0.28 1,259 (100%) 
Split 109    1,894 (94.7%)     51.4%        0.26 1,226 ( 97%) 
Split 110    1,893 (94.6%)     50.3%        0.26 1,240 ( 98%) 
Split 111    1,898 (94.9%)     51.5%        0.25 1,253 ( 99%) 
Split 112    1,900 (95.0%)     50.9%        0.25 1,255 ( 99%) 
Split 113    1,895 (94.8%)     50.1%        0.27 1,230 ( 97%) 
Split 114    1,901 (95.1%)     49.9%        0.25 1,241 ( 98%) 
Split 115    1,899 (95.0%)     49.3%        0.25 1,250 ( 99%) 
Split 116    1,900 (95.0%)     47.3%        0.25 1,226 ( 97%) 
Split 117    1,899 (94.9%)     48.0%        0.25 1,235 ( 98%) 
Split 118    1,895 (94.7%)     46.8%        0.26 1,213 ( 96%) 
Split 119    1,899 (94.9%)     47.9%        0.25 1,243 ( 98%) 
Split 120    1,904 (95.2%)     46.3%        0.25 1,237 ( 98%) 
Split 121    1,902 (95.1%)     46.0%        0.25 1,227 ( 97%) 
Split 122    1,916 (95.8%)     45.7%        0.22 1,224 ( 97%) 
Split 123    1,911 (95.6%)     45.8%        0.23 1,264 (100%) 
Split 124    1,911 (95.6%)     44.1%        0.23 1,249 ( 99%) 
Split 125    1,917 (95.8%)     43.8%        0.22 1,238 ( 98%) 
Split 126    1,913 (95.6%)     42.7%        0.23 1,212 ( 96%) 
Split 127    1,917 (95.9%)     41.9%        0.22 1,230 ( 97%) 
Split 128    1,913 (95.6%)     42.7%        0.23 1,235 ( 98%) 
Split 129    1,914 (95.7%)     41.0%        0.23 1,242 ( 98%) 
Split 130    1,917 (95.9%)     41.3%        0.22 1,241 ( 98%) 
Split 131    1,921 (96.1%)     40.6%        0.21 1,259 (100%) 
Split 132    1,924 (96.2%)     40.2%        0.21 1,252 ( 99%) 
Split 133    1,915 (95.8%)     38.9%        0.22 1,232 ( 97%) 
Split 134    1,919 (95.9%)     39.4%        0.22 1,199 ( 95%) 
Split 135    1,920 (96.0%)     38.2%        0.22 1,227 ( 97%) 
Split 136    1,923 (96.2%)     38.1%        0.22 1,233 ( 98%) 
Split 137    1,926 (96.3%)     37.1%        0.21 1,218 ( 96%) 
Split 138    1,929 (96.5%)     36.9%        0.20 1,238 ( 98%) 
Split 139    1,930 (96.5%)     35.3%        0.20 1,251 ( 99%) 
Split 140    1,932 (96.6%)     35.2%        0.20 1,240 ( 98%) 
Split 141    1,930 (96.5%)     35.1%        0.20 1,244 ( 98%) 
Split 142    1,930 (96.5%)     34.5%        0.20 1,233 ( 98%) 
Split 143    1,934 (96.7%)     34.8%        0.19 1,200 ( 95%) 
Split 144    1,933 (96.6%)     34.0%        0.20 1,206 ( 95%) 
Split 145    1,938 (96.9%)     31.7%        0.19 1,219 ( 96%) 
Split 146    1,939 (97.0%)     32.1%        0.18 1,210 ( 96%) 
Split 147    1,949 (97.5%)     31.2%        0.17 1,187 ( 94%) 
Split 148    1,953 (97.7%)     30.8%        0.16 1,176 ( 93%) 
Split 149    1,955 (97.8%)     28.7%        0.16 1,110 ( 88%) 
Resample     1,955 (97.8%)       NA%          NA 1,878 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
            Acc. rate MS Steps per Plan
MS Step 1       18.4%               120
MS Step 2       18.0%               720
MS Step 3       19.9%               720
MS Step 4       21.6%               720
MS Step 5       23.2%               600
MS Step 6       24.6%               600
MS Step 7       25.7%               600
MS Step 8       26.3%               480
MS Step 9       27.3%               480
MS Step 10      27.9%               480
MS Step 11      28.8%               480
MS Step 12      29.4%               480
MS Step 13      29.9%               480
MS Step 14      30.2%               480
MS Step 15      30.7%               480
MS Step 16      31.0%               480
MS Step 17      31.2%               480
MS Step 18      31.6%               480
MS Step 19      31.9%               480
MS Step 20      32.1%               480
MS Step 21      32.4%               480
MS Step 22      32.5%               480
MS Step 23      32.7%               480
MS Step 24      32.7%               480
MS Step 25      32.9%               480
MS Step 26      33.0%               480
MS Step 27      33.4%               480
MS Step 28      33.1%               360
MS Step 29      33.3%               480
MS Step 30      33.5%               480
MS Step 31      33.6%               360
MS Step 32      33.5%               360
MS Step 33      33.7%               360
MS Step 34      33.5%               360
MS Step 35      33.7%               360
MS Step 36      33.7%               360
MS Step 37      33.6%               360
MS Step 38      33.6%               360
MS Step 39      33.6%               360
MS Step 40      33.5%               360
MS Step 41      33.6%               360
MS Step 42      33.7%               360
MS Step 43      33.8%               360
MS Step 44      33.8%               360
MS Step 45      33.8%               360
MS Step 46      33.8%               360
MS Step 47      33.9%               360
MS Step 48      34.0%               360
MS Step 49      34.0%               360
MS Step 50      33.8%               360
MS Step 51      33.7%               360
MS Step 52      34.0%               360
MS Step 53      33.9%               360
MS Step 54      33.9%               360
MS Step 55      33.9%               360
MS Step 56      33.9%               360
MS Step 57      34.0%               360
MS Step 58      33.9%               360
MS Step 59      34.0%               360
MS Step 60      33.9%               360
MS Step 61      33.9%               360
MS Step 62      33.8%               360
MS Step 63      34.0%               360
MS Step 64      34.2%               360
MS Step 65      34.2%               360
MS Step 66      34.1%               360
MS Step 67      34.2%               360
MS Step 68      34.3%               360
MS Step 69      34.4%               360
MS Step 70      34.3%               360
MS Step 71      34.4%               360
MS Step 72      34.6%               360
MS Step 73      34.6%               360
MS Step 74      34.5%               360
MS Step 75      34.6%               360
MS Step 76      34.7%               360
MS Step 77      34.8%               360
MS Step 78      34.8%               360
MS Step 79      34.8%               360
MS Step 80      34.8%               360
MS Step 81      34.9%               360
MS Step 82      34.9%               360
MS Step 83      34.8%               360
MS Step 84      34.8%               360
MS Step 85      34.8%               360
MS Step 86      35.0%               360
MS Step 87      35.0%               360
MS Step 88      35.0%               360
MS Step 89      35.1%               360
MS Step 90      35.2%               360
MS Step 91      35.2%               360
MS Step 92      35.1%               360
MS Step 93      35.1%               360
MS Step 94      35.1%               360
MS Step 95      35.2%               360
MS Step 96      35.0%               360
MS Step 97      34.9%               360
MS Step 98      34.9%               360
MS Step 99      34.8%               360
MS Step 100     34.8%               360
MS Step 101     34.8%               360
MS Step 102     34.7%               360
MS Step 103     34.6%               360
MS Step 104     34.6%               360
MS Step 105     34.5%               360
MS Step 106     34.5%               360
MS Step 107     34.4%               360
MS Step 108     34.3%               360
MS Step 109     34.3%               360
MS Step 110     34.2%               360
MS Step 111     34.0%               360
MS Step 112     34.1%               360
MS Step 113     34.0%               360
MS Step 114     33.8%               360
MS Step 115     33.8%               360
MS Step 116     33.7%               360
MS Step 117     33.7%               360
MS Step 118     33.5%               360
MS Step 119     33.6%               360
MS Step 120     33.4%               360
MS Step 121     33.2%               360
MS Step 122     33.1%               480
MS Step 123     33.0%               480
MS Step 124     32.8%               480
MS Step 125     32.8%               480
MS Step 126     32.7%               480
MS Step 127     32.5%               480
MS Step 128     32.4%               480
MS Step 129     32.1%               480
MS Step 130     32.1%               480
MS Step 131     32.0%               480
MS Step 132     31.9%               480
MS Step 133     31.7%               480
MS Step 134     31.6%               480
MS Step 135     31.4%               480
MS Step 136     31.3%               480
MS Step 137     31.1%               480
MS Step 138     31.0%               480
MS Step 139     30.9%               480
MS Step 140     30.7%               480
MS Step 141     30.7%               480
MS Step 142     30.5%               480
MS Step 143     30.4%               480
MS Step 144     30.3%               480
MS Step 145     30.1%               480
MS Step 146     30.0%               480
MS Step 147     29.8%               480
MS Step 148     29.7%               480
MS Step 149     29.5%               480
```

## Additional Notes 
### Competitiveness Constraint - State Senate
<img width="1125" height="734" alt="image" src="https://github.com/user-attachments/assets/35c4db49-7749-4b1d-b576-6cbdde63ce61" />

### Competitiveness Constraint - State House
<img width="1125" height="734" alt="image" src="https://github.com/user-attachments/assets/ccc3d6f1-2ae8-4811-ab64-5476da6c16d5" />

### Core Preservation - State Senate
<img width="1022" height="640" alt="image" src="https://github.com/user-attachments/assets/a2254940-9e15-485d-821d-ad0de7fa8e2e" />
mean(pop_overlap): no cores = 0.52, with cores = 0.521

### Core preservation - State House 
<img width="1022" height="640" alt="image" src="https://github.com/user-attachments/assets/3f7d5d2c-c24f-4812-837f-e93530590648" />
mean(pop_overlap): no cores = 0.522 with cores = 0.513

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited
