### PR TITLE
2020 California State House/Senate Districts

### DIFF
--- a/analyses/CA_leg_2020/01_prep_CA_leg_2020.R
+++ b/analyses/CA_leg_2020/01_prep_CA_leg_2020.R
@@ -1,0 +1,115 @@
+###############################################################################
+# Download and prepare data for `CA_leg_2020` analysis
+# © ALARM Project, June 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg CA_leg_2020}")
+
+path_data <- download_redistricting_file("CA", "data-raw/CA", type = "block", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/CA_2020/shp_vtd.rds"
+perim_path <- "data-out/CA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong CA} shapefile")
+
+    # read in redistricting data
+    ca_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        left_join(y = tigris::blocks("CA", year = 2020), by  = "GEOID20") |>
+        sf::st_as_sf() |>
+        st_transform(EPSG$CA)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- PL94171::pl_get_baf("CA", "INCPLACE_CDP")[[1]] %>%
+        rename(GEOID = BLOCKID, muni = PLACEFP)
+
+    ca_shp <- left_join(ca_shp, d_muni, by = "GEOID") %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(muni, county_muni, .after = county)
+
+    ca_shp %>%
+        mutate(tract = str_sub(GEOID, 1, 11)) %>%
+        group_by(tract) %>%
+        summarize(n_county_muni = n_distinct(county_muni)) %>%
+        filter(n_county_muni > 1)
+
+    # group by tract and summarize
+    ca_shp <- ca_shp |>
+        mutate(tract = str_sub(GEOID, 1, 11)) |>
+        group_by(tract) |>
+        summarize(
+            muni = Mode(muni),
+            state = unique(state),
+            county = unique(county),
+            county_muni = Mode(county_muni),
+            across(where(is.numeric), sum)
+        ) |>
+        mutate(GEOID = tract)
+
+    # add the enacted plan
+    ca_shp <- ca_shp |>
+        left_join(y = leg_from_baf(state = "CA", to = "tract"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ca_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ca_shp <- rmapshaper::ms_simplify(ca_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ca_shp$adj <- adjacency(ca_shp)
+
+    # custom adjacency graph edits
+
+    # island 1: 7296
+    ca_shp$adj <- add_edge(ca_shp$adj, 7296, 7300)
+
+    # island 2: 3442 3443
+    nbrs <- geomander::suggest_component_connection(ca_shp, ca_shp$adj)
+    ca_shp$adj <- add_edge(ca_shp$adj, nbrs$x, nbrs$y)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(ca_shp$adj, ca_shp$ssd_2020)
+    ccm(ca_shp$adj, ca_shp$shd_2020)
+
+    ca_shp <- ca_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(ca_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ca_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong CA} shapefile")
+}
+
+# replace NA values with 0
+ca_shp <- ca_shp |>
+    mutate(
+        across(where(is.numeric), \(x) coalesce(x, 0)
+    ))

--- a/analyses/CA_leg_2020/02_setup_CA_leg_2020.R
+++ b/analyses/CA_leg_2020/02_setup_CA_leg_2020.R
@@ -1,0 +1,36 @@
+###############################################################################
+# Set up redistricting simulation for `CA_leg_2020`
+# © ALARM Project, June 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg CA_leg_2020}")
+
+map_ssd <- redist_map(ca_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = ca_shp$adj)
+
+map_shd <- redist_map(ca_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = ca_shp$adj)
+
+# custom ssd constraints
+constr_ssd <- redist_constr(map_ssd)
+constr_ssd <- add_constr_total_splits(constr_ssd, strength = 1, admin = map_ssd$county)
+
+# custom shd constraints
+constr_shd <- redist_constr(map_shd)
+constr_shd <- add_constr_total_splits(constr_shd, strength = 1.5, admin = map_shd$county)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "CA_SSD_2020"
+attr(map_shd, "analysis_name") <- "CA_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/CA_2020/CA_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/CA_2020/CA_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/CA_leg_2020/03_sim_CA_shd_2020.R
+++ b/analyses/CA_leg_2020/03_sim_CA_shd_2020.R
@@ -1,0 +1,60 @@
+###############################################################################
+# Simulate plans for `CA_shd_2020` SHD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CA_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 150
+
+plans <- redist_smc(
+    map_shd,
+    nsims = 3000, runs = 5,
+    constraints = constr_shd,
+    ncores = 0,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CA_2020/CA_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# The following line is uncommented when viewing validation plots
+# plans <- readRDS("data-out/CA_2020/CA_shd_2020_plans.rds")
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CA_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CA_2020/CA_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/CA_leg_2020/03_sim_CA_ssd_2020.R
+++ b/analyses/CA_leg_2020/03_sim_CA_ssd_2020.R
@@ -1,0 +1,76 @@
+###############################################################################
+# Simulate plans for `CA_ssd_2020` SSD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg CA_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 50
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 3000, runs = 5,
+    constraints = constr_ssd,
+    ncores = 0,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/CA_2020/CA_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# The following line is uncommented when viewing validation plots
+# plans <- readRDS("data-out/CA_2020/CA_ssd_2020_plans.rds")
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg CA_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/CA_2020/CA_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    # Extra validation plots for custom constraints -----
+
+    visual <- redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Hisp by VAP") +
+        labs(title = "Approximate Performance")
+    plans |>
+        subset_sampled() |>
+        group_by(draw) |>
+        summarize(n_hisp_perf = sum(vap_hisp/total_vap > 0.3 & ndshare > 0.5)) |>
+        count(n_hisp_perf)
+
+    print(visual)
+}

--- a/analyses/CA_leg_2020/doc_CA_leg_2020.md
+++ b/analyses/CA_leg_2020/doc_CA_leg_2020.md
@@ -1,0 +1,44 @@
+# 2020 California State House/Senate Districts
+
+## Redistricting requirements
+In California, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in California must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve political subdivisions
+5. preserve communities of interest
+6. not favor the incumbent
+7. not favor party
+8. have House nested in Senate or Congress
+
+Note: California is a state whose constitution encourages (though does not strictly require)
+simple nesting, and simple nesting does not occur. However, house and senate
+districts may follow the same lines more frequently than otherwise.
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+Block data was downloaded for California's redistricting data file. The data was grouped
+by the first 11 characters of the GEOID (tract ID) to get tract sums.
+
+Manual adjacency edits were made to connect precincts 7296 and 3443 with mainland California.
+According to the [state of California](https://wedrawthelines.ca.gov/faqs/), "Actual islands
+are to be considered connected to the nearest land mass." For the manual adjacency edits made in this 
+analysis, reference was made to [California's congressional analysis](https://github.com/alarm-redist/fifty-states/blob/main/analyses/CA_cd_2020/01_prep_CA_cd_2020.R).
+
+## Simulation Notes
+We sample 15,000 districting plans for California's lower house across 5 independent 
+runs of the SMC algorithm. We introduce a total county splits constraint of strength 1.5 
+and increase the number of merge-split proposals per SMC step to 177 total. The ncores 
+argument in redist_smc() was set to 0.
+
+
+We sample 15,000 districting plans for California's upper house across 5 independent 
+runs of the SMC algorithm. We introduce a total county splits constraint of strength 1 
+and increase the number of merge-split proposals per SMC step to 64 total. The ncores 
+argument in redist_smc() was set to 0.


### PR DESCRIPTION
## Redistricting requirements
In California, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in California must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve political subdivisions
5. preserve communities of interest
6. not favor the incumbent
7. not favor party
8. have House nested in Senate or Congress

Note: California is a state whose constitution encourages (though does not strictly require) simple nesting, and simple nesting does not occur. However, house and senate districts may follow the same lines more frequently than otherwise.

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for California comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Block data was downloaded for California's redistricting data file. The data was grouped by the first 11 characters of the GEOID (tract ID) to get tract sums.

Manual adjacency edits were made to connect precincts 7296 and 3443 with mainland California. According to the [state of California](https://wedrawthelines.ca.gov/faqs/), "Actual islands are to be considered connected to the nearest land mass." For the manual adjacency edits made in this analysis, reference was made to [California's congressional analysis files](https://github.com/alarm-redist/fifty-states/blob/main/analyses/CA_cd_2020/01_prep_CA_cd_2020.R).

## Simulation Notes
We sample 15,000 districting plans for California's lower house across 5 independent runs of the SMC algorithm. We introduce a total county splits constraint of strength 1.5 and increase the number of merge-split proposals per SMC step to 177 total. The ncores argument in redist_smc() was set to 0.

We sample 15,000 districting plans for California's upper house across 5 independent runs of the SMC algorithm. We introduce a total county splits constraint of strength 1 and increase the number of merge-split proposals per SMC step to 64 total. The ncores argument in redist_smc() was set to 0.

## Validation

### State House

<img width="522" height="682" alt="Screenshot 2026-07-20 at 1 50 04 PM" src="https://github.com/user-attachments/assets/4e417105-3919-4090-b89a-ccd37918b665" />

```
SMC with Merge-Split MCMC Steps: 10,000
sampled plans of 80 districts on 9,129
units
Plans sampled on Linking Edge Forest
Space using the Uniform Valid Edge
forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 79
• `mh_accept_per_smc` = 177
• `pair_rule` = uniform
Plan diversity 80% range: 0.78 to 0.86
67 rhat values are `NA`
Largest R-hat values for ordered
summary statistics:
             adv_16              adv_20 
              1.008               1.012 
             arv_16              arv_20 
              1.022               1.020 
    comp_bbox_reock           comp_edge 
              1.008               1.001 
        comp_polsby       county_splits 
              1.008               1.016 
              e_dem               e_dvs 
              1.003               1.014 
               egap         muni_splits 
              1.004               1.007 
            ndshare                 ndv 
              1.014               1.010 
                nrv               pbias 
              1.020               1.002 
           plan_dev            pop_aian 
              1.000               1.022 
          pop_asian           pop_black 
              1.014               1.018 
           pop_hisp            pop_nhpi 
              1.006               1.010 
          pop_other         pop_overlap 
              1.007               1.004 
            pop_two           pop_white 
              1.018               1.009 
             pr_dem      pre_16_dem_cli 
              1.004               1.008 
     pre_16_rep_tru      pre_20_dem_bid 
              1.022               1.012 
     pre_20_rep_tru total_county_splits 
              1.020               1.006 
  total_muni_splits           total_vap 
              1.008               1.002 
           vap_aian           vap_asian 
              1.022               1.014 
          vap_black            vap_hisp 
              1.017               1.007 
           vap_nhpi           vap_other 
              1.009               1.006 
            vap_two           vap_white 
              1.010               1.008 
• R-hat ≤ 1.05: 3293
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3293
Sampling diagnostics for SMC run 1 of 5
(10,000 samples)
         Eff. samples (%) Acc. rate
Split 1        192 (6.4%)    100.0%
Split 2        214 (7.1%)     98.8%
Split 3       336 (11.2%)     97.8%
Split 4       415 (13.8%)     96.1%
Split 5       576 (19.2%)     94.2%
Split 6       714 (23.8%)     94.7%
Split 7       926 (30.9%)     92.7%
Split 8     1,053 (35.1%)     92.9%
Split 9     1,044 (34.8%)     91.8%
Split 10    1,173 (39.1%)     91.0%
Split 11    1,303 (43.4%)     88.9%
Split 12    1,362 (45.4%)     88.2%
Split 13    1,496 (49.9%)     88.7%
Split 14    1,525 (50.8%)     86.8%
Split 15    1,580 (52.7%)     86.7%
Split 16    1,656 (55.2%)     85.1%
Split 17    1,704 (56.8%)     84.6%
Split 18    1,736 (57.9%)     84.7%
Split 19    1,787 (59.6%)     83.8%
Split 20    1,894 (63.1%)     82.4%
Split 21    1,896 (63.2%)     80.2%
Split 22    1,952 (65.1%)     78.7%
Split 23    1,986 (66.2%)     80.6%
Split 24    2,003 (66.8%)     79.3%
Split 25    2,062 (68.7%)     78.1%
Split 26    2,091 (69.7%)     77.0%
Split 27    2,170 (72.3%)     75.8%
Split 28    2,135 (71.2%)     74.7%
Split 29    2,207 (73.6%)     75.2%
Split 30    2,202 (73.4%)     72.5%
Split 31    2,230 (74.3%)     72.8%
Split 32    2,230 (74.3%)     71.6%
Split 33    2,256 (75.2%)     70.9%
Split 34    2,325 (77.5%)     70.5%
Split 35    2,313 (77.1%)     69.4%
Split 36    2,312 (77.1%)     69.1%
Split 37    2,342 (78.1%)     67.5%
Split 38    2,383 (79.4%)     65.7%
Split 39    2,424 (80.8%)     65.6%
Split 40    2,348 (78.3%)     64.6%
Split 41    2,408 (80.3%)     64.7%
Split 42    2,435 (81.2%)     64.4%
Split 43    2,453 (81.8%)     62.6%
Split 44    2,442 (81.4%)     61.2%
Split 45    2,485 (82.8%)     61.1%
Split 46    2,498 (83.3%)     60.2%
Split 47    2,494 (83.1%)     58.8%
Split 48    2,499 (83.3%)     57.3%
Split 49    2,521 (84.0%)     57.2%
Split 50    2,526 (84.2%)     56.2%
Split 51    2,526 (84.2%)     56.2%
Split 52    2,551 (85.0%)     54.1%
Split 53    2,547 (84.9%)     54.3%
Split 54    2,548 (84.9%)     53.7%
Split 55    2,564 (85.5%)     51.5%
Split 56    2,599 (86.6%)     51.7%
Split 57    2,604 (86.8%)     51.1%
Split 58    2,591 (86.4%)     51.4%
Split 59    2,614 (87.1%)     48.9%
Split 60    2,632 (87.7%)     48.4%
Split 61    2,611 (87.0%)     47.9%
Split 62    2,654 (88.5%)     46.0%
Split 63    2,653 (88.4%)     46.9%
Split 64    2,643 (88.1%)     45.7%
Split 65    2,651 (88.4%)     43.9%
Split 66    2,679 (89.3%)     42.8%
Split 67    2,665 (88.8%)     41.5%
Split 68    2,684 (89.5%)     41.6%
Split 69    2,672 (89.1%)     41.2%
Split 70    2,680 (89.3%)     41.0%
Split 71    2,664 (88.8%)     39.1%
Split 72    2,685 (89.5%)     38.4%
Split 73    2,702 (90.1%)     38.0%
Split 74    2,705 (90.2%)     36.9%
Split 75    2,700 (90.0%)     36.4%
Split 76    2,714 (90.5%)     35.0%
Split 77    2,710 (90.3%)     36.0%
Split 78    2,727 (90.9%)     33.8%
Split 79    2,712 (90.4%)     33.4%
Resample    2,712 (90.4%)       NA%
         Log wgt. sd  Max. unique 
Split 1         2.64 1,865 ( 98%) 
Split 2         4.36   734 ( 39%) 
Split 3         4.12   670 ( 35%) 
Split 4         3.88   799 ( 42%) 
Split 5         3.65   890 ( 47%) 
Split 6         3.45 1,010 ( 53%) 
Split 7         3.32 1,130 ( 60%) 
Split 8         3.01 1,216 ( 64%) 
Split 9         3.05 1,311 ( 69%) 
Split 10        2.78 1,277 ( 67%) 
Split 11        2.67 1,351 ( 71%) 
Split 12        2.66 1,408 ( 74%) 
Split 13        2.40 1,425 ( 75%) 
Split 14        2.37 1,468 ( 77%) 
Split 15        2.29 1,476 ( 78%) 
Split 16        2.03 1,499 ( 79%) 
Split 17        2.10 1,529 ( 81%) 
Split 18        1.94 1,503 ( 79%) 
Split 19        1.76 1,551 ( 82%) 
Split 20        1.77 1,589 ( 84%) 
Split 21        1.78 1,608 ( 85%) 
Split 22        1.54 1,581 ( 83%) 
Split 23        1.55 1,634 ( 86%) 
Split 24        1.40 1,647 ( 87%) 
Split 25        1.27 1,636 ( 86%) 
Split 26        1.17 1,695 ( 89%) 
Split 27        1.11 1,661 ( 88%) 
Split 28        1.13 1,671 ( 88%) 
Split 29        1.05 1,668 ( 88%) 
Split 30        1.08 1,682 ( 89%) 
Split 31        0.97 1,712 ( 90%) 
Split 32        0.97 1,691 ( 89%) 
Split 33        0.97 1,714 ( 90%) 
Split 34        0.85 1,729 ( 91%) 
Split 35        0.83 1,715 ( 90%) 
Split 36        0.87 1,746 ( 92%) 
Split 37        0.81 1,714 ( 90%) 
Split 38        0.77 1,738 ( 92%) 
Split 39        0.79 1,755 ( 93%) 
Split 40        0.78 1,761 ( 93%) 
Split 41        0.71 1,720 ( 91%) 
Split 42        0.71 1,757 ( 93%) 
Split 43        0.65 1,764 ( 93%) 
Split 44        0.70 1,821 ( 96%) 
Split 45        0.70 1,782 ( 94%) 
Split 46        0.62 1,800 ( 95%) 
Split 47        0.66 1,770 ( 93%) 
Split 48        0.64 1,796 ( 95%) 
Split 49        0.61 1,789 ( 94%) 
Split 50        0.59 1,770 ( 93%) 
Split 51        0.57 1,812 ( 96%) 
Split 52        0.59 1,776 ( 94%) 
Split 53        0.56 1,754 ( 92%) 
Split 54        0.58 1,796 ( 95%) 
Split 55        0.54 1,775 ( 94%) 
Split 56        0.53 1,827 ( 96%) 
Split 57        0.50 1,812 ( 96%) 
Split 58        0.52 1,794 ( 95%) 
Split 59        0.52 1,787 ( 94%) 
Split 60        0.46 1,797 ( 95%) 
Split 61        0.50 1,804 ( 95%) 
Split 62        0.43 1,822 ( 96%) 
Split 63        0.44 1,812 ( 96%) 
Split 64        0.46 1,832 ( 97%) 
Split 65        0.45 1,834 ( 97%) 
Split 66        0.42 1,795 ( 95%) 
Split 67        0.43 1,825 ( 96%) 
Split 68        0.42 1,792 ( 94%) 
Split 69        0.42 1,809 ( 95%) 
Split 70        0.42 1,801 ( 95%) 
Split 71        0.42 1,817 ( 96%) 
Split 72        0.40 1,807 ( 95%) 
Split 73        0.40 1,820 ( 96%) 
Split 74        0.40 1,839 ( 97%) 
Split 75        0.40 1,804 ( 95%) 
Split 76        0.39 1,801 ( 95%) 
Split 77        0.38 1,782 ( 94%) 
Split 78        0.37 1,763 ( 93%) 
Split 79        0.38 1,658 ( 87%) 
Resample          NA 2,602 (137%) 

Sampling diagnostics for Mergesplit
Steps of SMC run 1 of 5 (10,000
samples)
           Acc. rate MS Steps per Plan
MS Step 1      17.2%               177
MS Step 2      13.1%              1062
MS Step 3      13.7%              1416
MS Step 4      15.3%              1416
MS Step 5      17.0%              1239
MS Step 6      18.6%              1062
MS Step 7      20.0%              1062
MS Step 8      21.3%              1062
MS Step 9      22.1%               885
MS Step 10     22.9%               885
MS Step 11     23.7%               885
MS Step 12     24.4%               885
MS Step 13     25.0%               885
MS Step 14     25.7%               885
MS Step 15     26.2%               708
MS Step 16     26.7%               708
MS Step 17     27.3%               708
MS Step 18     27.5%               708
MS Step 19     27.8%               708
MS Step 20     28.1%               708
MS Step 21     28.3%               708
MS Step 22     28.5%               708
MS Step 23     28.8%               708
MS Step 24     29.0%               708
MS Step 25     29.3%               708
MS Step 26     29.4%               708
MS Step 27     29.6%               708
MS Step 28     29.5%               708
MS Step 29     29.7%               708
MS Step 30     29.8%               708
MS Step 31     29.9%               708
MS Step 32     29.9%               708
MS Step 33     30.0%               708
MS Step 34     30.1%               708
MS Step 35     30.1%               708
MS Step 36     30.2%               708
MS Step 37     30.2%               708
MS Step 38     30.1%               708
MS Step 39     30.1%               708
MS Step 40     30.0%               708
MS Step 41     30.0%               708
MS Step 42     30.0%               708
MS Step 43     29.9%               708
MS Step 44     29.9%               708
MS Step 45     29.8%               708
MS Step 46     29.8%               708
MS Step 47     29.6%               708
MS Step 48     29.7%               708
MS Step 49     29.6%               708
MS Step 50     29.6%               708
MS Step 51     29.5%               708
MS Step 52     29.4%               708
MS Step 53     29.2%               708
MS Step 54     29.2%               708
MS Step 55     29.1%               708
MS Step 56     29.0%               708
MS Step 57     28.8%               708
MS Step 58     28.8%               708
MS Step 59     28.6%               708
MS Step 60     28.6%               708
MS Step 61     28.4%               708
MS Step 62     28.4%               708
MS Step 63     28.3%               708
MS Step 64     28.1%               708
MS Step 65     28.0%               708
MS Step 66     27.8%               708
MS Step 67     27.7%               708
MS Step 68     27.6%               708
MS Step 69     27.5%               708
MS Step 70     27.3%               708
MS Step 71     27.2%               708
MS Step 72     27.0%               708
MS Step 73     26.9%               708
MS Step 74     26.8%               708
MS Step 75     26.6%               708
MS Step 76     26.4%               708
MS Step 77     26.4%               708
MS Step 78     26.4%               708
MS Step 79     26.2%               708

•  Watch out for low effective samples,
very low acceptance rates (less than
1%), large std. devs. of the log
weights (more than 3 or so), and low
numbers of unique plans. R-hat values
for summary statistics should be
between 1 and 1.05.
```

### State Senate 

<img width="564" height="733" alt="Screenshot 2026-07-20 at 1 52 41 PM" src="https://github.com/user-attachments/assets/940d6b2d-43f7-4eff-ab9b-c3405e241183" />

```
SMC with Merge-Split MCMC Steps:
10,000 sampled plans of 40 districts
on 9,129 units
Plans sampled on Linking Edge Forest
Space using the Uniform Valid Edge
forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 39
• `mh_accept_per_smc` = 64
• `pair_rule` = uniform
Plan diversity 80% range: 0.76 to 0.87
30 rhat values are `NA`
Largest R-hat values for ordered
summary statistics:
             adv_16 
              1.006 
             adv_20 
              1.004 
             arv_16 
              1.007 
             arv_20 
              1.007 
    comp_bbox_reock 
              1.006 
          comp_edge 
              1.001 
        comp_polsby 
              1.007 
      county_splits 
              1.015 
              e_dem 
              1.002 
              e_dvs 
              1.012 
               egap 
              1.001 
        muni_splits 
              1.003 
            ndshare 
              1.011 
                ndv 
              1.006 
                nrv 
              1.006 
              pbias 
              1.009 
           plan_dev 
              1.000 
           pop_aian 
              1.011 
          pop_asian 
              1.007 
          pop_black 
              1.011 
           pop_hisp 
              1.006 
           pop_nhpi 
              1.005 
          pop_other 
              1.004 
        pop_overlap 
              1.004 
            pop_two 
              1.006 
          pop_white 
              1.009 
             pr_dem 
              1.003 
     pre_16_dem_cli 
              1.006 
     pre_16_rep_tru 
              1.007 
     pre_20_dem_bid 
              1.004 
     pre_20_rep_tru 
              1.007 
total_county_splits 
              1.009 
  total_muni_splits 
              1.003 
          total_vap 
              1.003 
           vap_aian 
              1.009 
          vap_asian 
              1.009 
          vap_black 
              1.010 
           vap_hisp 
              1.006 
           vap_nhpi 
              1.006 
          vap_other 
              1.004 
            vap_two 
              1.004 
          vap_white 
              1.007 
• R-hat ≤ 1.05: 1650
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1650
Sampling diagnostics for SMC run 1 of
5 (10,000 samples)
         Eff. samples (%) Acc. rate
Split 1       432 (14.4%)    100.0%
Split 2       500 (16.7%)     98.2%
Split 3       702 (23.4%)     95.9%
Split 4       896 (29.9%)     94.9%
Split 5     1,016 (33.9%)     92.7%
Split 6     1,178 (39.3%)     91.3%
Split 7     1,304 (43.5%)     89.6%
Split 8     1,472 (49.1%)     86.9%
Split 9     1,569 (52.3%)     85.1%
Split 10    1,710 (57.0%)     84.3%
Split 11    1,773 (59.1%)     81.8%
Split 12    1,797 (59.9%)     79.5%
Split 13    1,946 (64.9%)     78.7%
Split 14    1,995 (66.5%)     75.6%
Split 15    2,010 (67.0%)     73.5%
Split 16    2,070 (69.0%)     73.0%
Split 17    2,108 (70.3%)     70.2%
Split 18    2,152 (71.7%)     69.1%
Split 19    2,175 (72.5%)     67.1%
Split 20    2,226 (74.2%)     64.7%
Split 21    2,244 (74.8%)     62.8%
Split 22    2,294 (76.5%)     61.8%
Split 23    2,328 (77.6%)     59.4%
Split 24    2,373 (79.1%)     58.2%
Split 25    2,362 (78.7%)     55.7%
Split 26    2,376 (79.2%)     54.2%
Split 27    2,446 (81.5%)     52.0%
Split 28    2,419 (80.6%)     51.7%
Split 29    2,468 (82.3%)     48.6%
Split 30    2,481 (82.7%)     47.6%
Split 31    2,521 (84.0%)     45.3%
Split 32    2,529 (84.3%)     44.2%
Split 33    2,579 (86.0%)     41.8%
Split 34    2,561 (85.4%)     41.8%
Split 35    2,611 (87.0%)     40.1%
Split 36    2,607 (86.9%)     36.8%
Split 37    2,633 (87.8%)     36.7%
Split 38    2,663 (88.8%)     34.5%
Split 39    2,675 (89.2%)     31.8%
Resample    2,675 (89.2%)       NA%
         Log wgt. sd  Max. unique 
Split 1         1.75 1,904 (100%) 
Split 2         2.29 1,043 ( 55%) 
Split 3         2.07 1,038 ( 55%) 
Split 4         1.85 1,167 ( 62%) 
Split 5         1.70 1,287 ( 68%) 
Split 6         1.54 1,351 ( 71%) 
Split 7         1.46 1,398 ( 74%) 
Split 8         1.31 1,432 ( 76%) 
Split 9         1.26 1,513 ( 80%) 
Split 10        1.18 1,533 ( 81%) 
Split 11        1.11 1,588 ( 84%) 
Split 12        1.01 1,601 ( 84%) 
Split 13        0.96 1,603 ( 85%) 
Split 14        0.88 1,610 ( 85%) 
Split 15        0.86 1,639 ( 86%) 
Split 16        0.83 1,695 ( 89%) 
Split 17        0.78 1,692 ( 89%) 
Split 18        0.73 1,695 ( 89%) 
Split 19        0.71 1,707 ( 90%) 
Split 20        0.69 1,701 ( 90%) 
Split 21        0.67 1,703 ( 90%) 
Split 22        0.63 1,726 ( 91%) 
Split 23        0.61 1,754 ( 92%) 
Split 24        0.58 1,742 ( 92%) 
Split 25        0.58 1,761 ( 93%) 
Split 26        0.54 1,721 ( 91%) 
Split 27        0.54 1,764 ( 93%) 
Split 28        0.53 1,766 ( 93%) 
Split 29        0.50 1,774 ( 94%) 
Split 30        0.48 1,778 ( 94%) 
Split 31        0.47 1,776 ( 94%) 
Split 32        0.46 1,784 ( 94%) 
Split 33        0.42 1,785 ( 94%) 
Split 34        0.44 1,772 ( 93%) 
Split 35        0.41 1,767 ( 93%) 
Split 36        0.42 1,772 ( 93%) 
Split 37        0.40 1,757 ( 93%) 
Split 38        0.37 1,747 ( 92%) 
Split 39        0.36 1,661 ( 88%) 
Resample          NA 2,594 (137%) 

Sampling diagnostics for Mergesplit
Steps of SMC run 1 of 5 (10,000
samples)
           Acc. rate MS Steps per Plan
MS Step 1      30.3%                64
MS Step 2      24.8%               256
MS Step 3      24.8%               320
MS Step 4      25.7%               320
MS Step 5      26.5%               256
MS Step 6      27.4%               256
MS Step 7      28.0%               256
MS Step 8      28.4%               256
MS Step 9      28.7%               256
MS Step 10     29.3%               256
MS Step 11     29.5%               256
MS Step 12     29.9%               256
MS Step 13     30.0%               256
MS Step 14     30.0%               256
MS Step 15     29.8%               256
MS Step 16     30.0%               256
MS Step 17     29.7%               256
MS Step 18     29.6%               256
MS Step 19     29.6%               256
MS Step 20     29.4%               256
MS Step 21     29.3%               256
MS Step 22     29.1%               256
MS Step 23     28.8%               256
MS Step 24     28.7%               256
MS Step 25     28.4%               256
MS Step 26     28.1%               256
MS Step 27     28.0%               256
MS Step 28     27.6%               256
MS Step 29     27.4%               256
MS Step 30     27.1%               256
MS Step 31     26.7%               256
MS Step 32     26.5%               256
MS Step 33     26.3%               256
MS Step 34     25.9%               256
MS Step 35     25.6%               256
MS Step 36     25.4%               256
MS Step 37     24.9%               256
MS Step 38     24.7%               320
MS Step 39     24.3%               320

•  Watch out for low effective samples,
very low acceptance rates (less than
1%), large std. devs. of the log
weights (more than 3 or so), and low
numbers of unique plans. R-hat values
for summary statistics should be
between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

Note: I am unsure about what the following item in the checklist means: "I have merged in the main branch and then recalculated my summary statistics."

@CoryMcCartan