### PR TITLE
Update finalize_analysis() for WV_cd_2000

### DIFF
--- a/R/finalize.R
+++ b/R/finalize.R
@@ -189,19 +189,38 @@ finalize_analysis = function(state, type = "cd", year = 2020, overwrite = TRUE) 
             }
 
             # ensure unshifted election data from ROAD
-            road_path <- str_glue(
-                "https://raw.githubusercontent.com/alarm-redist/census-2020/road/road-2000/{state}_{year}.csv"
-            )
-            
-            road_dat <- readr::read_csv(road_path, col_types = readr::cols(GEOID = readr::col_character()), show_col_types = FALSE) |>
-            dplyr::select(GEOID, ndv, nrv)
-            
-            map_in <- map_in |>
-            dplyr::select(-dplyr::any_of(c("ndv", "nrv"))) |>
-            dplyr::left_join(road_dat, by = "GEOID")
-            
-            warns <- TRUE
-            overwrite <- TRUE
+            road_rejoin_exceptions <- c("WV")
+
+            if (type == "cd" && state %in% road_rejoin_exceptions) {
+                if (!all(c("ndv", "nrv") %in% names(map_in)) ||
+                    anyNA(map_in$ndv) || anyNA(map_in$nrv)) {
+                    cli::cli_abort(
+                        "{.pkg {slug}} is a ROAD rejoin exception but does not have complete {.val ndv}/{.val nrv}."
+                    )
+                }
+
+                cli::cli_alert_info(
+                    "Skipping ROAD {.val ndv}/{.val nrv} rejoin for {.pkg {slug}}."
+                )
+            } else {
+                road_path <- str_glue(
+                    "https://raw.githubusercontent.com/alarm-redist/census-2020/road/road-2000/{state}_{year}.csv"
+                )
+
+                road_dat <- readr::read_csv(
+                    road_path,
+                    col_types = readr::cols(GEOID = readr::col_character()),
+                    show_col_types = FALSE
+                ) |>
+                    dplyr::select(GEOID, ndv, nrv)
+
+                map_in <- map_in |>
+                    dplyr::select(-dplyr::any_of(c("ndv", "nrv"))) |>
+                    dplyr::left_join(road_dat, by = "GEOID")
+
+                warns <- TRUE
+                overwrite <- TRUE
+            }
             
             if (warns && overwrite) {
                 cli::cli_alert_warning("Updating {.cls redist_map} file.")


### PR DESCRIPTION
This PR adds a narrow ROAD rejoin exception for `WV_cd_2000`.

`WV_cd_2000` is analyzed at the county level and already has validated non-missing `ndv/nrv` in the map. The default 2000 finalization step drops existing `ndv/nrv` and rejoins them from ROAD by GEOID; for WV, this should be skipped so the validated map values are preserved.