### PR TITLE
Update 01_prep_WV_cd_2000.R

### DIFF
--- a/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
@@ -55,7 +55,6 @@ if (!file.exists(here(shp_path))) {
         left_join(wv_df_cnty %>% mutate(county = sprintf("%03s", county)),
             by = "county")
 
-    # Assign each county the most frequent cd_2000 from its VTDs
     # Function to calculate mode
     stat_mode <- function(x) {
         ux <- na.omit(unique(x))

--- a/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
@@ -43,13 +43,13 @@ if (!file.exists(here(shp_path))) {
         )
 
     cnty_sf <- tt_counties("WV", year = 2000) %>%
-    st_transform(EPSG$WV) %>%
-    transmute(
-      county = sprintf("%03s", COUNTYFP00),
-      GEOID = paste0("54", sprintf("%03s", COUNTYFP00)),
-      state = "WV",
-      geometry
-    )
+        st_transform(EPSG$WV) %>%
+        transmute(
+            county = sprintf("%03s", COUNTYFP00),
+            GEOID = paste0("54", sprintf("%03s", COUNTYFP00)),
+            state = "WV",
+            geometry
+        )
 
     wv_shp <- cnty_sf %>%
         left_join(wv_df_cnty %>% mutate(county = sprintf("%03s", county)),
@@ -63,17 +63,17 @@ if (!file.exists(here(shp_path))) {
 
     # Mode district assignments per county from original VTD-level data
     county_cds <- wv_df %>%
-    mutate(county = sprintf("%03s", county)) %>%
-    group_by(county) %>%
-    summarise(
-        cd_1990 = stat_mode(cd_1990),
-        cd_2000 = stat_mode(cd_2000),
-        .groups = "drop"
-    )
+        mutate(county = sprintf("%03s", county)) %>%
+        group_by(county) %>%
+        summarise(
+            cd_1990 = stat_mode(cd_1990),
+            cd_2000 = stat_mode(cd_2000),
+            .groups = "drop"
+        )
 
     # Join district assignments back to county-level shapefile
     wv_shp <- wv_shp %>%
-    left_join(county_cds, by = "county")
+        left_join(county_cds, by = "county")
 
     # Drop unwanted columns if present
     wv_shp <- wv_shp %>% select(-any_of(c("mcd", "shd", "ssd")))

--- a/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
+++ b/analyses/WV_cd_2000/01_prep_WV_cd_2000.R
@@ -43,8 +43,13 @@ if (!file.exists(here(shp_path))) {
         )
 
     cnty_sf <- tt_counties("WV", year = 2000) %>%
-        st_transform(EPSG$WV) %>%
-        transmute(county = sprintf("%03s", COUNTYFP00), geometry)
+    st_transform(EPSG$WV) %>%
+    transmute(
+      county = sprintf("%03s", COUNTYFP00),
+      GEOID = paste0("54", sprintf("%03s", COUNTYFP00)),
+      state = "WV",
+      geometry
+    )
 
     wv_shp <- cnty_sf %>%
         left_join(wv_df_cnty %>% mutate(county = sprintf("%03s", county)),
@@ -57,15 +62,19 @@ if (!file.exists(here(shp_path))) {
         ux[which.max(tabulate(match(x, ux)))]
     }
 
-    # Mode cd_2000 per county from original VTD-level data
-    county_cd2000 <- wv_df %>%
-        mutate(county = sprintf("%03s", county)) %>%
-        group_by(county) %>%
-        summarise(cd_2000 = stat_mode(cd_2000), .groups = "drop")
+    # Mode district assignments per county from original VTD-level data
+    county_cds <- wv_df %>%
+    mutate(county = sprintf("%03s", county)) %>%
+    group_by(county) %>%
+    summarise(
+        cd_1990 = stat_mode(cd_1990),
+        cd_2000 = stat_mode(cd_2000),
+        .groups = "drop"
+    )
 
-    # Join mode cd_2000 back to county-level shapefile
+    # Join district assignments back to county-level shapefile
     wv_shp <- wv_shp %>%
-        left_join(county_cd2000, by = "county")
+    left_join(county_cds, by = "county")
 
     # Drop unwanted columns if present
     wv_shp <- wv_shp %>% select(-any_of(c("mcd", "shd", "ssd")))


### PR DESCRIPTION
This PR addresses a mismatch between the WV 2000 prep output and the expectations in `finalize_analysis()`.

WV aggregates to counties and drops all non-numeric and `cd_` columns, then only reattaches `cd_2000`. However, the 2000 validation requires both `cd_2000` and `cd_1990`, and also relies on `GEOID` for joining election data.

This PR:
- Restores `cd_1990` using county-level modal assignment
- Adds a county-level `GEOID`
- Ensures `state` is present