### PR TITLE
2020 Alabama State House/Senate Districts

### DIFF
--- a/analyses/AL_leg_2020/01_prep_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/01_prep_AL_leg_2020.R
@@ -1,0 +1,90 @@
+###############################################################################
+# Download and prepare data for `AL_leg_2020` analysis
+# © ALARM Project, June 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AL_leg_2020}")
+
+path_data <- download_redistricting_file("AL", "data-raw/AL", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AL_2020/shp_vtd.rds"
+perim_path <- "data-out/AL_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AL} shapefile")
+    # read in redistricting data
+    al_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$AL)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AL", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("AL"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("AL", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
+                  ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("AL", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
+                  shd_2010 = as.integer(sldl))
+
+    al_shp <- al_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    al_shp <- al_shp |>
+        left_join(y = leg_from_baf(state = "AL"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = al_shp,
+                             perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
+                                                 keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    al_shp$adj <- adjacency(al_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(al_shp$adj, al_shp$ssd_2020)
+    ccm(al_shp$adj, al_shp$shd_2020)
+
+    al_shp <- al_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(al_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    al_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AL} shapefile")
+}

--- a/analyses/AL_leg_2020/01_prep_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/01_prep_AL_leg_2020.R
@@ -42,10 +42,10 @@ if (!file.exists(here(shp_path))) {
         select(-vtd)
     d_ssd <- make_from_baf("AL", "SLDU", "VTD", year = 2020)  |>
         transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
-                  ssd_2010 = as.integer(sldu))
+            ssd_2010 = as.integer(sldu))
     d_shd <- make_from_baf("AL", "SLDL", "VTD", year = 2020)  |>
         transmute(GEOID = paste0(censable::match_fips("AL"), vtd),
-                  shd_2010 = as.integer(sldl))
+            shd_2010 = as.integer(sldl))
 
     al_shp <- al_shp |>
         left_join(d_muni, by = "GEOID") |>
@@ -61,13 +61,13 @@ if (!file.exists(here(shp_path))) {
 
     # Create perimeters in case shapes are simplified
     redistmetrics::prep_perims(shp = al_shp,
-                             perim_path = here(perim_path)) |>
+        perim_path = here(perim_path)) |>
         invisible()
 
     # simplifies geometry for faster processing, plotting, and smaller shapefiles
     if (requireNamespace("rmapshaper", quietly = TRUE)) {
         al_shp <- rmapshaper::ms_simplify(al_shp, keep = 0.05,
-                                                 keep_shapes = TRUE) |>
+            keep_shapes = TRUE) |>
             suppressWarnings()
     }
 

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -21,10 +21,10 @@ constr_shd <- add_constr_total_splits(constr_shd, strength = 1.3, admin = map_sh
 # make pseudo counties with default settings
 map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_ssd)))
+        pop_muni = get_target(map_ssd)))
 map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_shd)))
+        pop_muni = get_target(map_shd)))
 
 # Add an analysis name attribute
 attr(map_ssd, "analysis_name") <- "AL_SSD_2020"

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -1,0 +1,36 @@
+###############################################################################
+# Set up redistricting simulation for `AL_leg_2020`
+# © ALARM Project, June 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AL_leg_2020}")
+
+map_ssd <- redist_map(al_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = al_shp$adj)
+
+map_shd <- redist_map(al_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = al_shp$adj)
+
+# custom ssd constraint
+constr <- redist_constr(map_ssd)
+constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
+
+# custom shd constraint
+constr_shd <- redist_constr(map_shd)
+constr_shd <- add_constr_total_splits(constr_shd, strength = 1.3, admin = map_shd$county)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_shd)))
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "AL_SSD_2020"
+attr(map_shd, "analysis_name") <- "AL_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/AL_2020/AL_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/AL_2020/AL_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -15,8 +15,8 @@ constr <- redist_constr(map_ssd)
 constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
 constr <- add_constr_grp_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
                                tgts_group = c(0.63, 0.62, 0.61, 0.58, 0.57, 0.50, 0.45, 0.45))
-constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
-                               tgts_group = c(0.79))
+#constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
+                               #tgts_group = c(0.79))
 
 # custom shd constraint
 constr_shd <- redist_constr(map_shd)

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -13,8 +13,8 @@ map_shd <- redist_map(al_shp, pop_tol = 0.05,
 # custom ssd constraint
 constr <- redist_constr(map_ssd)
 constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
-constr <- add_constr_grp_hinge(constr, strength = 10, group_pop = map_ssd$vap_black,
-                               tgts_group = c(0.63, 0.62, 0.61, 0.58, 0.57, 0.50, 0.45, 0.45))
+constr <- add_constr_grp_hinge(constr, strength = 20, group_pop = map_ssd$vap_black,
+                               tgts_group = c(0.57, 0.55))
 #constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
                                #tgts_group = c(0.79))
 

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -12,7 +12,7 @@ map_shd <- redist_map(al_shp, pop_tol = 0.05,
 
 # custom ssd constraint
 constr <- redist_constr(map_ssd)
-constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
+constr <- add_constr_total_splits(constr, strength = 1, admin = map_ssd$county)
 constr <- add_constr_grp_hinge(constr, strength = 20, group_pop = map_ssd$vap_black,
                                tgts_group = c(0.57, 0.55))
 #constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -14,9 +14,9 @@ map_shd <- redist_map(al_shp, pop_tol = 0.05,
 constr <- redist_constr(map_ssd)
 constr <- add_constr_total_splits(constr, strength = 1, admin = map_ssd$county)
 constr <- add_constr_grp_hinge(constr, strength = 20, group_pop = map_ssd$vap_black,
-                               tgts_group = c(0.57, 0.55))
-#constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
-                               #tgts_group = c(0.79))
+                               tgts_group = c(0.52))
+constr <- add_constr_grp_inv_hinge(constr, strength = 10, total_pop = map_ssd$pop, group_pop = map_ssd$vap_black,
+                               tgts_group = c(0.75))
 
 # custom shd constraint
 constr_shd <- redist_constr(map_shd)

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -13,6 +13,10 @@ map_shd <- redist_map(al_shp, pop_tol = 0.05,
 # custom ssd constraint
 constr <- redist_constr(map_ssd)
 constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
+constr <- add_constr_grp_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
+                               tgts_group = c(0.63, 0.62, 0.61, 0.58, 0.57, 0.50, 0.45, 0.45))
+constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
+                               tgts_group = c(0.79))
 
 # custom shd constraint
 constr_shd <- redist_constr(map_shd)

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -13,7 +13,7 @@ map_shd <- redist_map(al_shp, pop_tol = 0.05,
 # custom ssd constraint
 constr <- redist_constr(map_ssd)
 constr <- add_constr_total_splits(constr, strength = 2.4, admin = map_ssd$county)
-constr <- add_constr_grp_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
+constr <- add_constr_grp_hinge(constr, strength = 10, group_pop = map_ssd$vap_black,
                                tgts_group = c(0.63, 0.62, 0.61, 0.58, 0.57, 0.50, 0.45, 0.45))
 #constr <- add_constr_grp_inv_hinge(constr, strength = 2, group_pop = map_ssd$vap_black,
                                #tgts_group = c(0.79))

--- a/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
+++ b/analyses/AL_leg_2020/02_setup_AL_leg_2020.R
@@ -16,7 +16,7 @@ constr <- add_constr_total_splits(constr, strength = 1, admin = map_ssd$county)
 constr <- add_constr_grp_hinge(constr, strength = 20, group_pop = map_ssd$vap_black,
                                tgts_group = c(0.52))
 constr <- add_constr_grp_inv_hinge(constr, strength = 10, total_pop = map_ssd$pop, group_pop = map_ssd$vap_black,
-                               tgts_group = c(0.75))
+                               tgts_group = c(0.68))
 
 # custom shd constraint
 constr_shd <- redist_constr(map_shd)

--- a/analyses/AL_leg_2020/03_sim_AL_shd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_shd_2020.R
@@ -1,0 +1,57 @@
+###############################################################################
+# Simulate plans for `AL_shd_2020` SHD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AL_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 312
+
+plans <- redist_smc(
+  map_shd,
+  nsims = 3000, runs = 5,
+  constraints = constr_shd,
+  ncores = 0,
+  counties = pseudo_county,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AL_2020/AL_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# The following line is uncommented when viewing validation plots
+# plans <- readRDS("data-out/AL_2020/AL_shd_2020_plans.rds")
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AL_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AL_2020/AL_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/AL_leg_2020/03_sim_AL_shd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_shd_2020.R
@@ -11,15 +11,15 @@ set.seed(2020)
 mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 312
 
 plans <- redist_smc(
-  map_shd,
-  nsims = 3000, runs = 5,
-  constraints = constr_shd,
-  ncores = 0,
-  counties = pseudo_county,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
+    map_shd,
+    nsims = 3000, runs = 5,
+    constraints = constr_shd,
+    ncores = 0,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
 )
 
 plans <- plans |>

--- a/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
@@ -1,0 +1,72 @@
+###############################################################################
+# Simulate plans for `AL_ssd_2020` SSD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AL_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 35
+
+plans <- redist_smc(
+  map_ssd,
+  nsims = 5000, runs = 5,
+  constraints = constr,
+  counties = pseudo_county,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AL_2020/AL_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# The following line is uncommented when viewing validation plots
+# plans <- readRDS("data-out/AL_2020/AL_ssd_2020_plans.rds")
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AL_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AL_2020/AL_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    # Extra validation plots for custom constraints -----
+
+    visual <- redist.plot.distr_qtys(plans, vap_black / total_vap,
+                                     color_thresh = NULL,
+                                     color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, '#3D77BB', '#B25D4C'),
+                                     size = 0.5, alpha = 0.5) +
+      scale_y_continuous('Percent Black by VAP') +
+      labs(title = 'Approximate Performance')
+    plans |>
+      subset_sampled() |>
+      group_by(draw) |>
+      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) |>
+      count(n_black_perf)
+
+    print(visual)
+}

--- a/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
@@ -11,14 +11,14 @@ set.seed(2020)
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 35
 
 plans <- redist_smc(
-  map_ssd,
-  nsims = 5000, runs = 5,
-  constraints = constr,
-  counties = pseudo_county,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
+    map_ssd,
+    nsims = 5000, runs = 5,
+    constraints = constr,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
 )
 
 plans <- plans |>
@@ -56,17 +56,17 @@ if (interactive()) {
 
     # Extra validation plots for custom constraints -----
 
-    visual <- redist.plot.distr_qtys(plans, vap_black / total_vap,
-                                     color_thresh = NULL,
-                                     color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, '#3D77BB', '#B25D4C'),
-                                     size = 0.5, alpha = 0.5) +
-      scale_y_continuous('Percent Black by VAP') +
-      labs(title = 'Approximate Performance')
+    visual <- redist.plot.distr_qtys(plans, vap_black/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Black by VAP") +
+        labs(title = "Approximate Performance")
     plans |>
-      subset_sampled() |>
-      group_by(draw) |>
-      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) |>
-      count(n_black_perf)
+        subset_sampled() |>
+        group_by(draw) |>
+        summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) |>
+        count(n_black_perf)
 
     print(visual)
 }

--- a/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
@@ -12,7 +12,7 @@ mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 35
 
 plans <- redist_smc(
     map_ssd,
-    nsims = 5000, runs = 5,
+    nsims = 2000, runs = 5,
     constraints = constr,
     counties = pseudo_county,
     sampling_space = "linking_edge",
@@ -35,7 +35,7 @@ write_rds(plans, here("data-out/AL_2020/AL_ssd_2020_plans.rds"), compress = "xz"
 cli_process_done()
 
 # The following line is uncommented when viewing validation plots
-# plans <- readRDS("data-out/AL_2020/AL_ssd_2020_plans.rds")
+ plans <- readRDS("data-out/AL_2020/AL_ssd_2020_plans.rds")
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg AL_ssd_2020}")
@@ -68,5 +68,20 @@ if (interactive()) {
         summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) |>
         count(n_black_perf)
 
-    print(visual)
+    # Dem seats by BVAP rank -- numeric
+   dem_seats <- plans |>
+      group_by(draw) |>
+      mutate(bvap = vap_black/total_vap, bvap_rank = rank(bvap)) |>
+      subset_sampled() |>
+      select(draw, district, bvap, bvap_rank, ndv, nrv) |>
+      mutate(dem = ndv > nrv) |>
+      group_by(bvap_rank) |>
+      summarize(dem = mean(dem))
+
+    # Total Black districts that are performing
+    performing <- plans |>
+      subset_sampled() |>
+      group_by(draw) |>
+      summarize(n_black_perf = sum(vap_black/total_vap > 0.3 & ndshare > 0.5)) |>
+      count(n_black_perf)
 }

--- a/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
+++ b/analyses/AL_leg_2020/03_sim_AL_ssd_2020.R
@@ -35,7 +35,7 @@ write_rds(plans, here("data-out/AL_2020/AL_ssd_2020_plans.rds"), compress = "xz"
 cli_process_done()
 
 # The following line is uncommented when viewing validation plots
- plans <- readRDS("data-out/AL_2020/AL_ssd_2020_plans.rds")
+# plans <- readRDS("data-out/AL_2020/AL_ssd_2020_plans.rds")
 
 # Compute summary statistics -----
 cli_process_start("Computing summary statistics for {.pkg AL_ssd_2020}")

--- a/analyses/AL_leg_2020/AL_main_shd.R
+++ b/analyses/AL_leg_2020/AL_main_shd.R
@@ -1,0 +1,5 @@
+setwd("~/fifty-states")
+
+source("analyses/AL_leg_2020/01_prep_AL_leg_2020.R")
+source("analyses/AL_leg_2020/02_setup_AL_leg_2020.R")
+source("analyses/AL_leg_2020/03_sim_AL_shd_2020.R")

--- a/analyses/AL_leg_2020/AL_main_ssd.R
+++ b/analyses/AL_leg_2020/AL_main_ssd.R
@@ -1,0 +1,5 @@
+setwd("~/fifty-states")
+
+source("analyses/AL_leg_2020/01_prep_AL_leg_2020.R")
+source("analyses/AL_leg_2020/02_setup_AL_leg_2020.R")
+source("analyses/AL_leg_2020/03_sim_AL_ssd_2020.R")

--- a/analyses/AL_leg_2020/doc_AL_leg_2020.md
+++ b/analyses/AL_leg_2020/doc_AL_leg_2020.md
@@ -1,0 +1,31 @@
+# 2020 Alabama State House/Senate Districts
+
+## Redistricting requirements
+In Alabama, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Alabama must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve political subdivisions
+5. preserve communities of interest
+6. avoid pairing incumbents
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 15,000 districting plans for Alabama's lower house across 5 independent 
+runs of the SMC algorithm. We introduce a total county splits constraint of strength 1.3 
+and increase the number of merge-split proposals per SMC step to 347 total. The ncores
+argument in redist_smc() was set to 0.
+
+We sample 25,000 districting plans for Alabama's upper house across 5 independent 
+runs of the SMC algorithm. We introduce a total county splits constraint of strength 2.4 
+and increase the number of merge-split proposals per SMC step to 47 total.
+


### PR DESCRIPTION
## Redistricting requirements
In Alabama, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Alabama must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve political subdivisions
5. preserve communities of interest
6. avoid pairing incumbents

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Alabama comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 15,000 districting plans for Alabama's lower house across 5 independent runs of the SMC algorithm. We introduce a total county splits constraint of strength 1.3 and increase the number of merge-split proposals per SMC step to 347 total. The ncores argument in redist_smc() was set to 0.

We sample 25,000 districting plans for Alabama's upper house across 5 independent runs of the SMC algorithm. We introduce a total county splits constraint of strength 2.4 and increase the number of merge-split proposals per SMC step to 47 total.

## Validation

### State House

<img width="567" height="744" alt="Screenshot 2026-07-20 at 6 18 18 PM" src="https://github.com/user-attachments/assets/c96d77c9-dfb0-4911-b966-52dd756f1440" />

```
SMC with Merge-Split MCMC Steps:
10,000 sampled plans of 105
districts on 1,837 units
Plans sampled on Linking Edge
Forest Space using the Uniform
Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 104
• `mh_accept_per_smc` = 347
• `pair_rule` = uniform
Plan diversity 80% range: 0.69 to
0.77
85 rhat values are `NA`
Largest R-hat values for ordered
summary statistics:
             adv_16 
              1.036 
             adv_18 
              1.035 
             adv_20 
              1.027 
             arv_16 
              1.034 
             arv_18 
              1.040 
             arv_20 
              1.034 
     atg_18_dem_sie 
              1.033 
     atg_18_rep_mar 
              1.040 
    comp_bbox_reock 
              1.023 
          comp_edge 
              1.005 
        comp_polsby 
              1.013 
      county_splits 
              1.008 
              e_dem 
              1.007 
              e_dvs 
              1.029 
               egap 
              1.008 
     gov_18_dem_mad 
              1.042 
     gov_18_rep_ive 
              1.043 
        muni_splits 
              1.009 
            ndshare 
              1.028 
                ndv 
              1.028 
                nrv 
              1.042 
              pbias 
              1.004 
           plan_dev 
              1.002 
           pop_aian 
              1.043 
          pop_asian 
              1.038 
          pop_black 
              1.035 
           pop_hisp 
            ❌1.057 
           pop_nhpi 
              1.028 
          pop_other 
              1.038 
        pop_overlap 
              1.022 
            pop_two 
              1.044 
          pop_white 
              1.032 
             pr_dem 
              1.009 
     pre_16_dem_cli 
              1.039 
     pre_16_rep_tru 
              1.029 
     pre_20_dem_bid 
              1.025 
     pre_20_rep_tru 
              1.033 
     sos_18_dem_mil 
              1.024 
     sos_18_rep_mer 
              1.042 
total_county_splits 
              1.015 
  total_muni_splits 
              1.004 
          total_vap 
              1.021 
     uss_16_dem_cru 
              1.026 
     uss_16_rep_she 
              1.029 
     uss_20_dem_jon 
              1.031 
     uss_20_rep_tub 
              1.034 
           vap_aian 
              1.044 
          vap_asian 
              1.038 
          vap_black 
              1.040 
           vap_hisp 
            ❌1.057 
           vap_nhpi 
              1.023 
          vap_other 
              1.038 
            vap_two 
              1.029 
          vap_white 
              1.034 
• R-hat ≤ 1.05: 5583
• 1.05 < R-hat ≤ 1.1: 2
• R-hat > 1.1: 0
• Total R-hats: 5585
ℹ ALERT: Chains have weakly converged.
Sampling diagnostics for SMC run
1 of 5 (10,000 samples)
          Eff. samples (%)
Split 1        471 (15.7%)
Split 2        372 (12.4%)
Split 3        673 (22.4%)
Split 4        845 (28.2%)
Split 5        972 (32.4%)
Split 6      1,086 (36.2%)
Split 7      1,303 (43.4%)
Split 8      1,401 (46.7%)
Split 9      1,509 (50.3%)
Split 10     1,630 (54.3%)
Split 11     1,693 (56.4%)
Split 12     1,804 (60.1%)
Split 13     1,899 (63.3%)
Split 14     1,996 (66.5%)
Split 15     2,045 (68.2%)
Split 16     2,093 (69.8%)
Split 17     2,186 (72.9%)
Split 18     2,151 (71.7%)
Split 19     2,202 (73.4%)
Split 20     2,230 (74.3%)
Split 21     2,309 (77.0%)
Split 22     2,316 (77.2%)
Split 23     2,348 (78.3%)
Split 24     2,362 (78.7%)
Split 25     2,417 (80.6%)
Split 26     2,414 (80.5%)
Split 27     2,463 (82.1%)
Split 28     2,482 (82.7%)
Split 29     2,487 (82.9%)
Split 30     2,521 (84.0%)
Split 31     2,529 (84.3%)
Split 32     2,543 (84.8%)
Split 33     2,542 (84.7%)
Split 34     2,575 (85.8%)
Split 35     2,549 (85.0%)
Split 36     2,591 (86.4%)
Split 37     2,604 (86.8%)
Split 38     2,614 (87.1%)
Split 39     2,625 (87.5%)
Split 40     2,640 (88.0%)
Split 41     2,679 (89.3%)
Split 42     2,666 (88.9%)
Split 43     2,676 (89.2%)
Split 44     2,675 (89.2%)
Split 45     2,691 (89.7%)
Split 46     2,724 (90.8%)
Split 47     2,707 (90.2%)
Split 48     2,733 (91.1%)
Split 49     2,717 (90.6%)
Split 50     2,725 (90.8%)
Split 51     2,751 (91.7%)
Split 52     2,760 (92.0%)
Split 53     2,765 (92.2%)
Split 54     2,757 (91.9%)
Split 55     2,765 (92.2%)
Split 56     2,774 (92.5%)
Split 57     2,778 (92.6%)
Split 58     2,788 (92.9%)
Split 59     2,791 (93.0%)
Split 60     2,801 (93.4%)
Split 61     2,798 (93.3%)
Split 62     2,808 (93.6%)
Split 63     2,803 (93.4%)
Split 64     2,816 (93.9%)
Split 65     2,822 (94.1%)
Split 66     2,823 (94.1%)
Split 67     2,828 (94.3%)
Split 68     2,839 (94.6%)
Split 69     2,833 (94.4%)
Split 70     2,836 (94.5%)
Split 71     2,854 (95.1%)
Split 72     2,847 (94.9%)
Split 73     2,850 (95.0%)
Split 74     2,858 (95.3%)
Split 75     2,866 (95.5%)
Split 76     2,865 (95.5%)
Split 77     2,864 (95.5%)
Split 78     2,866 (95.5%)
Split 79     2,878 (95.9%)
Split 80     2,873 (95.8%)
Split 81     2,871 (95.7%)
Split 82     2,883 (96.1%)
Split 83     2,881 (96.0%)
Split 84     2,882 (96.1%)
Split 85     2,893 (96.4%)
Split 86     2,894 (96.5%)
Split 87     2,896 (96.5%)
Split 88     2,898 (96.6%)
Split 89     2,900 (96.7%)
Split 90     2,893 (96.4%)
Split 91     2,906 (96.9%)
Split 92     2,906 (96.9%)
Split 93     2,903 (96.8%)
Split 94     2,915 (97.2%)
Split 95     2,906 (96.9%)
Split 96     2,912 (97.1%)
Split 97     2,914 (97.1%)
Split 98     2,917 (97.2%)
Split 99     2,915 (97.2%)
Split 100    2,927 (97.6%)
Split 101    2,931 (97.7%)
Split 102    2,930 (97.7%)
Split 103    2,932 (97.7%)
Split 104    2,943 (98.1%)
Resample     2,943 (98.1%)
          Acc. rate Log wgt. sd
Split 1      100.0%        2.67
Split 2       98.7%        4.46
Split 3       97.2%        3.87
Split 4       95.8%        3.45
Split 5       94.5%        3.13
Split 6       93.0%        2.79
Split 7       91.6%        2.35
Split 8       91.1%        2.28
Split 9       89.8%        2.06
Split 10      88.9%        1.89
Split 11      87.0%        1.85
Split 12      86.1%        1.66
Split 13      86.1%        1.42
Split 14      85.5%        1.36
Split 15      84.0%        1.28
Split 16      83.1%        1.21
Split 17      81.6%        1.08
Split 18      79.5%        1.04
Split 19      79.6%        1.04
Split 20      79.3%        0.95
Split 21      77.4%        0.91
Split 22      77.1%        0.91
Split 23      74.5%        0.91
Split 24      74.0%        0.82
Split 25      74.5%        0.78
Split 26      71.5%        0.81
Split 27      70.3%        0.75
Split 28      69.3%        0.70
Split 29      70.2%        0.69
Split 30      68.3%        0.66
Split 31      68.4%        0.64
Split 32      67.9%        0.63
Split 33      65.4%        0.65
Split 34      64.8%        0.60
Split 35      63.6%        0.59
Split 36      63.8%        0.54
Split 37      62.3%        0.54
Split 38      60.4%        0.54
Split 39      60.6%        0.55
Split 40      59.3%        0.53
Split 41      57.8%        0.46
Split 42      57.0%        0.49
Split 43      55.9%        0.47
Split 44      55.3%        0.48
Split 45      54.8%        0.46
Split 46      54.7%        0.44
Split 47      52.7%        0.42
Split 48      52.6%        0.44
Split 49      51.6%        0.43
Split 50      50.2%        0.41
Split 51      49.4%        0.40
Split 52      48.8%        0.40
Split 53      48.2%        0.37
Split 54      46.7%        0.38
Split 55      46.2%        0.37
Split 56      44.8%        0.34
Split 57      45.5%        0.36
Split 58      44.7%        0.34
Split 59      43.3%        0.33
Split 60      43.7%        0.32
Split 61      41.4%        0.36
Split 62      41.3%        0.32
Split 63      41.2%        0.33
Split 64      39.9%        0.32
Split 65      39.3%        0.31
Split 66      39.3%        0.28
Split 67      38.0%        0.30
Split 68      36.9%        0.30
Split 69      38.3%        0.30
Split 70      37.2%        0.30
Split 71      35.4%        0.27
Split 72      35.7%        0.28
Split 73      35.2%        0.26
Split 74      33.8%        0.27
Split 75      33.7%        0.25
Split 76      32.7%        0.24
Split 77      33.2%        0.24
Split 78      32.0%        0.24
Split 79      31.2%        0.24
Split 80      31.5%        0.24
Split 81      31.1%        0.24
Split 82      30.2%        0.22
Split 83      29.3%        0.23
Split 84      28.9%        0.23
Split 85      28.0%        0.21
Split 86      27.7%        0.21
Split 87      27.1%        0.21
Split 88      26.9%        0.20
Split 89      26.2%        0.21
Split 90      25.9%        0.22
Split 91      25.1%        0.20
Split 92      24.9%        0.19
Split 93      24.4%        0.20
Split 94      23.9%        0.18
Split 95      23.5%        0.19
Split 96      22.8%        0.19
Split 97      22.4%        0.19
Split 98      22.2%        0.19
Split 99      20.8%        0.19
Split 100     21.1%        0.17
Split 101     20.3%        0.16
Split 102     19.7%        0.17
Split 103     19.6%        0.17
Split 104     18.1%        0.15
Resample        NA%          NA
           Max. unique 
Split 1   1,917 (101%) 
Split 2     962 ( 51%) 
Split 3     873 ( 46%) 
Split 4   1,015 ( 54%) 
Split 5   1,166 ( 61%) 
Split 6   1,220 ( 64%) 
Split 7   1,310 ( 69%) 
Split 8   1,402 ( 74%) 
Split 9   1,426 ( 75%) 
Split 10  1,497 ( 79%) 
Split 11  1,520 ( 80%) 
Split 12  1,565 ( 83%) 
Split 13  1,568 ( 83%) 
Split 14  1,588 ( 84%) 
Split 15  1,648 ( 87%) 
Split 16  1,671 ( 88%) 
Split 17  1,657 ( 87%) 
Split 18  1,742 ( 92%) 
Split 19  1,687 ( 89%) 
Split 20  1,700 ( 90%) 
Split 21  1,721 ( 91%) 
Split 22  1,748 ( 92%) 
Split 23  1,759 ( 93%) 
Split 24  1,719 ( 91%) 
Split 25  1,730 ( 91%) 
Split 26  1,752 ( 92%) 
Split 27  1,766 ( 93%) 
Split 28  1,755 ( 93%) 
Split 29  1,779 ( 94%) 
Split 30  1,772 ( 93%) 
Split 31  1,809 ( 95%) 
Split 32  1,803 ( 95%) 
Split 33  1,790 ( 94%) 
Split 34  1,795 ( 95%) 
Split 35  1,812 ( 96%) 
Split 36  1,832 ( 97%) 
Split 37  1,822 ( 96%) 
Split 38  1,788 ( 94%) 
Split 39  1,814 ( 96%) 
Split 40  1,815 ( 96%) 
Split 41  1,812 ( 96%) 
Split 42  1,836 ( 97%) 
Split 43  1,820 ( 96%) 
Split 44  1,847 ( 97%) 
Split 45  1,799 ( 95%) 
Split 46  1,843 ( 97%) 
Split 47  1,820 ( 96%) 
Split 48  1,813 ( 96%) 
Split 49  1,816 ( 96%) 
Split 50  1,826 ( 96%) 
Split 51  1,797 ( 95%) 
Split 52  1,836 ( 97%) 
Split 53  1,795 ( 95%) 
Split 54  1,854 ( 98%) 
Split 55  1,852 ( 98%) 
Split 56  1,840 ( 97%) 
Split 57  1,860 ( 98%) 
Split 58  1,823 ( 96%) 
Split 59  1,892 (100%) 
Split 60  1,836 ( 97%) 
Split 61  1,838 ( 97%) 
Split 62  1,829 ( 96%) 
Split 63  1,828 ( 96%) 
Split 64  1,847 ( 97%) 
Split 65  1,837 ( 97%) 
Split 66  1,845 ( 97%) 
Split 67  1,869 ( 99%) 
Split 68  1,848 ( 97%) 
Split 69  1,850 ( 98%) 
Split 70  1,847 ( 97%) 
Split 71  1,851 ( 98%) 
Split 72  1,844 ( 97%) 
Split 73  1,832 ( 97%) 
Split 74  1,839 ( 97%) 
Split 75  1,871 ( 99%) 
Split 76  1,859 ( 98%) 
Split 77  1,868 ( 99%) 
Split 78  1,830 ( 97%) 
Split 79  1,833 ( 97%) 
Split 80  1,870 ( 99%) 
Split 81  1,863 ( 98%) 
Split 82  1,835 ( 97%) 
Split 83  1,880 ( 99%) 
Split 84  1,821 ( 96%) 
Split 85  1,868 ( 99%) 
Split 86  1,850 ( 98%) 
Split 87  1,858 ( 98%) 
Split 88  1,843 ( 97%) 
Split 89  1,842 ( 97%) 
Split 90  1,857 ( 98%) 
Split 91  1,829 ( 96%) 
Split 92  1,835 ( 97%) 
Split 93  1,824 ( 96%) 
Split 94  1,820 ( 96%) 
Split 95  1,816 ( 96%) 
Split 96  1,799 ( 95%) 
Split 97  1,822 ( 96%) 
Split 98  1,803 ( 95%) 
Split 99  1,761 ( 93%) 
Split 100 1,761 ( 93%) 
Split 101 1,729 ( 91%) 
Split 102 1,733 ( 91%) 
Split 103 1,592 ( 84%) 
Split 104 1,308 ( 69%) 
Resample  2,827 (149%) 

Sampling diagnostics for
Mergesplit Steps of SMC run 1 of
5 (10,000 samples)
            Acc. rate
MS Step 1       23.0%
MS Step 2       21.8%
MS Step 3       23.0%
MS Step 4       24.5%
MS Step 5       25.8%
MS Step 6       27.2%
MS Step 7       28.3%
MS Step 8       29.4%
MS Step 9       30.4%
MS Step 10      31.1%
MS Step 11      32.1%
MS Step 12      32.6%
MS Step 13      33.3%
MS Step 14      33.7%
MS Step 15      34.2%
MS Step 16      34.7%
MS Step 17      35.0%
MS Step 18      35.4%
MS Step 19      35.6%
MS Step 20      36.0%
MS Step 21      36.2%
MS Step 22      36.5%
MS Step 23      36.6%
MS Step 24      36.8%
MS Step 25      36.9%
MS Step 26      37.0%
MS Step 27      37.2%
MS Step 28      37.3%
MS Step 29      37.4%
MS Step 30      37.4%
MS Step 31      37.4%
MS Step 32      37.5%
MS Step 33      37.5%
MS Step 34      37.5%
MS Step 35      37.6%
MS Step 36      37.6%
MS Step 37      37.6%
MS Step 38      37.6%
MS Step 39      37.6%
MS Step 40      37.6%
MS Step 41      37.5%
MS Step 42      37.6%
MS Step 43      37.5%
MS Step 44      37.5%
MS Step 45      37.5%
MS Step 46      37.4%
MS Step 47      37.4%
MS Step 48      37.4%
MS Step 49      37.2%
MS Step 50      37.2%
MS Step 51      37.2%
MS Step 52      37.1%
MS Step 53      37.1%
MS Step 54      37.0%
MS Step 55      37.0%
MS Step 56      36.9%
MS Step 57      36.8%
MS Step 58      36.8%
MS Step 59      36.7%
MS Step 60      36.6%
MS Step 61      36.6%
MS Step 62      36.5%
MS Step 63      36.4%
MS Step 64      36.4%
MS Step 65      36.3%
MS Step 66      36.3%
MS Step 67      36.2%
MS Step 68      36.1%
MS Step 69      36.0%
MS Step 70      36.0%
MS Step 71      35.9%
MS Step 72      35.8%
MS Step 73      35.7%
MS Step 74      35.7%
MS Step 75      35.5%
MS Step 76      35.6%
MS Step 77      35.5%
MS Step 78      35.4%
MS Step 79      35.3%
MS Step 80      35.2%
MS Step 81      35.1%
MS Step 82      35.1%
MS Step 83      35.0%
MS Step 84      34.8%
MS Step 85      34.8%
MS Step 86      34.6%
MS Step 87      34.6%
MS Step 88      34.5%
MS Step 89      34.4%
MS Step 90      34.3%
MS Step 91      34.3%
MS Step 92      34.2%
MS Step 93      34.1%
MS Step 94      34.0%
MS Step 95      34.0%
MS Step 96      33.9%
MS Step 97      33.8%
MS Step 98      33.7%
MS Step 99      33.7%
MS Step 100     33.6%
MS Step 101     33.6%
MS Step 102     33.4%
MS Step 103     33.4%
MS Step 104     33.2%
            MS Steps per Plan
MS Step 1                 347
MS Step 2                1735
MS Step 3                1735
MS Step 4                1735
MS Step 5                1735
MS Step 6                1388
MS Step 7                1388
MS Step 8                1388
MS Step 9                1388
MS Step 10               1388
MS Step 11               1388
MS Step 12               1388
MS Step 13               1388
MS Step 14               1388
MS Step 15               1041
MS Step 16               1041
MS Step 17               1041
MS Step 18               1041
MS Step 19               1041
MS Step 20               1041
MS Step 21               1041
MS Step 22               1041
MS Step 23               1041
MS Step 24               1041
MS Step 25               1041
MS Step 26               1041
MS Step 27               1041
MS Step 28               1041
MS Step 29               1041
MS Step 30               1041
MS Step 31               1041
MS Step 32               1041
MS Step 33               1041
MS Step 34               1041
MS Step 35               1041
MS Step 36               1041
MS Step 37               1041
MS Step 38               1041
MS Step 39               1041
MS Step 40               1041
MS Step 41               1041
MS Step 42               1041
MS Step 43               1041
MS Step 44               1041
MS Step 45               1041
MS Step 46               1041
MS Step 47               1041
MS Step 48               1041
MS Step 49               1041
MS Step 50               1041
MS Step 51               1041
MS Step 52               1041
MS Step 53               1041
MS Step 54               1041
MS Step 55               1041
MS Step 56               1041
MS Step 57               1041
MS Step 58               1041
MS Step 59               1041
MS Step 60               1041
MS Step 61               1041
MS Step 62               1041
MS Step 63               1041
MS Step 64               1041
MS Step 65               1041
MS Step 66               1041
MS Step 67               1041
MS Step 68               1041
MS Step 69               1041
MS Step 70               1041
MS Step 71               1041
MS Step 72               1041
MS Step 73               1041
MS Step 74               1041
MS Step 75               1041
MS Step 76               1041
MS Step 77               1041
MS Step 78               1041
MS Step 79               1041
MS Step 80               1041
MS Step 81               1041
MS Step 82               1041
MS Step 83               1041
MS Step 84               1041
MS Step 85               1041
MS Step 86               1041
MS Step 87               1041
MS Step 88               1041
MS Step 89               1041
MS Step 90               1041
MS Step 91               1041
MS Step 92               1041
MS Step 93               1041
MS Step 94               1041
MS Step 95               1041
MS Step 96               1041
MS Step 97               1041
MS Step 98               1041
MS Step 99               1041
MS Step 100              1041
MS Step 101              1041
MS Step 102              1041
MS Step 103              1041
MS Step 104              1041

•  Watch out for low effective
samples, very low acceptance
rates (less than 1%), large std.
devs. of the log weights (more
than 3 or so), and low numbers of
unique plans. R-hat values for
summary statistics should be
between 1 and 1.05.
Warning message:
In UseMethod("depth") :
  no applicable method for 'depth' applied to an object of class "NULL"
```

### State Senate

<img width="573" height="744" alt="Screenshot 2026-07-20 at 6 23 31 PM" src="https://github.com/user-attachments/assets/5707bbc4-5280-4cbb-aa02-634591ef6858" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 35
districts on 1,837 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid
Edge forward kernel.
SMC Parameters:                       
• `weight_type` = optimal             
• `seq_alpha` = 1                     
• `pop_temper` = 0                    
Mergesplit Parameters:                
• `total_ms_steps` = 34               
• `mh_accept_per_smc` = 47            
• `pair_rule` = uniform               
Plan diversity 80% range: 0.69 to 0.83
22 rhat values are `NA`or NJ_shd_2020

Largest R-hat values for ordered summary statistics:
             adv_16              adv_18 
              1.010               1.011 
             adv_20              arv_16 
              1.013               1.019 
             arv_18              arv_20 
              1.019               1.015 
     atg_18_dem_sie      atg_18_rep_mar 
              1.017               1.019 
    comp_bbox_reock           comp_edge 
              1.010               1.008 
        comp_polsby       county_splits 
              1.006               1.005 
              e_dem               e_dvs 
              1.003               1.010 
               egap      gov_18_dem_mad 
              1.002               1.015 
     gov_18_rep_ive         muni_splits 
              1.018               1.002 
            ndshare                 ndv 
              1.011               1.010 
                nrv               pbias 
              1.019               1.007 
           plan_dev            pop_aian 
              1.002               1.012 
          pop_asian           pop_black 
              1.014               1.021 
           pop_hisp            pop_nhpi 
              1.016               1.017 
          pop_other         pop_overlap 
              1.010               1.019 
            pop_two           pop_white 
              1.011               1.013 
             pr_dem      pre_16_dem_cli 
              1.004               1.009 
     pre_16_rep_tru      pre_20_dem_bid 
              1.019               1.013 
     pre_20_rep_tru      sos_18_dem_mil 
              1.014               1.014 
     sos_18_rep_mer total_county_splits 
              1.019               1.003 
  total_muni_splits           total_vap 
              1.002               1.003 
     uss_16_dem_cru      uss_16_rep_she 
              1.009               1.019 
     uss_20_dem_jon      uss_20_rep_tub 
              1.013               1.016 
           vap_aian           vap_asian 
              1.012               1.014 
          vap_black            vap_hisp 
              1.019               1.011 
           vap_nhpi           vap_other 
              1.018               1.018 
            vap_two           vap_white 
              1.013               1.013 
• R-hat ≤ 1.05: 1868                  
• 1.05 < R-hat ≤ 1.1: 0               
• R-hat > 1.1: 0                      
• Total R-hats: 1868                  
Sampling diagnostics for SMC run 1 of 5 (10,000
samples)
         Eff. samples (%) Acc. rate Log wgt. sd
Split 1     1,131 (22.6%)    100.0%        2.36
Split 2       987 (19.7%)     97.3%        3.95
Split 3     1,172 (23.4%)     93.6%        3.42
Split 4     1,316 (26.3%)     91.0%        2.99
Split 5     1,435 (28.7%)     87.0%        2.70
Split 6     1,594 (31.9%)     85.4%        2.50
Split 7     1,701 (34.0%)     81.4%        2.30
Split 8     2,022 (40.4%)     78.8%        2.09
Split 9     2,133 (42.7%)     75.5%        1.96
Split 10    2,175 (43.5%)     73.2%        1.87
Split 11    2,487 (49.7%)     70.9%        1.72
Split 12    2,550 (51.0%)     67.9%        1.62
Split 13    2,691 (53.8%)     65.9%        1.51
Split 14    2,779 (55.6%)     62.5%        1.44
Split 15    2,936 (58.7%)     60.5%        1.37
Split 16    2,928 (58.6%)     58.0%        1.31
Split 17    3,086 (61.7%)     54.4%        1.28
Split 18    3,189 (63.8%)     53.9%        1.18
Split 19    3,257 (65.1%)     51.5%        1.18
Split 20    3,308 (66.2%)     48.8%        1.07
Split 21    3,344 (66.9%)     47.5%        1.10
Split 22    3,430 (68.6%)     45.6%        1.04
Split 23    3,514 (70.3%)     43.9%        1.00
Split 24    3,625 (72.5%)     41.7%        0.91
Split 25    3,728 (74.6%)     39.4%        0.84
Split 26    3,695 (73.9%)     38.2%        0.86
Split 27    3,753 (75.1%)     37.1%        0.81
Split 28    3,755 (75.1%)     35.1%        0.78
Split 29    3,924 (78.5%)     34.2%        0.70
Split 30    3,890 (77.8%)     33.1%        0.70
Split 31    3,935 (78.7%)     31.8%        0.67
Split 32    3,986 (79.7%)     30.9%        0.63
Split 33    4,039 (80.8%)     29.4%        0.61
Split 34    4,076 (81.5%)     27.4%        0.58
Resample    4,076 (81.5%)       NA%          NA
          Max. unique 
Split 1  3,166 (100%) 
Split 2  1,770 ( 56%) 
Split 3  1,650 ( 52%) 
Split 4  1,839 ( 58%) 
Split 5  1,923 ( 61%) 
Split 6  2,019 ( 64%) 
Split 7  2,138 ( 68%) 
Split 8  2,211 ( 70%) 
Split 9  2,277 ( 72%) 
Split 10 2,375 ( 75%) 
Split 11 2,389 ( 76%) 
Split 12 2,489 ( 79%) 
Split 13 2,524 ( 80%) 
Split 14 2,539 ( 80%) 
Split 15 2,585 ( 82%) 
Split 16 2,649 ( 84%) 
Split 17 2,611 ( 83%) 
Split 18 2,687 ( 85%) 
Split 19 2,692 ( 85%) 
Split 20 2,792 ( 88%) 
Split 21 2,712 ( 86%) 
Split 22 2,736 ( 87%) 
Split 23 2,776 ( 88%) 
Split 24 2,759 ( 87%) 
Split 25 2,751 ( 87%) 
Split 26 2,846 ( 90%) 
Split 27 2,826 ( 89%) 
Split 28 2,839 ( 90%) 
Split 29 2,828 ( 89%) 
Split 30 2,844 ( 90%) 
Split 31 2,798 ( 89%) 
Split 32 2,815 ( 89%) 
Split 33 2,756 ( 87%) 
Split 34 2,587 ( 82%) 
Resample 4,102 (130%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1
of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      29.6%                47
MS Step 2      27.2%               188
MS Step 3      27.3%               188
MS Step 4      27.4%               188
MS Step 5      27.5%               188
MS Step 6      27.5%               188
MS Step 7      27.5%               188
MS Step 8      27.5%               188
MS Step 9      27.7%               188
MS Step 10     27.7%               188
MS Step 11     27.6%               188
MS Step 12     27.8%               188
MS Step 13     27.8%               188
MS Step 14     27.9%               188
MS Step 15     27.9%               188
MS Step 16     27.7%               188
MS Step 17     27.8%               188
MS Step 18     27.7%               188
MS Step 19     27.9%               188
MS Step 20     27.8%               188
MS Step 21     27.9%               188
MS Step 22     27.8%               188
MS Step 23     27.9%               188
MS Step 24     27.9%               188
MS Step 25     27.8%               188
MS Step 26     27.7%               188
MS Step 27     27.8%               188
MS Step 28     27.8%               188
MS Step 29     27.7%               188
MS Step 30     27.6%               188
MS Step 31     27.7%               188
MS Step 32     27.8%               188
MS Step 33     27.9%               188
MS Step 34     27.9%               188

•  Watch out for low effective samples, very low
acceptance rates (less than 1%), large std. devs. of
the log weights (more than 3 or so), and low numbers
of unique plans. R-hat values for summary statistics
should be between 1 and 1.05.
ℹ Running simulations for NJ_shd_2020
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny