### PR TITLE
2020 Florida State House/Senate Districts

### DIFF
--- a/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
@@ -77,23 +77,23 @@ if (!file.exists(here(shp_path))) {
     # Manually add bridges for separated VTD pieces that are used
     # together in the enacted legislative districts.
     fl_shp$adj <- fl_shp$adj |>
-      add_edge(
-        v1 = c(
-          "12101000044", "1209500630C", "12057000920",
-          "12103000254", "12101000045", "12101000046",
-          "12101000047", "1209500433B", "12097000153",
-          "12103000019", "12115000060", "12099000735",
-          "12099000705", "1201100X045", "12099000233"
-        ),
-        v2 = c(
-          "12101000043", "12095000631", "12057000914",
-          "12103000265", "12101000043", "12101000043",
-          "12101000043", "1209500440C", "1209500126A",
-          "12057000940", "12115000069", "12099000704",
-          "12099000731", "1201100X019", "12099000234"
-        ),
-        ids = fl_shp$GEOID
-      )
+        add_edge(
+            v1 = c(
+                "12101000044", "1209500630C", "12057000920",
+                "12103000254", "12101000045", "12101000046",
+                "12101000047", "1209500433B", "12097000153",
+                "12103000019", "12115000060", "12099000735",
+                "12099000705", "1201100X045", "12099000233"
+            ),
+            v2 = c(
+                "12101000043", "12095000631", "12057000914",
+                "12103000265", "12101000043", "12101000043",
+                "12101000043", "1209500440C", "1209500126A",
+                "12057000940", "12115000069", "12099000704",
+                "12099000731", "1201100X019", "12099000234"
+            ),
+            ids = fl_shp$GEOID
+        )
 
     # check max number of connected components
     # 1 is one fully connected component, more is worse
@@ -103,13 +103,9 @@ if (!file.exists(here(shp_path))) {
     fl_shp <- fl_shp |>
         fix_geo_assignment(muni)
 
-    # compute merge groups
-    fl_shp$merge_group <- contiguity_merges(fl_shp)
-
     write_rds(fl_shp, here(shp_path), compress = "gz")
     cli_process_done()
 } else {
     fl_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong FL} shapefile")
 }
-

--- a/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
@@ -74,6 +74,27 @@ if (!file.exists(here(shp_path))) {
     # create adjacency graph
     fl_shp$adj <- adjacency(fl_shp)
 
+    # Manually add bridges for separated VTD pieces that are used
+    # together in the enacted legislative districts.
+    fl_shp$adj <- fl_shp$adj |>
+      add_edge(
+        v1 = c(
+          "12101000044", "1209500630C", "12057000920",
+          "12103000254", "12101000045", "12101000046",
+          "12101000047", "1209500433B", "12097000153",
+          "12103000019", "12115000060", "12099000735",
+          "12099000705", "1201100X045", "12099000233"
+        ),
+        v2 = c(
+          "12101000043", "12095000631", "12057000914",
+          "12103000265", "12101000043", "12101000043",
+          "12101000043", "1209500440C", "1209500126A",
+          "12057000940", "12115000069", "12099000704",
+          "12099000731", "1201100X019", "12099000234"
+        ),
+        ids = fl_shp$GEOID
+      )
+
     # check max number of connected components
     # 1 is one fully connected component, more is worse
     ccm(fl_shp$adj, fl_shp$ssd_2020)
@@ -82,9 +103,13 @@ if (!file.exists(here(shp_path))) {
     fl_shp <- fl_shp |>
         fix_geo_assignment(muni)
 
+    # compute merge groups
+    fl_shp$merge_group <- contiguity_merges(fl_shp)
+
     write_rds(fl_shp, here(shp_path), compress = "gz")
     cli_process_done()
 } else {
     fl_shp <- read_rds(here(shp_path))
     cli_alert_success("Loaded {.strong FL} shapefile")
 }
+

--- a/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/01_prep_FL_leg_2020.R
@@ -1,0 +1,90 @@
+###############################################################################
+# Download and prepare data for `FL_leg_2020` analysis
+# © ALARM Project, May 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg FL_leg_2020}")
+
+path_data <- download_redistricting_file("FL", "data-raw/FL", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/FL_2020/shp_vtd.rds"
+perim_path <- "data-out/FL_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong FL} shapefile")
+    # read in redistricting data
+    fl_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$FL)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("FL", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("FL"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("FL", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("FL"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("FL", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("FL"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    fl_shp <- fl_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    fl_shp <- fl_shp |>
+        left_join(y = leg_from_baf(state = "FL"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = fl_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        fl_shp <- rmapshaper::ms_simplify(fl_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    fl_shp$adj <- adjacency(fl_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(fl_shp$adj, fl_shp$ssd_2020)
+    ccm(fl_shp$adj, fl_shp$shd_2020)
+
+    fl_shp <- fl_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(fl_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    fl_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong FL} shapefile")
+}

--- a/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
@@ -1,0 +1,28 @@
+###############################################################################
+# Set up redistricting simulation for `FL_leg_2020`
+# © ALARM Project, May 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg FL_leg_2020}")
+
+map_ssd <- redist_map(fl_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = fl_shp$adj)
+
+map_shd <- redist_map(fl_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = fl_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "FL_SSD_2020"
+attr(map_shd, "analysis_name") <- "FL_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/FL_2020/FL_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/FL_2020/FL_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
@@ -10,13 +10,19 @@ map_ssd <- redist_map(fl_shp, pop_tol = 0.05,
 map_shd <- redist_map(fl_shp, pop_tol = 0.05,
     existing_plan = shd_2020, adj = fl_shp$adj)
 
-# make pseudo counties with default settings
-map_ssd <- map_ssd |>
-    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-        pop_muni = get_target(map_ssd)*5))
-map_shd <- map_shd |>
-    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-        pop_muni = get_target(map_shd)*10))
+# merged maps: use these only for simulation
+map_ssd_merged <- map_ssd |>
+  merge_by(merge_group, drop_geom = TRUE)
+map_shd_merged <- map_shd |>
+  merge_by(merge_group, drop_geom = TRUE)
+
+# Pseudo-county on merged simulation map
+map_ssd_merged <- map_ssd_merged |>
+    mutate(pseudo_county = pick_county_muni(map_ssd_merged, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd_merged)))
+map_shd_merged <- map_shd_merged |>
+    mutate(pseudo_county = pick_county_muni(map_shd_merged, counties = county, munis = muni,
+        pop_muni = get_target(map_shd_merged)))
 
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "FL_SSD_2020"

--- a/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
@@ -10,19 +10,13 @@ map_ssd <- redist_map(fl_shp, pop_tol = 0.05,
 map_shd <- redist_map(fl_shp, pop_tol = 0.05,
     existing_plan = shd_2020, adj = fl_shp$adj)
 
-# merged maps: use these only for simulation
-map_ssd_merged <- map_ssd |>
-  merge_by(merge_group, drop_geom = TRUE)
-map_shd_merged <- map_shd |>
-  merge_by(merge_group, drop_geom = TRUE)
-
 # Pseudo-county on merged simulation map
-map_ssd_merged <- map_ssd_merged |>
-    mutate(pseudo_county = pick_county_muni(map_ssd_merged, counties = county, munis = muni,
-        pop_muni = get_target(map_ssd_merged)))
-map_shd_merged <- map_shd_merged |>
-    mutate(pseudo_county = pick_county_muni(map_shd_merged, counties = county, munis = muni,
-        pop_muni = get_target(map_shd_merged)))
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)*5))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)*5))
 
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "FL_SSD_2020"

--- a/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
+++ b/analyses/FL_leg_2020/02_setup_FL_leg_2020.R
@@ -13,10 +13,10 @@ map_shd <- redist_map(fl_shp, pop_tol = 0.05,
 # make pseudo counties with default settings
 map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-        pop_muni = get_target(map_ssd)))
+        pop_muni = get_target(map_ssd)*5))
 map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-        pop_muni = get_target(map_shd)))
+        pop_muni = get_target(map_shd)*10))
 
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "FL_SSD_2020"

--- a/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
@@ -8,23 +8,24 @@ cli_process_start("Running simulations for {.pkg FL_shd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 50
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 350
 
-constr <- redist_constr(map_shd_merged) |>
-  add_constr_total_splits(strength = 2.3, admin = map_shd_merged$county)
+constr <- redist_constr(map_shd) |>
+    add_constr_total_splits(strength = 2.4, admin = map_shd$county)  |>
+    add_constr_polsby(strength = 1)
 
 plans <- redist_smc(
-  map_shd_merged,
-  nsims = 2e3, runs = 5,
-  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-  counties = county,
-  constraints = constr,
-  compactness = 1.2,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
-) |> pullback(map_shd)
+    map_shd,
+    nsims = 2e3, runs = 5,
+    ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    pop_temper = 0.05,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
 
 plans <- plans |>
     group_by(chain) |>

--- a/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
@@ -11,7 +11,8 @@ set.seed(2020)
 mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 230
 
 constr <- redist_constr(map_shd) |>
-    add_constr_total_splits(strength = 2.6, admin = map_shd$county)
+    add_constr_total_splits(strength = 2.5, admin = map_shd$county)  |>
+    add_constr_polsby(strength = 1)
 
 plans <- redist_smc(
     map_shd,

--- a/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
@@ -8,24 +8,23 @@ cli_process_start("Running simulations for {.pkg FL_shd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 230
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 50
 
-constr <- redist_constr(map_shd) |>
-    add_constr_total_splits(strength = 2.5, admin = map_shd$county)  |>
-    add_constr_polsby(strength = 1)
+constr <- redist_constr(map_shd_merged) |>
+  add_constr_total_splits(strength = 2.3, admin = map_shd_merged$county)
 
 plans <- redist_smc(
-    map_shd,
-    nsims = 2e3, runs = 5,
-    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-    counties = pseudo_county,
-    constraints = constr,
-    pop_temper = 0.04,
-    sampling_space = "linking_edge",
-    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-    split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = TRUE
-)
+  map_shd_merged,
+  nsims = 2e3, runs = 5,
+  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+  counties = county,
+  constraints = constr,
+  compactness = 1.2,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+) |> pullback(map_shd)
 
 plans <- plans |>
     group_by(chain) |>

--- a/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `FL_shd_2020` SHD
+# © ALARM Project, May 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg FL_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 230
+
+constr <- redist_constr(map_shd) |>
+    add_constr_total_splits(strength = 2.6, admin = map_shd$county)
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 2e3, runs = 5,
+    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    pop_temper = 0.04,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/FL_2020/FL_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg FL_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/FL_2020/FL_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_shd_2020.R
@@ -8,15 +8,15 @@ cli_process_start("Running simulations for {.pkg FL_shd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 350
+mh_accept_per_smc <- 550
 
 constr <- redist_constr(map_shd) |>
-    add_constr_total_splits(strength = 2.4, admin = map_shd$county)  |>
-    add_constr_polsby(strength = 1)
+    add_constr_total_splits(strength = 2.2, admin = map_shd$county)  |>
+    add_constr_polsby(strength = 0.9)
 
 plans <- redist_smc(
     map_shd,
-    nsims = 2e3, runs = 5,
+    nsims = 2500, runs = 5,
     ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
     counties = pseudo_county,
     constraints = constr,

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -8,24 +8,24 @@ cli_process_start("Running simulations for {.pkg FL_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 90
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 60
 
-constr <- redist_constr(map_ssd) |>
-  add_constr_total_splits(strength = 2.4, admin = map_ssd$county) |>
-  add_constr_polsby(strength = 1)
+constr <- redist_constr(map_ssd_merged) |>
+  add_constr_total_splits(strength = 2.4, admin = map_ssd_merged$county) |>
+  add_constr_total_splits(strength = 0.4, admin = map_ssd_merged$muni)
 
 plans <- redist_smc(
-  map_ssd,
-  nsims = 2e3, runs = 5,
-  # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-  counties = pseudo_county,
+  map_ssd_merged,
+  nsims = 2e3, runs = 3,
+  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+  counties = county,
   constraints = constr,
-  pop_temper = 0.03,
+  compactness = 1.2,
   sampling_space = "linking_edge",
   ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
   split_params = list(splitting_schedule = "any_valid_sizes"),
   verbose = TRUE
-)
+) |> pullback(map_ssd)
 
 plans <- plans |>
     group_by(chain) |>
@@ -57,3 +57,4 @@ if (interactive()) {
     validate_analysis(plans, map_ssd)
     summary(plans)
 }
+

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -8,24 +8,24 @@ cli_process_start("Running simulations for {.pkg FL_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 60
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 160
 
-constr <- redist_constr(map_ssd_merged) |>
-  add_constr_total_splits(strength = 2.4, admin = map_ssd_merged$county) |>
-  add_constr_total_splits(strength = 0.4, admin = map_ssd_merged$muni)
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(strength = 2.55, admin = map_ssd$county) |>
+    add_constr_polsby(strength = 1.1)
 
 plans <- redist_smc(
-  map_ssd_merged,
-  nsims = 2e3, runs = 3,
-  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-  counties = county,
-  constraints = constr,
-  compactness = 1.2,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
-) |> pullback(map_ssd)
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    pop_temper = 0.04,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
 
 plans <- plans |>
     group_by(chain) |>
@@ -57,4 +57,3 @@ if (interactive()) {
     validate_analysis(plans, map_ssd)
     summary(plans)
 }
-

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -1,0 +1,58 @@
+###############################################################################
+# Simulate plans for `FL_ssd_2020` SSD
+# © ALARM Project, May 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg FL_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 90
+
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(strength = 2.4, admin = map_ssd$county)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+    counties = pseudo_county,
+    constraints = constr,
+    pop_temper = 0.03,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/FL_2020/FL_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg FL_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/FL_2020/FL_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -11,19 +11,20 @@ set.seed(2020)
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 90
 
 constr <- redist_constr(map_ssd) |>
-    add_constr_total_splits(strength = 2.4, admin = map_ssd$county)
+  add_constr_total_splits(strength = 2.4, admin = map_ssd$county) |>
+  add_constr_polsby(strength = 1)
 
 plans <- redist_smc(
-    map_ssd,
-    nsims = 2e3, runs = 5,
-    # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
-    counties = pseudo_county,
-    constraints = constr,
-    pop_temper = 0.03,
-    sampling_space = "linking_edge",
-    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-    split_params = list(splitting_schedule = "any_valid_sizes"),
-    verbose = TRUE
+  map_ssd,
+  nsims = 2e3, runs = 5,
+  # ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+  counties = pseudo_county,
+  constraints = constr,
+  pop_temper = 0.03,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
 )
 
 plans <- plans |>

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -11,8 +11,8 @@ set.seed(2020)
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 270
 
 constr <- redist_constr(map_ssd) |>
-  add_constr_total_splits(strength = 2.62, admin = map_ssd$county) |>
-  add_constr_polsby(strength = 1.1)
+    add_constr_total_splits(strength = 2.62, admin = map_ssd$county) |>
+    add_constr_polsby(strength = 1.1)
 
 plans <- redist_smc(
     map_ssd,

--- a/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
+++ b/analyses/FL_leg_2020/03_sim_FL_ssd_2020.R
@@ -8,11 +8,11 @@ cli_process_start("Running simulations for {.pkg FL_ssd_2020}")
 
 set.seed(2020)
 
-mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 160
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 270
 
 constr <- redist_constr(map_ssd) |>
-    add_constr_total_splits(strength = 2.55, admin = map_ssd$county) |>
-    add_constr_polsby(strength = 1.1)
+  add_constr_total_splits(strength = 2.62, admin = map_ssd$county) |>
+  add_constr_polsby(strength = 1.1)
 
 plans <- redist_smc(
     map_ssd,
@@ -20,7 +20,7 @@ plans <- redist_smc(
     ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
     counties = pseudo_county,
     constraints = constr,
-    pop_temper = 0.04,
+    pop_temper = 0.05,
     sampling_space = "linking_edge",
     ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
     split_params = list(splitting_schedule = "any_valid_sizes"),

--- a/analyses/FL_leg_2020/doc_FL_leg_2020.md
+++ b/analyses/FL_leg_2020/doc_FL_leg_2020.md
@@ -1,0 +1,27 @@
+# 2020 Florida State House/Senate Districts
+
+## Redistricting requirements
+In Florida, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Florida must:
+
+1. be contiguous [NCSL 184]
+2. have equal populations [NCSL 24]
+3. be geographically compact [NCSL 184]
+4. preserve county and municipality boundaries as much as possible [NCSL 184]
+5. be not favoring any incumbent [NCSL 185]
+6. be not favoring any political party [NCSL 185]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Florida comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 10,000 districting plans for Florida's lower house across 5 independent runs of the SMC algorithm.
+We introduce mild population tempering (pop_temper = 0.04), impose a county-split constraint, and increase the number of merge-split proposals per SMC step (270).
+
+We sample 10,000 districting plans for Florida's upper house across 5 independent runs of the SMC algorithm.
+We introduce mild population tempering (pop_temper = 0.03), impose a county-split constraint, and increase the number of merge-split proposals per SMC step (104).

--- a/analyses/FL_leg_2020/doc_FL_leg_2020.md
+++ b/analyses/FL_leg_2020/doc_FL_leg_2020.md
@@ -17,11 +17,11 @@ We enforce a maximum population deviation of 5.0%.
 Data for Florida comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+Manual adjacency bridges were added to address disconnected components identified in the enacted Senate and House plans under the geometry-derived adjacency graph.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Florida's lower house across 5 independent runs of the SMC algorithm.
-We introduce mild population tempering (pop_temper = 0.04), impose a county-split constraint, and increase the number of merge-split proposals per SMC step (270).
+We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (390).
 
 We sample 10,000 districting plans for Florida's upper house across 5 independent runs of the SMC algorithm.
-We introduce mild population tempering (pop_temper = 0.03), impose a county-split constraint, and increase the number of merge-split proposals per SMC step (104).
+We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (174).

--- a/analyses/FL_leg_2020/doc_FL_leg_2020.md
+++ b/analyses/FL_leg_2020/doc_FL_leg_2020.md
@@ -24,4 +24,4 @@ We sample 10,000 districting plans for Florida's lower house across 5 independen
 We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (390).
 
 We sample 10,000 districting plans for Florida's upper house across 5 independent runs of the SMC algorithm.
-We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (174).
+We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (284).

--- a/analyses/FL_leg_2020/doc_FL_leg_2020.md
+++ b/analyses/FL_leg_2020/doc_FL_leg_2020.md
@@ -20,8 +20,8 @@ Data for Florida comes from the ALARM Project's [2020 Redistricting Data Files](
 Manual adjacency bridges were added to address disconnected components identified in the enacted Senate and House plans under the geometry-derived adjacency graph.
 
 ## Simulation Notes
-We sample 10,000 districting plans for Florida's lower house across 5 independent runs of the SMC algorithm.
-We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (390).
+We sample 12,500 districting plans for Florida's lower house across 5 independent runs of the SMC algorithm.
+We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (550).
 
 We sample 10,000 districting plans for Florida's upper house across 5 independent runs of the SMC algorithm.
 We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (284).


### PR DESCRIPTION
## Redistricting requirements
In Florida, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Florida must:

1. be contiguous [NCSL 184]
2. have equal populations [NCSL 24]
3. be geographically compact [NCSL 184]
4. preserve county and municipality boundaries as much as possible [NCSL 184]
5. be not favoring any incumbent [NCSL 185]
6. be not favoring any political party [NCSL 185]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Florida comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Manual adjacency bridges were added to address disconnected components identified in the enacted Senate and House plans under the geometry-derived adjacency graph.

## Simulation Notes
We sample 12,500 districting plans for Florida's lower house across 5 independent runs of the SMC algorithm.
We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (550).

We sample 10,000 districting plans for Florida's upper house across 5 independent runs of the SMC algorithm.
We introduce mild population tempering, impose a county-split constraint and a Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (284).


## Validation
### State Senate
<img width="3000" height="5400" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/065ceaef-d379-405e-94a8-9d43a536d24b" />


```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 40
                 districts on 7,211 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.05
Mergesplit Parameters:
• `total_ms_steps` = 39
• `mh_accept_per_smc` = 284
• `pair_rule` = uniform
Plan diversity 80% range: 0.63 to 0.77
26 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.004               1.004               1.004               1.009               1.004 
             arv_20      atg_18_dem_sha      atg_18_rep_moo     comp_bbox_reock           comp_edge 
              1.003               1.005               1.004               1.005               1.001 
        comp_polsby       county_splits               e_dem               e_dvs                egap 
              1.002               1.001               1.000               1.005               1.000 
     gov_18_dem_gil      gov_18_rep_des         muni_splits             ndshare                 ndv 
              1.004               1.005               1.001               1.005               1.002 
                nrv               pbias            plan_dev            pop_aian           pop_asian 
              1.004               1.001               1.001               1.004               1.009 
          pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.005               1.008               1.005               1.005               1.013 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru 
              1.004               1.002               1.005               1.004               1.003 
     pre_20_dem_bid      pre_20_rep_tru total_county_splits   total_muni_splits           total_vap 
              1.004               1.003               1.000               1.000               1.002 
     uss_16_dem_mur      uss_16_rep_rub      uss_18_dem_nel      uss_18_rep_sco            vap_aian 
              1.006               1.014               1.007               1.005               1.005 
          vap_asian           vap_black            vap_hisp            vap_nhpi           vap_other 
              1.008               1.005               1.008               1.010               1.005 
            vap_two           vap_white 
              1.005               1.004 
• R-hat ≤ 1.05: 2054
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2054
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1        153 (7.6%)    100.0%        1.56 1,264 (100%) 
Split 2       235 (11.7%)     97.9%        1.94   687 ( 54%) 
Split 3       315 (15.7%)     96.5%        1.88   672 ( 53%) 
Split 4       284 (14.2%)     94.5%        1.87   689 ( 54%) 
Split 5       284 (14.2%)     92.8%        1.85   734 ( 58%) 
Split 6       393 (19.6%)     91.7%        1.75   729 ( 58%) 
Split 7       399 (20.0%)     88.1%        1.70   786 ( 62%) 
Split 8       422 (21.1%)     87.2%        1.64   817 ( 65%) 
Split 9       442 (22.1%)     85.0%        1.60   798 ( 63%) 
Split 10      486 (24.3%)     84.1%        1.57   781 ( 62%) 
Split 11      485 (24.3%)     81.1%        1.50   821 ( 65%) 
Split 12      536 (26.8%)     80.3%        1.47   868 ( 69%) 
Split 13      521 (26.0%)     77.2%        1.43   878 ( 69%) 
Split 14      650 (32.5%)     77.2%        1.37   881 ( 70%) 
Split 15      716 (35.8%)     75.1%        1.27   911 ( 72%) 
Split 16      738 (36.9%)     72.7%        1.25   909 ( 72%) 
Split 17      784 (39.2%)     72.5%        1.25   947 ( 75%) 
Split 18      786 (39.3%)     69.1%        1.22   949 ( 75%) 
Split 19      841 (42.0%)     67.4%        1.15   937 ( 74%) 
Split 20      941 (47.1%)     66.2%        1.05   986 ( 78%) 
Split 21      982 (49.1%)     63.3%        1.08 1,001 ( 79%) 
Split 22      920 (46.0%)     63.4%        1.05 1,030 ( 81%) 
Split 23    1,037 (51.9%)     61.2%        0.99   997 ( 79%) 
Split 24    1,086 (54.3%)     58.9%        0.99 1,046 ( 83%) 
Split 25    1,145 (57.2%)     57.7%        0.91 1,055 ( 83%) 
Split 26    1,192 (59.6%)     56.3%        0.91 1,046 ( 83%) 
Split 27    1,184 (59.2%)     54.3%        0.89 1,090 ( 86%) 
Split 28    1,223 (61.1%)     52.8%        0.88 1,043 ( 83%) 
Split 29    1,324 (66.2%)     52.5%        0.82 1,093 ( 86%) 
Split 30    1,330 (66.5%)     50.0%        0.81 1,101 ( 87%) 
Split 31    1,388 (69.4%)     48.5%        0.79 1,091 ( 86%) 
Split 32    1,375 (68.7%)     47.5%        0.77 1,071 ( 85%) 
Split 33    1,404 (70.2%)     44.9%        0.78 1,095 ( 87%) 
Split 34    1,496 (74.8%)     44.1%        0.66 1,147 ( 91%) 
Split 35    1,488 (74.4%)     43.3%        0.64 1,129 ( 89%) 
Split 36    1,527 (76.3%)     41.9%        0.62 1,144 ( 90%) 
Split 37    1,568 (78.4%)     41.7%        0.62 1,149 ( 91%) 
Split 38    1,617 (80.8%)     38.9%        0.55 1,111 ( 88%) 
Split 39    1,649 (82.5%)     35.4%        0.53 1,114 ( 88%) 
Resample    1,649 (82.5%)       NA%          NA 1,659 (131%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      26.9%               284
MS Step 2      26.0%              1136
MS Step 3      24.2%              1136
MS Step 4      22.9%              1420
MS Step 5      21.8%              1420
MS Step 6      21.1%              1420
MS Step 7      20.6%              1420
MS Step 8      20.3%              1420
MS Step 9      20.4%              1420
MS Step 10     20.2%              1420
MS Step 11     20.1%              1420
MS Step 12     20.1%              1420
MS Step 13     20.3%              1420
MS Step 14     20.5%              1420
MS Step 15     20.8%              1420
MS Step 16     21.3%              1420
MS Step 17     21.7%              1420
MS Step 18     22.2%              1420
MS Step 19     22.9%              1420
MS Step 20     23.5%              1420
MS Step 21     23.9%              1420
MS Step 22     24.4%              1420
MS Step 23     24.7%              1420
MS Step 24     25.2%              1420
MS Step 25     25.6%              1136
MS Step 26     26.0%              1136
MS Step 27     26.5%              1136
MS Step 28     26.7%              1136
MS Step 29     27.1%              1136
MS Step 30     27.4%              1136
MS Step 31     27.5%              1136
MS Step 32     27.9%              1136
MS Step 33     27.9%              1136
MS Step 34     28.1%              1136
MS Step 35     28.3%              1136
MS Step 36     28.4%              1136
MS Step 37     28.4%              1136
MS Step 38     28.4%              1136
MS Step 39     28.3%              1136

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the
log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics
should be between 1 and 1.05.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population
tolerance. If the acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
If the weight variance (Log wgt. sd) increases steadily or is particularly large for the "Resample" step,
consider increasing `seq_alpha`. To visualize what geographic areas may be causing problems, try running
the following code. Highlighted areas are those that may be causing the bottleneck.
    plot(<map object>, rowMeans(as.matrix(plans) == <bottleneck iteration>))
```

### State House
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/173a19c7-ffa4-4b49-ae62-e63ac254259d" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 120
                 districts on 7,211 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.05
Mergesplit Parameters:
• `total_ms_steps` = 119
• `mh_accept_per_smc` = 550
• `pair_rule` = uniform
Plan diversity 80% range: 0.72 to 0.79
89 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.009               1.010               1.006               1.017               1.018 
             arv_20      atg_18_dem_sha      atg_18_rep_moo     comp_bbox_reock           comp_edge 
              1.014               1.008               1.018               1.012               1.002 
        comp_polsby       county_splits               e_dem               e_dvs                egap 
              1.006               1.003               1.009               1.030               1.009 
     gov_18_dem_gil      gov_18_rep_des         muni_splits             ndshare                 ndv 
              1.010               1.018               1.006               1.030               1.009 
                nrv               pbias            plan_dev            pop_aian           pop_asian 
              1.016               1.006               1.001               1.026               1.010 
          pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.017               1.024               1.015               1.013               1.009 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru 
              1.012               1.014               1.007               1.009               1.018 
     pre_20_dem_bid      pre_20_rep_tru total_county_splits   total_muni_splits           total_vap 
              1.006               1.014               1.014               1.002               1.003 
     uss_16_dem_mur      uss_16_rep_rub      uss_18_dem_nel      uss_18_rep_sco            vap_aian 
              1.006               1.016               1.007               1.018               1.021 
          vap_asian           vap_black            vap_hisp            vap_nhpi           vap_other 
              1.009               1.016               1.023               1.021               1.012 
            vap_two           vap_white 
              1.012               1.010 
• R-hat ≤ 1.05: 6151
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 6151
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
          Eff. samples (%) Acc. rate Log wgt. sd  Max. unique    
Split 1          43 (1.7%)    100.0%        2.51 1,568 ( 99%)  * 
Split 2          88 (3.5%)     99.2%        3.83   425 ( 27%)  * 
Split 3         200 (8.0%)     98.9%        3.47   549 ( 35%)    
Split 4        284 (11.3%)     98.4%        2.86   680 ( 43%)    
Split 5        366 (14.6%)     98.2%        2.73   795 ( 50%)    
Split 6        382 (15.3%)     97.6%        2.54   846 ( 54%)    
Split 7        606 (24.2%)     96.9%        2.42   882 ( 56%)    
Split 8        515 (20.6%)     95.8%        2.21 1,007 ( 64%)    
Split 9         241 (9.6%)     95.9%        2.06 1,002 ( 63%)    
Split 10       754 (30.2%)     95.5%        1.97   952 ( 60%)    
Split 11       759 (30.4%)     95.2%        1.97 1,057 ( 67%)    
Split 12       841 (33.6%)     93.5%        1.93 1,094 ( 69%)    
Split 13       776 (31.0%)     93.7%        1.89 1,077 ( 68%)    
Split 14       837 (33.5%)     92.4%        1.80 1,070 ( 68%)    
Split 15       808 (32.3%)     92.3%        1.79 1,086 ( 69%)    
Split 16       977 (39.1%)     90.7%        1.68 1,115 ( 71%)    
Split 17       966 (38.6%)     91.6%        1.67 1,128 ( 71%)    
Split 18     1,060 (42.4%)     89.5%        1.60 1,158 ( 73%)    
Split 19     1,005 (40.2%)     89.6%        1.58 1,171 ( 74%)    
Split 20     1,105 (44.2%)     89.3%        1.59 1,172 ( 74%)    
Split 21     1,093 (43.7%)     88.6%        1.55 1,202 ( 76%)    
Split 22     1,132 (45.3%)     88.1%        1.45 1,192 ( 75%)    
Split 23     1,172 (46.9%)     87.4%        1.41 1,209 ( 77%)    
Split 24     1,205 (48.2%)     86.9%        1.42 1,230 ( 78%)    
Split 25     1,194 (47.7%)     86.3%        1.37 1,241 ( 79%)    
Split 26     1,230 (49.2%)     85.6%        1.37 1,277 ( 81%)    
Split 27     1,245 (49.8%)     85.1%        1.33 1,243 ( 79%)    
Split 28     1,257 (50.3%)     84.6%        1.32 1,262 ( 80%)    
Split 29     1,292 (51.7%)     84.4%        1.33 1,237 ( 78%)    
Split 30     1,341 (53.6%)     84.7%        1.28 1,264 ( 80%)    
Split 31     1,318 (52.7%)     83.3%        1.25 1,300 ( 82%)    
Split 32     1,258 (50.3%)     82.2%        1.24 1,284 ( 81%)    
Split 33     1,303 (52.1%)     82.3%        1.25 1,281 ( 81%)    
Split 34     1,324 (52.9%)     81.6%        1.16 1,267 ( 80%)    
Split 35     1,339 (53.6%)     80.9%        1.17 1,262 ( 80%)    
Split 36     1,430 (57.2%)     80.2%        1.18 1,280 ( 81%)    
Split 37     1,381 (55.3%)     80.2%        1.12 1,308 ( 83%)    
Split 38     1,458 (58.3%)     78.9%        1.17 1,282 ( 81%)    
Split 39     1,369 (54.7%)     79.5%        1.12 1,346 ( 85%)    
Split 40     1,501 (60.0%)     79.3%        1.07 1,295 ( 82%)    
Split 41     1,499 (60.0%)     77.2%        1.08 1,339 ( 85%)    
Split 42     1,504 (60.2%)     76.3%        1.06 1,335 ( 84%)    
Split 43     1,470 (58.8%)     76.1%        1.09 1,349 ( 85%)    
Split 44     1,557 (62.3%)     76.8%        1.01 1,331 ( 84%)    
Split 45     1,530 (61.2%)     75.5%        1.04 1,343 ( 85%)    
Split 46     1,514 (60.6%)     75.4%        1.08 1,346 ( 85%)    
Split 47     1,536 (61.5%)     75.0%        1.02 1,346 ( 85%)    
Split 48     1,569 (62.8%)     73.3%        1.08 1,347 ( 85%)    
Split 49     1,592 (63.7%)     73.8%        1.07 1,313 ( 83%)    
Split 50     1,542 (61.7%)     73.2%        0.99 1,357 ( 86%)    
Split 51     1,592 (63.7%)     72.3%        0.99 1,362 ( 86%)    
Split 52     1,579 (63.2%)     72.6%        1.05 1,348 ( 85%)    
Split 53     1,588 (63.5%)     71.5%        1.02 1,341 ( 85%)    
Split 54     1,634 (65.3%)     71.4%        1.00 1,360 ( 86%)    
Split 55     1,640 (65.6%)     69.7%        1.02 1,373 ( 87%)    
Split 56     1,642 (65.7%)     69.4%        0.96 1,375 ( 87%)    
Split 57     1,647 (65.9%)     70.8%        0.99 1,353 ( 86%)    
Split 58     1,643 (65.7%)     67.9%        0.95 1,368 ( 87%)    
Split 59     1,708 (68.3%)     66.1%        0.93 1,379 ( 87%)    
Split 60     1,711 (68.5%)     67.5%        0.95 1,381 ( 87%)    
Split 61     1,710 (68.4%)     67.3%        0.93 1,383 ( 88%)    
Split 62     1,686 (67.4%)     67.2%        0.94 1,365 ( 86%)    
Split 63     1,722 (68.9%)     66.1%        0.97 1,388 ( 88%)    
Split 64     1,697 (67.9%)     65.9%        0.94 1,371 ( 87%)    
Split 65     1,757 (70.3%)     64.8%        0.88 1,409 ( 89%)    
Split 66     1,705 (68.2%)     63.9%        0.91 1,407 ( 89%)    
Split 67     1,764 (70.6%)     63.7%        0.88 1,392 ( 88%)    
Split 68     1,732 (69.3%)     64.2%        0.89 1,414 ( 89%)    
Split 69     1,761 (70.5%)     64.0%        0.87 1,407 ( 89%)    
Split 70     1,757 (70.3%)     62.2%        0.87 1,401 ( 89%)    
Split 71     1,784 (71.4%)     61.7%        0.84 1,369 ( 87%)    
Split 72     1,793 (71.7%)     62.1%        0.87 1,414 ( 89%)    
Split 73     1,782 (71.3%)     60.3%        0.85 1,431 ( 91%)    
Split 74     1,818 (72.7%)     60.7%        0.83 1,419 ( 90%)    
Split 75     1,837 (73.5%)     59.7%        0.83 1,421 ( 90%)    
Split 76     1,819 (72.8%)     60.2%        0.81 1,429 ( 90%)    
Split 77     1,851 (74.0%)     59.5%        0.83 1,424 ( 90%)    
Split 78     1,799 (71.9%)     58.4%        0.90 1,454 ( 92%)    
Split 79     1,808 (72.3%)     57.8%        0.90 1,402 ( 89%)    
Split 80     1,864 (74.6%)     56.6%        0.85 1,434 ( 91%)    
Split 81     1,841 (73.6%)     57.8%        0.87 1,438 ( 91%)    
Split 82     1,863 (74.5%)     55.2%        0.86 1,399 ( 89%)    
Split 83     1,854 (74.2%)     55.7%        0.81 1,425 ( 90%)    
Split 84     1,853 (74.1%)     56.0%        0.83 1,412 ( 89%)    
Split 85     1,892 (75.7%)     55.0%        0.80 1,428 ( 90%)    
Split 86     1,903 (76.1%)     54.8%        0.87 1,422 ( 90%)    
Split 87     1,876 (75.0%)     54.8%        0.85 1,442 ( 91%)    
Split 88     1,873 (74.9%)     53.1%        0.82 1,462 ( 93%)    
Split 89     1,883 (75.3%)     52.7%        0.86 1,418 ( 90%)    
Split 90     1,900 (76.0%)     52.1%        0.80 1,448 ( 92%)    
Split 91     1,901 (76.0%)     52.0%        0.86 1,446 ( 92%)    
Split 92     1,881 (75.2%)     52.9%        0.81 1,449 ( 92%)    
Split 93     1,954 (78.2%)     50.3%        0.75 1,419 ( 90%)    
Split 94     1,916 (76.6%)     49.6%        0.80 1,447 ( 92%)    
Split 95     1,921 (76.8%)     49.6%        0.81 1,426 ( 90%)    
Split 96     1,933 (77.3%)     48.5%        0.85 1,442 ( 91%)    
Split 97     1,909 (76.3%)     50.1%        0.83 1,440 ( 91%)    
Split 98     1,935 (77.4%)     48.7%        0.86 1,462 ( 93%)    
Split 99     1,921 (76.9%)     47.8%        0.84 1,440 ( 91%)    
Split 100    1,974 (79.0%)     46.1%        0.80 1,457 ( 92%)    
Split 101    1,981 (79.2%)     47.1%        0.76 1,451 ( 92%)    
Split 102    1,948 (77.9%)     45.2%        0.79 1,470 ( 93%)    
Split 103    2,009 (80.4%)     45.4%        0.77 1,421 ( 90%)    
Split 104    1,967 (78.7%)     45.5%        0.84 1,447 ( 92%)    
Split 105    1,999 (80.0%)     45.9%        0.81 1,471 ( 93%)    
Split 106    2,003 (80.1%)     43.9%        0.80 1,428 ( 90%)    
Split 107    2,006 (80.3%)     42.5%        0.84 1,485 ( 94%)    
Split 108    2,029 (81.1%)     43.0%        0.73 1,446 ( 92%)    
Split 109    1,993 (79.7%)     42.8%        0.80 1,433 ( 91%)    
Split 110    2,002 (80.1%)     41.3%        0.78 1,458 ( 92%)    
Split 111    2,007 (80.3%)     41.8%        0.74 1,447 ( 92%)    
Split 112    2,023 (80.9%)     41.3%        0.75 1,486 ( 94%)    
Split 113    2,036 (81.4%)     40.7%        0.77 1,436 ( 91%)    
Split 114    2,074 (83.0%)     39.5%        0.65 1,471 ( 93%)    
Split 115    2,104 (84.2%)     38.6%        0.63 1,482 ( 94%)    
Split 116    2,103 (84.1%)     39.4%        0.66 1,467 ( 93%)    
Split 117    2,110 (84.4%)     37.7%        0.64 1,462 ( 93%)    
Split 118    2,133 (85.3%)     37.2%        0.65 1,447 ( 92%)    
Split 119    2,291 (91.7%)     35.7%        0.39 1,420 ( 90%)    
Resample     2,291 (91.7%)       NA%          NA 2,211 (140%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
            Acc. rate MS Steps per Plan
MS Step 1        9.9%               550
MS Step 2       11.8%              6050
MS Step 3       14.4%              4950
MS Step 4       15.6%              3850
MS Step 5       16.2%              3850
MS Step 6       16.7%              3850
MS Step 7       17.0%              3300
MS Step 8       17.3%              3300
MS Step 9       17.7%              3300
MS Step 10      18.0%              3300
MS Step 11      18.2%              3300
MS Step 12      18.4%              3300
MS Step 13      18.6%              3300
MS Step 14      18.9%              3300
MS Step 15      19.1%              3300
MS Step 16      19.3%              3300
MS Step 17      19.5%              3300
MS Step 18      19.6%              3300
MS Step 19      19.8%              3300
MS Step 20      19.9%              3300
MS Step 21      19.9%              3300
MS Step 22      20.1%              3300
MS Step 23      20.3%              2750
MS Step 24      20.4%              2750
MS Step 25      20.4%              2750
MS Step 26      20.5%              2750
MS Step 27      20.6%              2750
MS Step 28      20.6%              2750
MS Step 29      20.7%              2750
MS Step 30      20.7%              2750
MS Step 31      20.6%              2750
MS Step 32      20.7%              2750
MS Step 33      20.8%              2750
MS Step 34      20.8%              2750
MS Step 35      20.8%              2750
MS Step 36      21.0%              2750
MS Step 37      21.1%              2750
MS Step 38      21.0%              2750
MS Step 39      21.1%              2750
MS Step 40      21.1%              2750
MS Step 41      21.1%              2750
MS Step 42      21.0%              2750
MS Step 43      21.2%              2750
MS Step 44      21.2%              2750
MS Step 45      21.1%              2750
MS Step 46      21.1%              2750
MS Step 47      21.3%              2750
MS Step 48      21.3%              2750
MS Step 49      21.3%              2750
MS Step 50      21.3%              2750
MS Step 51      21.3%              2750
MS Step 52      21.4%              2750
MS Step 53      21.5%              2750
MS Step 54      21.5%              2750
MS Step 55      21.6%              2750
MS Step 56      21.5%              2750
MS Step 57      21.6%              2750
MS Step 58      21.7%              2750
MS Step 59      21.7%              2750
MS Step 60      21.7%              2750
MS Step 61      21.7%              2750
MS Step 62      21.8%              2750
MS Step 63      21.7%              2750
MS Step 64      21.7%              2750
MS Step 65      21.8%              2750
MS Step 66      21.8%              2750
MS Step 67      21.9%              2750
MS Step 68      21.9%              2750
MS Step 69      21.9%              2750
MS Step 70      22.0%              2750
MS Step 71      21.9%              2750
MS Step 72      22.0%              2750
MS Step 73      22.0%              2750
MS Step 74      22.1%              2750
MS Step 75      22.1%              2750
MS Step 76      22.2%              2750
MS Step 77      22.3%              2750
MS Step 78      22.3%              2750
MS Step 79      22.3%              2750
MS Step 80      22.4%              2750
MS Step 81      22.4%              2750
MS Step 82      22.3%              2750
MS Step 83      22.3%              2750
MS Step 84      22.3%              2750
MS Step 85      22.4%              2750
MS Step 86      22.4%              2750
MS Step 87      22.4%              2750
MS Step 88      22.4%              2750
MS Step 89      22.3%              2750
MS Step 90      22.3%              2750
MS Step 91      22.4%              2750
MS Step 92      22.4%              2750
MS Step 93      22.4%              2750
MS Step 94      22.4%              2750
MS Step 95      22.4%              2750
MS Step 96      22.3%              2750
MS Step 97      22.3%              2750
MS Step 98      22.3%              2750
MS Step 99      22.3%              2750
MS Step 100     22.3%              2750
MS Step 101     22.3%              2750
MS Step 102     22.3%              2750
MS Step 103     22.2%              2750
MS Step 104     22.3%              2750
MS Step 105     22.2%              2750
MS Step 106     22.2%              2750
MS Step 107     22.2%              2750
MS Step 108     22.2%              2750
MS Step 109     22.1%              2750
MS Step 110     22.0%              2750
MS Step 111     22.0%              2750
MS Step 112     22.0%              2750
MS Step 113     22.0%              2750
MS Step 114     21.9%              2750
MS Step 115     21.8%              2750
MS Step 116     21.8%              2750
MS Step 117     21.8%              2750
MS Step 118     21.7%              2750
MS Step 119     30.9%              2750

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the
log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics
should be between 1 and 1.05.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population
tolerance. If the acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01.
If the weight variance (Log wgt. sd) increases steadily or is particularly large for the "Resample" step,
consider increasing `seq_alpha`. To visualize what geographic areas may be causing problems, try running
the following code. Highlighted areas are those that may be causing the bottleneck.
    plot(<map object>, rowMeans(as.matrix(plans) == <bottleneck iteration>))
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited
