### PR TITLE
2020 West Virginia State House/Senate Districts

### DIFF
--- a/analyses/WV_leg_2020/01_prep_WV_leg_2020.R
+++ b/analyses/WV_leg_2020/01_prep_WV_leg_2020.R
@@ -1,0 +1,276 @@
+###############################################################################
+# Download and prepare data for `WV_leg_2020` analysis
+# © ALARM Project, May 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Count connected components in an adjacency graph.
+# This is used only as a diagnostic check before and after the WV adjacency fix.
+count_adj_components <- function(adj) {
+    n <- length(adj)
+
+    # Use a temporary 1-based copy for graph traversal.
+    vals <- unlist(adj, use.names = FALSE)
+    one_based <- length(vals) > 0 && max(vals, na.rm = TRUE) == n
+
+    adj_1 <- lapply(adj, function(x) {
+        x <- x[!is.na(x)]
+        if (!one_based) x <- x + 1L
+        x[x >= 1L & x <= n]
+    })
+
+    comp <- rep(NA_integer_, n)
+    comp_id <- 0L
+
+    # Breadth-first search assigns every row to one connected component.
+    for (i in seq_len(n)) {
+        if (!is.na(comp[i])) next
+
+        comp_id <- comp_id + 1L
+        queue <- i
+        comp[i] <- comp_id
+
+        while (length(queue) > 0) {
+            v <- queue[1]
+            queue <- queue[-1]
+
+            nbrs <- adj_1[[v]]
+            nbrs <- nbrs[is.na(comp[nbrs])]
+
+            if (length(nbrs) > 0) {
+                comp[nbrs] <- comp_id
+                queue <- c(queue, nbrs)
+            }
+        }
+    }
+
+    list(
+        n_components = comp_id,
+        component = comp,
+        component_sizes = sort(tabulate(comp), decreasing = TRUE)
+    )
+}
+
+# Convert adjacency indices to the convention expected by redist.
+# For n rows, valid stored neighbor indices should run from 0 to n - 1.
+normalize_adj_indices <- function(adj) {
+    n <- length(adj)
+    vals <- unlist(adj, use.names = FALSE)
+
+    if (length(vals) == 0) return(adj)
+
+    # If the adjacency contains n, it is using 1-based row indices.
+    # Subtract 1 so the largest valid stored index becomes n - 1.
+    if (max(vals, na.rm = TRUE) == n) {
+        adj <- lapply(adj, function(x) {
+            x <- x[!is.na(x)]
+            x - 1L
+        })
+    }
+
+    adj
+}
+
+# Connect isolated adjacency components by adding one nearest-neighbor bridge
+# edge from each smaller component to the largest component.
+connect_adj_components <- function(shp, adj) {
+    n <- length(adj)
+    vals <- unlist(adj, use.names = FALSE)
+    one_based <- length(vals) > 0 && max(vals, na.rm = TRUE) == n
+
+    comp_info <- count_adj_components(adj)
+    comp <- comp_info$component
+    comp_id <- comp_info$n_components
+
+    # If the graph is already connected, no repair is needed.
+    if (comp_id == 1L) {
+        attr(adj, "bridge_log") <- tibble()
+        return(adj)
+    }
+
+    # Treat the largest component as the main graph.
+    main_comp <- which.max(tabulate(comp))
+    main_idx <- which(comp == main_comp)
+
+    bridge_log <- tibble(
+        from_row = integer(),
+        to_row = integer(),
+        from_geoid = character(),
+        to_geoid = character(),
+        from_county = character(),
+        to_county = character(),
+        distance = numeric()
+    )
+
+    for (this_comp in setdiff(seq_len(comp_id), main_comp)) {
+        this_idx <- which(comp == this_comp)
+
+        # Find the nearest row in the main component.
+        nearest_main_pos <- st_nearest_feature(
+            st_geometry(shp[this_idx, ]),
+            st_geometry(shp[main_idx, ])
+        )
+
+        d <- st_distance(
+            st_geometry(shp[this_idx, ]),
+            st_geometry(shp[main_idx[nearest_main_pos], ]),
+            by_element = TRUE
+        )
+
+        # Add one bridge edge using the shortest pair.
+        k <- which.min(d)
+        i <- this_idx[k]
+        j <- main_idx[nearest_main_pos[k]]
+
+        # Add bridge edges using the same indexing convention as the current
+        # adjacency object. The object is normalized before ccm() and saving.
+        i_adj <- if (one_based) i else i - 1L
+        j_adj <- if (one_based) j else j - 1L
+
+        adj[[i]] <- sort(unique(c(adj[[i]], j_adj)))
+        adj[[j]] <- sort(unique(c(adj[[j]], i_adj)))
+
+        # Record the added bridge edge for inspection.
+        bridge_log <- bind_rows(
+            bridge_log,
+            tibble(
+                from_row = i,
+                to_row = j,
+                from_geoid = shp$GEOID[i],
+                to_geoid = shp$GEOID[j],
+                from_county = shp$county[i],
+                to_county = shp$county[j],
+                distance = as.numeric(d[k])
+            )
+        )
+    }
+
+    attr(adj, "bridge_log") <- bridge_log
+    adj
+}
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg WV_leg_2020}")
+
+path_data <- download_redistricting_file("WV", "data-raw/WV", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/WV_2020/shp_vtd.rds"
+perim_path <- "data-out/WV_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong WV} shapefile")
+
+    # read in redistricting data
+    wv_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$WV) |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("WV", "INCPLACE_CDP", "VTD", year = 2020) |>
+        mutate(GEOID = paste0(censable::match_fips("WV"), vtd)) |>
+        select(-vtd)
+
+    d_ssd <- make_from_baf("WV", "SLDU", "VTD", year = 2020) |>
+        transmute(
+            GEOID = paste0(censable::match_fips("WV"), vtd),
+            ssd_2010 = as.integer(sldu)
+        )
+
+    d_shd <- make_from_baf("WV", "SLDL", "VTD", year = 2020) |>
+        transmute(
+            GEOID = paste0(censable::match_fips("WV"), vtd),
+            shd_2010 = as.integer(sldl)
+        )
+
+    wv_shp <- wv_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    wv_shp <- wv_shp |>
+        left_join(y = leg_from_baf(state = "WV", year_shd = 2023), by = "GEOID")
+
+    # WV-specific fix: remove rows without enacted legislative assignments.
+    # These rows cannot be used in enacted-plan contiguity checks.
+    wv_shp <- wv_shp |>
+        filter(!is.na(ssd_2020), !is.na(shd_2020))
+
+    stopifnot(sum(is.na(wv_shp$ssd_2020)) == 0)
+    stopifnot(sum(is.na(wv_shp$shd_2020)) == 0)
+
+    wv_shp <- wv_shp |>
+        fix_geo_assignment(muni)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(
+        shp = wv_shp,
+        perim_path = here(perim_path)
+    ) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        wv_shp <- rmapshaper::ms_simplify(
+            wv_shp,
+            keep = 0.05,
+            keep_shapes = TRUE
+        ) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph AFTER dropping invalid rows
+    wv_adj <- adjacency(wv_shp)
+
+    # WV-specific fix: the automatic adjacency graph has a few isolated
+    # components. Add one nearest-neighbor bridge edge from each isolated
+    # component to the main component before running contiguity checks.
+    adj_before <- count_adj_components(wv_adj)
+    wv_adj <- connect_adj_components(wv_shp, wv_adj)
+    adj_after <- count_adj_components(wv_adj)
+
+    cli_alert_info("WV adjacency components before repair: {adj_before$n_components}")
+    cli_alert_info("WV adjacency components after repair: {adj_after$n_components}")
+    print(attr(wv_adj, "bridge_log"))
+
+    stopifnot(adj_after$n_components == 1L)
+
+    # Normalize adjacency indices before redist contiguity checks.
+    wv_adj <- normalize_adj_indices(wv_adj)
+
+    stopifnot(max(unlist(wv_adj), na.rm = TRUE) <= nrow(wv_shp) - 1L)
+    stopifnot(min(unlist(wv_adj), na.rm = TRUE) >= 0L)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(wv_adj, wv_shp$ssd_2020)
+    ccm(wv_adj, wv_shp$shd_2020)
+
+    wv_shp$adj <- wv_adj
+
+    write_rds(wv_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    wv_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong WV} shapefile")
+}

--- a/analyses/WV_leg_2020/02_setup_WV_leg_2020.R
+++ b/analyses/WV_leg_2020/02_setup_WV_leg_2020.R
@@ -1,0 +1,29 @@
+###############################################################################
+# Set up redistricting simulation for `WV_leg_2020`
+# © ALARM Project, May 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg WV_leg_2020}")
+
+map_ssd <- redist_map(wv_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = wv_shp$adj)
+
+map_shd <- redist_map(wv_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = wv_shp$adj)
+
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "WV_SSD_2020"
+attr(map_shd, "analysis_name") <- "WV_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/WV_2020/WV_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/WV_2020/WV_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/WV_leg_2020/03_sim_WV_shd_2020.R
+++ b/analyses/WV_leg_2020/03_sim_WV_shd_2020.R
@@ -1,0 +1,65 @@
+###############################################################################
+# Simulate plans for `WV_shd_2020` SHD
+# © ALARM Project, May 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WV_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 130
+
+# County split constraint -----
+constr <- redist_constr(map_shd)
+constr <- add_constr_total_splits(
+    constr,
+    strength = 1.5,
+    admin = county
+)
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 2e3, runs = 5, ncores = 15L,
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WV_2020/WV_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WV_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WV_2020/WV_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/WV_leg_2020/03_sim_WV_ssd_2020.R
+++ b/analyses/WV_leg_2020/03_sim_WV_ssd_2020.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Simulate plans for `WV_ssd_2020` SSD
+# © ALARM Project, May 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg WV_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 70
+
+# Penalize total county splits.
+# This targets total_county_splits, not just county_splits.
+constr <- redist_constr(map_ssd)
+constr <- add_constr_total_splits(
+    constr,
+    strength = 2,
+    admin = map_ssd$county
+)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/WV_2020/WV_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg WV_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/WV_2020/WV_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/WV_leg_2020/doc_WV_leg_2020.md
+++ b/analyses/WV_leg_2020/doc_WV_leg_2020.md
@@ -1,0 +1,23 @@
+# 2020 West Virginia State House/Senate Districts
+
+## Redistricting requirements
+In West Virginia, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in West Virginia must:
+
+1. be contiguous [NCSL 186]
+2. have equal populations [NCSL 24]
+3. be geographically compact [NCSL 186]
+4. preserve political subdivision boundaries as much as possible [NCSL 186]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for West Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+We remove geographic units without enacted state House or Senate district assignments. The automatically generated adjacency graph contains disconnected components, so we add a nearest-neighbor bridge edge from each disconnected component to the main component before checking contiguity.
+
+## Simulation Notes
+We sample 10,000 districting plans for West Virginia's lower house across 5 independent runs of the SMC algorithm. We impose a total county splits constraint and increase the number of merge-split proposals per SMC step.
+
+We sample 10,000 districting plans for West Virginia's upper house across 5 independent runs of the SMC algorithm. We impose a total county splits constraint and increase the number of merge-split proposals per SMC step.


### PR DESCRIPTION
## Redistricting requirements
In West Virginia, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in West Virginia must:

1. be contiguous [NCSL 186]
2. have equal populations [NCSL 24]
3. be geographically compact [NCSL 186]
4. preserve political subdivision boundaries as much as possible [NCSL 186]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for West Virginia comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
We remove geographic units without enacted state House or Senate district assignments. The automatically generated adjacency graph contains disconnected components, so we add a nearest-neighbor bridge edge from each disconnected component to the main component before checking contiguity.

## Simulation Notes
We sample 10,000 districting plans for West Virginia's lower house across 5 independent runs of the SMC algorithm. We impose a total county splits constraint and increase the number of merge-split proposals per SMC step.

We sample 10,000 districting plans for West Virginia's upper house across 5 independent runs of the SMC algorithm. We impose a total county splits constraint and increase the number of merge-split proposals per SMC step.


## SSD Validation

<img width="3000" height="5400" alt="validation_20260717_2204" src="https://github.com/user-attachments/assets/11df26ac-5a9c-4bc6-9971-14543d9c190d" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 16 districts on 1,051 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 15
• `mh_accept_per_smc` = 76
• `pair_rule` = uniform
Plan diversity 80% range: 0.39 to 0.66
13 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_20              arv_20      atg_20_dem_pet      atg_20_rep_mor 
              1.012               1.006               1.009               1.009 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.010               1.004               1.005               1.004 
              e_dem               e_dvs                egap      gov_20_dem_sal 
              1.003               1.013               1.002               1.011 
     gov_20_rep_jus         muni_splits             ndshare                 ndv 
              1.006               1.002               1.013               1.012 
                nrv               pbias            plan_dev            pop_aian 
              1.006               1.003               1.010               1.011 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.019               1.011               1.012               1.015 
          pop_other         pop_overlap             pop_two           pop_white 
              1.016               1.003               1.012               1.003 
             pr_dem      pre_20_dem_bid      pre_20_rep_tru      sos_20_dem_ten 
              1.003               1.011               1.006               1.008 
     sos_20_rep_war total_county_splits   total_muni_splits           total_vap 
              1.008               1.003               1.002               1.003 
     uss_20_dem_swe      uss_20_rep_cap            vap_aian           vap_asian 
              1.008               1.006               1.010               1.014 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.009               1.014               1.015               1.017 
            vap_two           vap_white 
              1.010               1.003 
• R-hat ≤ 1.05: 723
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 723
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1     1,087 (54.3%)    100.0%        0.80 1,263 (100%) 
Split 2       567 (28.3%)     91.4%        1.22 1,057 ( 84%) 
Split 3       701 (35.0%)     81.1%        1.42   866 ( 68%) 
Split 4       796 (39.8%)     71.8%        1.28   920 ( 73%) 
Split 5       877 (43.8%)     65.7%        1.19   929 ( 73%) 
Split 6     1,059 (52.9%)     58.2%        1.06   991 ( 78%) 
Split 7     1,247 (62.3%)     52.6%        0.99 1,037 ( 82%) 
Split 8     1,212 (60.6%)     45.7%        0.92 1,048 ( 83%) 
Split 9     1,330 (66.5%)     39.7%        0.80 1,084 ( 86%) 
Split 10    1,405 (70.3%)     38.2%        0.69 1,100 ( 87%) 
Split 11    1,494 (74.7%)     32.1%        0.61 1,080 ( 85%) 
Split 12    1,540 (77.0%)     27.2%        0.58 1,120 ( 89%) 
Split 13    1,609 (80.4%)     23.3%        0.51 1,105 ( 87%) 
Split 14    1,723 (86.2%)     15.9%        0.43 1,055 ( 83%) 
Split 15    1,780 (89.0%)      1.2%        0.35   102 (  8%) 
Resample    1,780 (89.0%)       NA%          NA 1,723 (136%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      57.7%                76
MS Step 2      45.7%               152
MS Step 3      41.0%               228
MS Step 4      38.1%               228
MS Step 5      36.1%               228
MS Step 6      35.1%               228
MS Step 7      34.5%               228
MS Step 8      34.1%               228
MS Step 9      33.4%               228
MS Step 10     33.3%               228
MS Step 11     33.0%               228
MS Step 12     32.3%               304
MS Step 13     31.9%               304
MS Step 14     31.4%               304
MS Step 15     30.3%               304
```

## SHD Validation

<img width="3000" height="5400" alt="validation_20260717_2206" src="https://github.com/user-attachments/assets/046d8800-d97e-4e1f-9a0c-bb88c820d45a" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 72 districts on 1,051 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 71
• `mh_accept_per_smc` = 154
• `pair_rule` = uniform
Plan diversity 80% range: 0.53 to 0.64
92 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_20              arv_20      atg_20_dem_pet      atg_20_rep_mor 
              1.018               1.011               1.013               1.010 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.005               1.001               1.011               1.006 
              e_dem               e_dvs                egap      gov_20_dem_sal 
              1.007               1.019               1.006               1.012 
     gov_20_rep_jus         muni_splits             ndshare                 ndv 
              1.019               1.005               1.019               1.018 
                nrv               pbias            plan_dev            pop_aian 
              1.011               1.017               1.005               1.020 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.018               1.020               1.015               1.013 
          pop_other         pop_overlap             pop_two           pop_white 
              1.033               1.020               1.015               1.009 
             pr_dem      pre_20_dem_bid      pre_20_rep_tru      sos_20_dem_ten 
              1.010               1.018               1.010               1.019 
     sos_20_rep_war total_county_splits   total_muni_splits           total_vap 
              1.012               1.011               1.003               1.030 
     uss_20_dem_swe      uss_20_rep_cap            vap_aian           vap_asian 
              1.016               1.015               1.031               1.017 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.018               1.020               1.013               1.031 
            vap_two           vap_white 
              1.014               1.010 
• R-hat ≤ 1.05: 3220
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3220
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       683 (34.1%)    100.0%        1.00 1,258 (100%) 
Split 2       567 (28.3%)     98.7%        1.41 1,018 ( 81%) 
Split 3       887 (44.3%)     97.9%        1.49   939 ( 74%) 
Split 4       936 (46.8%)     96.3%        1.39 1,010 ( 80%) 
Split 5     1,089 (54.4%)     94.5%        1.24 1,002 ( 79%) 
Split 6     1,135 (56.7%)     91.9%        1.11 1,036 ( 82%) 
Split 7     1,223 (61.2%)     91.0%        1.06 1,045 ( 83%) 
Split 8     1,312 (65.6%)     88.6%        0.96 1,077 ( 85%) 
Split 9     1,377 (68.8%)     87.6%        0.84 1,112 ( 88%) 
Split 10    1,450 (72.5%)     85.6%        0.77 1,146 ( 91%) 
Split 11    1,479 (73.9%)     83.5%        0.75 1,123 ( 89%) 
Split 12    1,514 (75.7%)     80.9%        0.73 1,156 ( 91%) 
Split 13    1,560 (78.0%)     79.4%        0.69 1,135 ( 90%) 
Split 14    1,590 (79.5%)     77.0%        0.66 1,152 ( 91%) 
Split 15    1,616 (80.8%)     74.2%        0.59 1,164 ( 92%) 
Split 16    1,631 (81.6%)     72.6%        0.57 1,166 ( 92%) 
Split 17    1,643 (82.1%)     71.6%        0.57 1,188 ( 94%) 
Split 18    1,666 (83.3%)     69.7%        0.53 1,231 ( 97%) 
Split 19    1,674 (83.7%)     66.8%        0.52 1,186 ( 94%) 
Split 20    1,707 (85.3%)     67.6%        0.49 1,219 ( 96%) 
Split 21    1,738 (86.9%)     65.2%        0.44 1,199 ( 95%) 
Split 22    1,720 (86.0%)     62.6%        0.48 1,221 ( 97%) 
Split 23    1,752 (87.6%)     61.3%        0.43 1,196 ( 95%) 
Split 24    1,762 (88.1%)     59.9%        0.43 1,188 ( 94%) 
Split 25    1,766 (88.3%)     58.6%        0.42 1,216 ( 96%) 
Split 26    1,782 (89.1%)     57.3%        0.40 1,203 ( 95%) 
Split 27    1,791 (89.5%)     55.2%        0.39 1,205 ( 95%) 
Split 28    1,809 (90.4%)     53.3%        0.38 1,213 ( 96%) 
Split 29    1,800 (90.0%)     53.1%        0.37 1,197 ( 95%) 
Split 30    1,822 (91.1%)     50.0%        0.35 1,231 ( 97%) 
Split 31    1,832 (91.6%)     49.8%        0.34 1,232 ( 97%) 
Split 32    1,846 (92.3%)     49.5%        0.30 1,220 ( 97%) 
Split 33    1,855 (92.7%)     48.6%        0.31 1,217 ( 96%) 
Split 34    1,846 (92.3%)     47.1%        0.32 1,235 ( 98%) 
Split 35    1,858 (92.9%)     45.5%        0.30 1,239 ( 98%) 
Split 36    1,862 (93.1%)     46.5%        0.29 1,224 ( 97%) 
Split 37    1,881 (94.1%)     43.7%        0.28 1,205 ( 95%) 
Split 38    1,873 (93.7%)     43.7%        0.28 1,239 ( 98%) 
Split 39    1,885 (94.2%)     41.3%        0.27 1,239 ( 98%) 
Split 40    1,882 (94.1%)     41.6%        0.27 1,229 ( 97%) 
Split 41    1,880 (94.0%)     40.1%        0.27 1,227 ( 97%) 
Split 42    1,892 (94.6%)     40.2%        0.25 1,185 ( 94%) 
Split 43    1,899 (94.9%)     38.9%        0.23 1,237 ( 98%) 
Split 44    1,897 (94.9%)     37.0%        0.24 1,246 ( 99%) 
Split 45    1,897 (94.9%)     36.3%        0.24 1,228 ( 97%) 
Split 46    1,902 (95.1%)     36.2%        0.24 1,227 ( 97%) 
Split 47    1,913 (95.6%)     33.8%        0.22 1,220 ( 97%) 
Split 48    1,915 (95.7%)     33.4%        0.22 1,225 ( 97%) 
Split 49    1,916 (95.8%)     32.2%        0.22 1,224 ( 97%) 
Split 50    1,918 (95.9%)     32.0%        0.21 1,241 ( 98%) 
Split 51    1,926 (96.3%)     29.8%        0.20 1,234 ( 98%) 
Split 52    1,923 (96.2%)     29.5%        0.21 1,227 ( 97%) 
Split 53    1,927 (96.3%)     29.2%        0.21 1,203 ( 95%) 
Split 54    1,934 (96.7%)     29.5%        0.19 1,239 ( 98%) 
Split 55    1,930 (96.5%)     27.0%        0.20 1,224 ( 97%) 
Split 56    1,930 (96.5%)     27.7%        0.20 1,215 ( 96%) 
Split 57    1,933 (96.6%)     25.7%        0.19 1,226 ( 97%) 
Split 58    1,933 (96.6%)     24.8%        0.19 1,228 ( 97%) 
Split 59    1,939 (96.9%)     25.5%        0.18 1,242 ( 98%) 
Split 60    1,941 (97.1%)     23.2%        0.18 1,211 ( 96%) 
Split 61    1,945 (97.2%)     24.0%        0.17 1,212 ( 96%) 
Split 62    1,946 (97.3%)     22.8%        0.17 1,201 ( 95%) 
Split 63    1,948 (97.4%)     22.6%        0.17 1,216 ( 96%) 
Split 64    1,950 (97.5%)     22.2%        0.16 1,216 ( 96%) 
Split 65    1,952 (97.6%)     21.4%        0.16 1,193 ( 94%) 
Split 66    1,956 (97.8%)     20.1%        0.15 1,223 ( 97%) 
Split 67    1,957 (97.8%)     20.4%        0.15 1,186 ( 94%) 
Split 68    1,964 (98.2%)     19.8%        0.14 1,176 ( 93%) 
Split 69    1,966 (98.3%)     18.8%        0.14 1,130 ( 89%) 
Split 70    1,973 (98.7%)     18.2%        0.12 1,073 ( 85%) 
Split 71    1,975 (98.8%)     17.8%        0.11   957 ( 76%) 
Resample    1,975 (98.8%)       NA%          NA 1,917 (152%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      54.4%               154
MS Step 2      47.0%               308
MS Step 3      43.9%               462
MS Step 4      43.2%               462
MS Step 5      42.8%               462
MS Step 6      42.6%               462
MS Step 7      42.8%               462
MS Step 8      42.7%               462
MS Step 9      43.1%               462
MS Step 10     43.4%               462
MS Step 11     43.4%               462
MS Step 12     43.5%               462
MS Step 13     43.5%               462
MS Step 14     43.6%               462
MS Step 15     43.7%               462
MS Step 16     43.8%               462
MS Step 17     43.7%               462
MS Step 18     43.8%               462
MS Step 19     43.8%               462
MS Step 20     43.9%               462
MS Step 21     43.9%               462
MS Step 22     44.0%               462
MS Step 23     43.7%               462
MS Step 24     43.8%               462
MS Step 25     43.7%               462
MS Step 26     43.5%               462
MS Step 27     43.5%               462
MS Step 28     43.4%               462
MS Step 29     43.1%               462
MS Step 30     43.2%               462
MS Step 31     43.1%               462
MS Step 32     43.0%               462
MS Step 33     42.7%               462
MS Step 34     42.5%               462
MS Step 35     42.4%               462
MS Step 36     42.3%               462
MS Step 37     42.3%               462
MS Step 38     41.9%               462
MS Step 39     41.7%               462
MS Step 40     41.7%               462
MS Step 41     41.6%               462
MS Step 42     41.5%               462
MS Step 43     41.2%               462
MS Step 44     41.0%               462
MS Step 45     40.9%               462
MS Step 46     40.6%               462
MS Step 47     40.4%               462
MS Step 48     40.3%               462
MS Step 49     40.1%               462
MS Step 50     40.0%               462
MS Step 51     39.9%               462
MS Step 52     39.7%               462
MS Step 53     39.6%               462
MS Step 54     39.5%               462
MS Step 55     39.4%               462
MS Step 56     39.0%               462
MS Step 57     38.8%               462
MS Step 58     38.6%               462
MS Step 59     38.6%               462
MS Step 60     38.3%               462
MS Step 61     38.2%               462
MS Step 62     37.7%               462
MS Step 63     37.7%               462
MS Step 64     37.5%               462
MS Step 65     37.3%               462
MS Step 66     37.1%               462
MS Step 67     36.7%               462
MS Step 68     36.6%               462
MS Step 69     36.4%               462
MS Step 70     36.2%               462
MS Step 71     36.1%               462
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

**delete this line and all the tags except the reviewers you need**
@philipwosull 
