### PR TITLE
Compare Indiana 2000 Congressional Districts: Baseline vs. Agent Analysis (Diagnostics)

### DIFF
--- a/analyses/IN_cd_2000_agent/01_prep_IN_cd_2000_agent.R
+++ b/analyses/IN_cd_2000_agent/01_prep_IN_cd_2000_agent.R
@@ -1,0 +1,23 @@
+###############################################################################
+# Download and prepare data for `IN_cd_2000_agent` analysis
+# © ALARM Project, April 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(baf)
+    library(cli)
+    library(here)
+    library(stringr)
+    devtools::load_all() # load utilities
+})
+
+# Load pre-built shapefile -----
+shp_path <- "data-out/IN_2000_agent/shp_vtd.rds"
+
+in_shp <- read_rds(here(shp_path))
+cli_alert_success("Loaded {.strong IN} shapefile")

--- a/analyses/IN_cd_2000_agent/02_setup_IN_cd_2000_agent.R
+++ b/analyses/IN_cd_2000_agent/02_setup_IN_cd_2000_agent.R
@@ -1,0 +1,21 @@
+###############################################################################
+# Set up redistricting simulation for `IN_cd_2000_agent`
+# © ALARM Project, April 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg IN_cd_2000_agent}")
+
+map <- redist_map(in_shp, pop_tol = 0.005,
+    existing_plan = cd_2000, adj = in_shp$adj)
+
+map <- map %>%
+    mutate(pseudo_county = pick_county_muni(map, counties = county, munis = muni,
+        pop_muni = get_target(map)))
+
+# Add an analysis name attribute
+attr(map, "analysis_name") <- "IN_2000_agent"
+
+map$state <- "IN"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map, "data-out/IN_2000_agent/IN_cd_2000_agent_map.rds", compress = "xz")
+cli_process_done()

--- a/analyses/IN_cd_2000_agent/03_sim_IN_cd_2000_agent.R
+++ b/analyses/IN_cd_2000_agent/03_sim_IN_cd_2000_agent.R
@@ -1,0 +1,42 @@
+###############################################################################
+# Simulate plans for `IN_cd_2000_agent`
+# © ALARM Project, April 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg IN_cd_2000_agent}")
+
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = pseudo_county, ncores = 15)
+
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_plans object. Do not edit this path.
+write_rds(plans, here("data-out/IN_2000_agent/IN_cd_2000_agent_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg IN_cd_2000_agent}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/IN_2000_agent/IN_cd_2000_agent_stats.csv")
+
+cli_process_done()
+
+# Extra validation plots -----
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map)
+    summary(plans)
+}

--- a/analyses/IN_cd_2000_agent/doc_IN_cd_2000_agent.md
+++ b/analyses/IN_cd_2000_agent/doc_IN_cd_2000_agent.md
@@ -1,0 +1,19 @@
+# 2000 Indiana Congressional Districts
+
+## Redistricting requirements
+In Indiana, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), there are no state law requirements for congressional districts.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 0.5%.
+We use a pseudo-county constraint to limit county and municipality splits.
+
+## Data Sources
+Data for Indiana comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Indiana across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 5,000.
+We use a pseudo-county constraint to limit the county and municipality (i.e., city and township) splits.


### PR DESCRIPTION
This PR compares our original `IN_cd_2000` analysis with the AI-generated `IN_cd_2000_agent` analysis. Overall, I think the AI-generated pipeline works reasonably well as an initial draft and can help speed up parts of the analysis workflow.
The main substantive difference is that the AI-generated analysis uses a **pseudo-county** constraint, whereas ours uses a **county constraint**. Since Indiana did not appear to have explicit state-law congressional redistricting requirements in 2000, I am unsure whether the pseudo-county constraint is necessary here.
For this run, the AI-generated `01_prep` was also simplified because the pipeline hit a 403 error when downloading the 2000 VTD shapefiles from `census.gov`, so I substituted a locally cached shapefile from a previously completed analysis. I don't consider this the main difference in general; it was a workaround for this run.
Despite these differences, the diagnostics looked reasonable: all R-hats were below 1.05, and the validation plots looked broadly similar aside from the county and municipality splits.

## Summary
### Original
```
✔ Preparing IN shapefile ... done
SMC: 5,000 sampled plans of 9 districts on 5,034 units
`adapt_k_thresh`=0.99 • `seq_alpha`=0.5
`pop_temper`=0           
ℹ Preparing IN shapefile

Plan diversity 80% range: 0.61 to 0.83
ℹ Preparing IN shapefile

R-hat values for summary statistics:
  pop_overlap     total_vap      plan_dev     comp_edge   comp_polsby     pop_other       pop_two 
        1.013         1.017         1.007         1.010         1.003         1.012         1.011 
     pop_aian     pop_white      pop_hisp     pop_asian      pop_nhpi     pop_black      vap_hisp 
        1.010         1.008         1.006         1.001         1.012         1.006         1.005 
     vap_aian     vap_asian     vap_white     vap_black      vap_nhpi     vap_other       vap_two 
        1.009         1.002         1.008         1.006         1.010         1.003         1.013 
county_splits           ndv           nrv       ndshare 
        1.003         1.011         1.008         1.006 

Sampling diagnostics for SMC run 1 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,858 (92.9%)     15.0%        0.56 1,263 (100%)     12 
Split 2     1,834 (91.7%)     19.1%        0.59 1,245 ( 98%)      8 
Split 3     1,761 (88.1%)     27.5%        0.68 1,235 ( 98%)      5 
Split 4     1,743 (87.2%)     28.6%        0.70 1,220 ( 97%)      4 
Split 5     1,728 (86.4%)     21.4%        0.73 1,195 ( 95%)      5 
Split 6     1,701 (85.0%)     26.7%        0.74 1,189 ( 94%)      3 
Split 7     1,740 (87.0%)     18.1%        0.71 1,157 ( 92%)      4 
Split 8     1,683 (84.2%)      7.9%        0.77 1,052 ( 83%)      3 
Resample      951 (47.6%)       NA%        0.77 1,356 (107%)     NA 

Sampling diagnostics for SMC run 2 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,857 (92.9%)     18.0%        0.56 1,283 (101%)     10 
Split 2     1,817 (90.8%)     25.7%        0.61 1,235 ( 98%)      6 
Split 3     1,746 (87.3%)     32.6%        0.68 1,212 ( 96%)      4 
Split 4     1,737 (86.9%)     28.7%        0.70 1,212 ( 96%)      4 
Split 5     1,748 (87.4%)     18.3%        0.72 1,227 ( 97%)      6 
Split 6     1,711 (85.6%)     21.8%        0.71 1,202 ( 95%)      4 
Split 7     1,749 (87.5%)     20.6%        0.70 1,167 ( 92%)      3 
Split 8     1,724 (86.2%)      8.9%        0.72 1,037 ( 82%)      2 
Resample    1,015 (50.7%)       NA%        0.72 1,406 (111%)     NA 

Sampling diagnostics for SMC run 3 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,866 (93.3%)     14.8%        0.55 1,238 ( 98%)     12 
Split 2     1,842 (92.1%)     17.1%        0.58 1,238 ( 98%)      9 
Split 3     1,760 (88.0%)     22.9%        0.67 1,228 ( 97%)      6 
Split 4     1,682 (84.1%)     24.9%        0.74 1,210 ( 96%)      5 
Split 5     1,668 (83.4%)     25.8%        0.75 1,212 ( 96%)      4 
Split 6     1,716 (85.8%)     21.9%        0.73 1,198 ( 95%)      4 
Split 7     1,749 (87.4%)     20.6%        0.72 1,133 ( 90%)      3 
Split 8     1,692 (84.6%)      7.2%        0.74 1,024 ( 81%)      3 
Resample      962 (48.1%)       NA%        0.74 1,345 (106%)     NA 

Sampling diagnostics for SMC run 4 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,860 (93.0%)     17.9%        0.57 1,262 (100%)     10 
Split 2     1,837 (91.9%)     20.3%        0.59 1,243 ( 98%)      8 
Split 3     1,777 (88.8%)     27.4%        0.66 1,221 ( 97%)      5 
Split 4     1,745 (87.2%)     28.3%        0.70 1,203 ( 95%)      4 
Split 5     1,758 (87.9%)     15.6%        0.70 1,199 ( 95%)      7 
Split 6     1,751 (87.5%)     13.7%        0.70 1,174 ( 93%)      7 
Split 7     1,744 (87.2%)     14.1%        0.72 1,137 ( 90%)      5 
Split 8     1,688 (84.4%)      5.9%        0.76 1,037 ( 82%)      4 
Resample      925 (46.2%)       NA%        0.76 1,346 (106%)     NA 

Sampling diagnostics for SMC run 5 of 5 (2,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1     1,859 (92.9%)     16.9%        0.56 1,264 (100%)     11 
Split 2     1,848 (92.4%)     20.0%        0.58 1,210 ( 96%)      8 
Split 3     1,758 (87.9%)     19.8%        0.68 1,232 ( 97%)      7 
Split 4     1,752 (87.6%)     28.2%        0.70 1,204 ( 95%)      4 
Split 5     1,787 (89.3%)     25.1%        0.67 1,204 ( 95%)      4 
Split 6     1,767 (88.3%)     26.1%        0.68 1,211 ( 96%)      3 
Split 7     1,712 (85.6%)     25.4%        0.74 1,172 ( 93%)      2 
Split 8     1,600 (80.0%)      3.5%        0.87 1,012 ( 80%)      7 
Resample      844 (42.2%)       NA%        0.87 1,227 ( 97%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
```

### AI-generated
```
SMC: 5,000 sampled plans of 9 districts on 5,034 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.58 to 0.81
Largest R-hat values for ordered summary statistics:
    comp_bbox_reock           comp_edge         comp_polsby       county_splits         muni_splits 
              1.028               1.005               1.018               1.005               1.004 
            ndshare                 ndv                 nrv            plan_dev            pop_aian 
              1.030               1.030               1.020               1.008               1.029 
          pop_asian           pop_black            pop_hisp            pop_nhpi           pop_other 
              1.012               1.016               1.022               1.015               1.023 
        pop_overlap             pop_two           pop_white total_county_splits   total_muni_splits 
              1.005               1.021               1.016               1.002               1.004 
          total_vap            vap_aian           vap_asian           vap_black            vap_hisp 
              1.015               1.029               1.012               1.016               1.022 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.015               1.020               1.014               1.017 
• R-hat ≤ 1.05: 261
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 261
Sampling diagnostics for SMC run 1 of 5 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       907 (45.4%)     20.2%        1.17 1,283 (101%)      9 
Split 2       901 (45.0%)     25.5%        0.99   944 ( 75%)      6 
Split 3       969 (48.5%)     30.6%        0.93   988 ( 78%)      4 
Split 4     1,011 (50.6%)     20.9%        0.90   999 ( 79%)      6 
Split 5       959 (48.0%)     24.4%        0.88 1,033 ( 82%)      4 
Split 6       892 (44.6%)     27.0%        0.86   992 ( 78%)      3 
Split 7       690 (34.5%)     27.0%        0.87   990 ( 78%)      2 
Split 8     1,879 (94.0%)      5.9%        0.26   887 ( 70%)      4 
Resample    1,879 (94.0%)       NA%          NA 1,807 (143%)     NA 

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the
log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics
should be between 1 and 1.05.
```

## Validation
### Original
<img width="3000" height="4500" alt="validation_20250731_0204" src="https://github.com/user-attachments/assets/eada353b-cf32-4ced-b8a0-baf98b535450" />

### AI-generated
<img width="3000" height="5400" alt="validation_20260419_0058" src="https://github.com/user-attachments/assets/d3a12322-c3fc-4473-8f69-6d959b9bf159" />

@kosukeimai @christopherkenny 