### PR TITLE
Update 03_sim_UT_cd_2000.R

### DIFF
--- a/analyses/UT_cd_2000/03_sim_UT_cd_2000.R
+++ b/analyses/UT_cd_2000/03_sim_UT_cd_2000.R
@@ -8,7 +8,7 @@ if (interactive()) {
     cli_process_start("Running simulations for {.pkg UT_cd_2000}")
 
     set.seed(2000)
-    plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county)
+    plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
     plans <- plans %>%
         group_by(chain) %>%
         filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples


### PR DESCRIPTION
This PR updates `03_sim_UT_cd_2000.R` to correct a mismatch: the code specified pseudo-counties, while the simulations were in fact run using county constraints.