### PR TITLE
Update finalize.R

### DIFF
--- a/R/finalize.R
+++ b/R/finalize.R
@@ -258,18 +258,17 @@ finalize_analysis = function(state, type = "cd", year = 2020, overwrite = TRUE) 
             }
             cli::cli_progress_update()
 
-            map_cols <- setdiff(names(map_in)[map_in |>
-                                                  dplyr::as_tibble() |>
-                                                  tidyselect::eval_select(dplyr::starts_with(c(
-                                                      'pop', 'vap', 'pre', 'uss', 'gov', 'atg', 'sos'
-                                                  )), .)], c(
-                                                      "GEOID", "state", "county", "muni", "county_muni", "cd_2000",
-                                                      "cd_1990", "vtd", "pop", "vap", "area_land", "area_water", "adj",
-                                                      "geometry", "pseudo_county")
+            map_cols <- setdiff(
+                names(map_in)[grepl("^(pop|vap|pre|uss|gov|atg|sos)", names(map_in))],
+                c(
+                    "GEOID", "state", "county", "muni", "county_muni", "cd_2000",
+                    "cd_1990", "vtd", "pop", "vap", "area_land", "area_water", "adj",
+                    "geometry", "pseudo_county"
+                )
             )
             exp_cols <- c("pop_overlap", "total_vap", "plan_dev", "comp_edge",
                           "comp_polsby", map_cols,
-                          "ndshare", "e_dvs", "pr_dem", "e_dem", "pbias", "egap")
+                          "ndshare")
             if (!all(exp_cols %in% names(stats_in))) {
                 cli::cli_abort("Missing the following column{?s} in {.cls redist_plans}:
                       {.arg {setdiff(exp_cols, names(stats_in))}}.")

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -193,7 +193,7 @@ finalize_analysis = function(state, type = "cd", year = 2020, overwrite = TRUE) 
                 "https://raw.githubusercontent.com/alarm-redist/census-2020/road/road-2000/{state}_{year}.csv"
             )
             
-            road_dat <- readr::read_csv(road_path, show_col_types = FALSE) |>
+            road_dat <- readr::read_csv(road_path, col_types = readr::cols(GEOID = readr::col_character()), show_col_types = FALSE) |>
             dplyr::select(GEOID, ndv, nrv)
             
             map_in <- map_in |>

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -339,8 +339,8 @@ pub_dataverse = function(slug, path_map, path_plans, path_stats) {
     
     dv_set <- get_dataset(dv_id)
     if (length(dv_set$files) > 0) {
-        existing <- dplyr::filter(dv_set$files, str_detect(filename, slug)) |>
-            dplyr::arrange(filename)
+        existing <- dv_set$files[grepl(slug, dv_set$files$filename), ]
+        existing <- existing[order(existing$filename), ]
     } else {
         existing = data.frame()
     }


### PR DESCRIPTION
This PR makes two 2000-specific fixes to the upload workflow, based on the errors I encountered while uploading data.

`finalize_analysis()`
- Fixed the 2000 `map_cols` check by replacing the column-selection step with a simpler name-based match.

- Updated the 2000 stats check after `finalize_analysis()` errored because `e_dvs`, `pr_dem`, `e_dem`, `pbias`, and `egap` were not present in the 2000 stats output.

`pub_dataverse`

- Fixed the duplicate-file check by replacing a `dplyr` step that failed on Dataverse file metadata with a simpler filename-based check.

After these changes, I was able to upload the data successfully.
Please let me know whether these 2000-specific changes are acceptable.