### PR TITLE
Update 2020 Nebraska State House/Senate Districts setup sim doc

### DIFF
--- a/analyses/NE_leg_2020/02_setup_NE_leg_2020.R
+++ b/analyses/NE_leg_2020/02_setup_NE_leg_2020.R
@@ -12,18 +12,6 @@ map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
         pop_muni = get_target(map_ssd)))
 
-map_ssd <- mutate(map_ssd,
-    core_id = redist.identify.cores(map_ssd$adj, map_ssd$ssd_2010, boundary = 2),
-    core_id_lump = forcats::fct_lump_n(as.character(core_id), max(ssd_2010)), # lump all non-core precincts in to "Other"
-    core_id = if_else(as.logical(is_county_split(core_id_lump, county)), # break off counties which are split by core border
-        str_c(county, "_", core_id),
-        as.character(core_id))) |>
-    select(-core_id_lump)
-
-# IF MERGING CORES OR OTHER UNITS:
-# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
-map_cores <- merge_by(map_ssd, core_id, drop_geom = TRUE)
-
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "NE_SSD_2020"
 

--- a/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
+++ b/analyses/NE_leg_2020/03_sim_NE_ssd_2020.R
@@ -8,21 +8,21 @@ cli_process_start("Running simulations for {.pkg NE_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 140
 
-constr <- redist_constr(map_cores) |>
-    add_constr_total_splits(strength = 1.7, admin = map_cores$county)
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(strength = 1.6, admin = map_ssd$county)
 
 plans <- redist_smc(
-    map_cores,
+    map_ssd,
     nsims = 2e3, runs = 5,
-    counties = pseudo_county,
+    counties = map_ssd$ssd_2010,
     constraints = constr,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),
     verbose = TRUE
-) |> pullback(map_ssd)
+)
 
 plans <- plans |>
     group_by(chain) |>
@@ -52,21 +52,4 @@ if (interactive()) {
     library(patchwork)
     validate_analysis(plans, map_ssd)
     summary(plans)
-
-    # cores preservation plot -----
-    plans_nocores <- redist_smc(
-        map_ssd,
-        nsims = 200,
-        runs = 2,
-        counties = map_ssd$pseudo_county
-    )
-
-    d_overl <- bind_rows(
-        with_cores = as_tibble(match_numbers(plans, map_ssd$ssd_2010)),
-        no_cores = as_tibble(match_numbers(plans_nocores, map_ssd$ssd_2010)),
-        .id = "run"
-    )
-
-    ggplot(d_overl, aes(reorder(district, pop_overlap), pop_overlap, color = run)) +
-        geom_boxplot(coef = 1e6)
 }

--- a/analyses/NE_leg_2020/doc_NE_leg_2020.md
+++ b/analyses/NE_leg_2020/doc_NE_leg_2020.md
@@ -14,7 +14,7 @@ In Nebraska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org
 Nebraska has a unicameral legislature, and thus only one set of state legislative districts is drawn. Accordingly, we simulate a single legislative plan using the 03_sim_NE_ssd.R script.
 
 ### Algorithmic Constraints
-We enforce a maximum population deviation of 5.0%.
+We enforce a maximum population deviation of 5.0%. To preserve the cores of prior districts, we use the previous SSDs as county-like units in the counties argument, which limits splits of prior districts during simulation.
 
 ## Data Sources
 Data for Nebraska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

--- a/analyses/NE_leg_2020/doc_NE_leg_2020.md
+++ b/analyses/NE_leg_2020/doc_NE_leg_2020.md
@@ -20,7 +20,7 @@ We enforce a maximum population deviation of 5.0%.
 Data for Nebraska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-To preserve the cores of prior districts, we merge all precincts which are more than two precincts away from a district border, under the 2010 plan. Precincts in counties which are split by existing district boundaries are merged only within their county.
+No manual pre-processing decisions were necessary.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Nebraska's unicameral legislature across 5 independent runs of the SMC algorithm.


### PR DESCRIPTION
## Redistricting requirements
In Nebraska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:

1. be contiguous [NCSL 184] 
2. have equal populations [NCSL 24] 
3. be geographically compacts [NCSL 184] 
4. preserve county and municipality boundaries as much as possible [NCSL 184] 
5. preserve cores of prior districts  [NCSL 185]
6. be not favoring any incumbent [NCSL 185]
7. be not favoring any political party [NCSL 185]

Nebraska has a unicameral legislature, and thus only one set of state legislative districts is drawn. Accordingly, we simulate a single legislative plan using the 03_sim_NE_ssd.R script.

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Nebraska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 10,000 districting plans for Nebraska's unicameral legislature across 5 independent runs of the SMC algorithm.
No special techniques were needed to produce the sample.

## Validation
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/306931f2-72a9-47a4-8203-b4c0b67ac2f7" />
<img width="468" height="335" alt="image" src="https://github.com/user-attachments/assets/81905bb2-c789-4b13-b99a-1ccf571bc04d" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 49 districts on 1,402 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 48
• `mh_accept_per_smc` = 157
• `pair_rule` = uniform
Plan diversity 80% range: 0.35 to 0.46
35 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.022               1.016               1.019               1.019 
             arv_18              arv_20      atg_18_rep_pet     comp_bbox_reock 
              1.019               1.024               1.013               1.015 
          comp_edge         comp_polsby       county_splits               e_dem 
              1.007               1.006               1.004               1.002 
              e_dvs                egap      gov_18_dem_kri      gov_18_rep_ric 
              1.027               1.002               1.025               1.014 
        muni_splits             ndshare                 ndv                 nrv 
              1.004               1.027               1.023               1.017 
              pbias            plan_dev            pop_aian           pop_asian 
              1.006               1.009               1.028               1.013 
          pop_black            pop_hisp            pop_nhpi           pop_other 
              1.020               1.029               1.017               1.016 
        pop_overlap             pop_two           pop_white              pr_dem 
              1.009               1.023               1.017               1.008 
     pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru 
              1.022               1.019               1.024               1.027 
     sos_18_dem_dan      sos_18_rep_evn total_county_splits   total_muni_splits 
              1.021               1.019               1.011               1.004 
          total_vap      uss_18_dem_ray      uss_18_rep_fis      uss_20_dem_jan 
              1.004               1.018               1.019               1.015 
     uss_20_rep_sas            vap_aian           vap_asian           vap_black 
              1.018               1.028               1.018               1.017 
           vap_hisp            vap_nhpi           vap_other             vap_two 
              1.030               1.021               1.028               1.016 
          vap_white 
              1.017 
• R-hat ≤ 1.05: 2562
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2562
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       231 (11.5%)    100.0%        1.96 1,273 (101%) 
Split 2       304 (15.2%)     98.4%        3.12   731 ( 58%) 
Split 3       391 (19.5%)     97.1%        2.53   693 ( 55%) 
Split 4       514 (25.7%)     95.3%        2.27   769 ( 61%) 
Split 5       723 (36.1%)     93.5%        2.08   816 ( 65%) 
Split 6       827 (41.3%)     93.0%        1.85   896 ( 71%) 
Split 7       837 (41.8%)     91.2%        1.74   909 ( 72%) 
Split 8       902 (45.1%)     90.3%        1.73   946 ( 75%) 
Split 9     1,006 (50.3%)     87.5%        1.51   974 ( 77%) 
Split 10    1,088 (54.4%)     87.0%        1.54   999 ( 79%) 
Split 11    1,122 (56.1%)     86.7%        1.40 1,012 ( 80%) 
Split 12    1,162 (58.1%)     83.9%        1.40 1,013 ( 80%) 
Split 13    1,213 (60.6%)     82.5%        1.37 1,045 ( 83%) 
Split 14    1,250 (62.5%)     80.4%        1.30 1,078 ( 85%) 
Split 15    1,288 (64.4%)     80.1%        1.16 1,063 ( 84%) 
Split 16    1,316 (65.8%)     78.1%        1.30 1,104 ( 87%) 
Split 17    1,398 (69.9%)     76.3%        1.11 1,115 ( 88%) 
Split 18    1,414 (70.7%)     76.3%        1.09 1,113 ( 88%) 
Split 19    1,373 (68.7%)     73.8%        1.06 1,119 ( 89%) 
Split 20    1,419 (70.9%)     72.9%        1.03 1,100 ( 87%) 
Split 21    1,467 (73.3%)     72.3%        1.03 1,134 ( 90%) 
Split 22    1,470 (73.5%)     68.8%        1.05 1,141 ( 90%) 
Split 23    1,489 (74.5%)     67.7%        1.00 1,125 ( 89%) 
Split 24    1,525 (76.2%)     65.3%        0.96 1,149 ( 91%) 
Split 25    1,553 (77.6%)     63.7%        0.86 1,154 ( 91%) 
Split 26    1,558 (77.9%)     62.2%        0.87 1,160 ( 92%) 
Split 27    1,573 (78.6%)     62.8%        0.87 1,141 ( 90%) 
Split 28    1,573 (78.6%)     57.9%        0.92 1,167 ( 92%) 
Split 29    1,586 (79.3%)     58.0%        0.87 1,191 ( 94%) 
Split 30    1,601 (80.0%)     58.8%        0.81 1,148 ( 91%) 
Split 31    1,633 (81.7%)     54.6%        0.80 1,158 ( 92%) 
Split 32    1,626 (81.3%)     53.7%        0.86 1,165 ( 92%) 
Split 33    1,619 (81.0%)     52.4%        0.82 1,165 ( 92%) 
Split 34    1,645 (82.2%)     50.1%        0.78 1,187 ( 94%) 
Split 35    1,649 (82.5%)     49.3%        0.76 1,151 ( 91%) 
Split 36    1,652 (82.6%)     47.3%        0.71 1,174 ( 93%) 
Split 37    1,670 (83.5%)     45.7%        0.81 1,168 ( 92%) 
Split 38    1,674 (83.7%)     45.8%        0.85 1,175 ( 93%) 
Split 39    1,696 (84.8%)     44.0%        0.77 1,129 ( 89%) 
Split 40    1,689 (84.4%)     41.0%        0.75 1,131 ( 89%) 
Split 41    1,688 (84.4%)     41.1%        0.75 1,163 ( 92%) 
Split 42    1,689 (84.5%)     38.4%        0.80 1,128 ( 89%) 
Split 43    1,697 (84.9%)     37.2%        0.75 1,145 ( 91%) 
Split 44    1,681 (84.1%)     34.6%        0.77 1,130 ( 89%) 
Split 45    1,727 (86.3%)     34.4%        0.67 1,111 ( 88%) 
Split 46    1,724 (86.2%)     31.2%        0.67 1,124 ( 89%) 
Split 47    1,696 (84.8%)     28.5%        0.80 1,046 ( 83%) 
Split 48    1,723 (86.2%)     27.9%        0.81   921 ( 73%) 
Resample    1,723 (86.2%)       NA%          NA 1,689 (134%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      28.6%               157
MS Step 2      24.6%               628
MS Step 3      24.5%               785
MS Step 4      25.1%               785
MS Step 5      26.3%               628
MS Step 6      27.2%               628
MS Step 7      28.4%               628
MS Step 8      29.2%               628
MS Step 9      29.7%               628
MS Step 10     30.4%               628
MS Step 11     31.0%               628
MS Step 12     31.5%               628
MS Step 13     32.1%               628
MS Step 14     32.4%               628
MS Step 15     33.0%               628
MS Step 16     33.1%               628
MS Step 17     33.6%               628
MS Step 18     34.1%               471
MS Step 19     34.3%               471
MS Step 20     34.5%               471
MS Step 21     34.7%               471
MS Step 22     35.1%               471
MS Step 23     35.3%               471
MS Step 24     35.4%               471
MS Step 25     35.7%               471
MS Step 26     35.7%               471
MS Step 27     35.9%               471
MS Step 28     36.0%               471
MS Step 29     36.2%               471
MS Step 30     36.5%               471
MS Step 31     36.5%               471
MS Step 32     36.4%               471
MS Step 33     36.6%               471
MS Step 34     36.8%               471
MS Step 35     36.8%               471
MS Step 36     36.7%               471
MS Step 37     36.8%               471
MS Step 38     36.9%               471
MS Step 39     37.1%               471
MS Step 40     37.1%               471
MS Step 41     37.1%               471
MS Step 42     37.1%               471
MS Step 43     37.1%               471
MS Step 44     37.2%               471
MS Step 45     37.0%               471
MS Step 46     37.0%               471
MS Step 47     36.8%               471
MS Step 48     36.7%               471
```

@CoryMcCartan
