### PR TITLE
2020 Louisiana State House/Senate Districts

### DIFF
--- a/analyses/LA_leg_2020/01_prep_LA_leg_2020.R
+++ b/analyses/LA_leg_2020/01_prep_LA_leg_2020.R
@@ -1,0 +1,113 @@
+###############################################################################
+# Download and prepare data for `LA_leg_2020` analysis
+# © ALARM Project, June 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg LA_leg_2020}")
+
+path_data <- download_redistricting_file("LA", "data-raw/LA", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/LA_2020/shp_vtd.rds"
+perim_path <- "data-out/LA_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong LA} shapefile")
+  # read in redistricting data
+  la_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+    join_vtd_shapefile(year = 2020) |>
+    st_transform(EPSG$LA)  |>
+    rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+  # add municipalities
+  d_muni <- make_from_baf("LA", "INCPLACE_CDP", "VTD", year = 2020)  |>
+    mutate(GEOID = paste0(censable::match_fips("LA"), vtd)) |>
+    select(-vtd)
+  d_ssd <- make_from_baf("LA", "SLDU", "VTD", year = 2020)  |>
+    transmute(GEOID = paste0(censable::match_fips("LA"), vtd),
+              ssd_2010 = as.integer(sldu))
+  d_shd <- make_from_baf("LA", "SLDL", "VTD", year = 2020)  |>
+    transmute(GEOID = paste0(censable::match_fips("LA"), vtd),
+              shd_2010 = as.integer(sldl))
+
+  la_shp <- la_shp |>
+    left_join(d_muni, by = "GEOID") |>
+    left_join(d_ssd, by = "GEOID") |>
+    left_join(d_shd, by = "GEOID") |>
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+    relocate(muni, county_muni, ssd_2010, .after = county) |>
+    relocate(muni, county_muni, shd_2010, .after = county)
+
+  # add the enacted plan
+  la_shp <- la_shp |>
+    left_join(y = leg_from_baf(state = "LA"), by = "GEOID") |>
+    mutate(ssd_2020 = case_match(
+      GEOID,
+      "22051ZZZZZZ" ~ "009",
+      "22071ZZZZZZ" ~ "004",
+      "22103ZZZZZZ" ~ "011",
+      "22105ZZZZZZ" ~ "037",
+      .default = ssd_2020
+    )) |>
+    mutate(ssd_2020 = as.integer(ssd_2020))
+
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = la_shp,
+                             perim_path = here(perim_path)) |>
+    invisible()
+
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    la_shp <- rmapshaper::ms_simplify(la_shp, keep = 0.05,
+                                      keep_shapes = TRUE) |>
+      suppressWarnings()
+  }
+
+  # create adjacency graph
+  la_shp$adj <- adjacency(la_shp)
+
+  # add bridges
+  la_shp$adj <- la_shp$adj |>
+    geomander::add_edge(
+      v1 = match("2212100001C", la_shp$GEOID),
+      v2 = match("22047000021", la_shp$GEOID),
+      zero = TRUE
+    ) |>
+    geomander::add_edge(
+      v1 = match("220570005-2", la_shp$GEOID),
+      v2 = match("22057002-14", la_shp$GEOID),
+      zero = TRUE
+    )
+
+  # check max number of connected components
+  # 1 is one fully connected component, more is worse
+  ccm(la_shp$adj, la_shp$ssd_2020)
+  ccm(la_shp$adj, la_shp$shd_2020)
+
+  la_shp <- la_shp |>
+    fix_geo_assignment(muni)
+
+  write_rds(la_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  la_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong LA} shapefile")
+}
+

--- a/analyses/LA_leg_2020/02_setup_LA_leg_2020.R
+++ b/analyses/LA_leg_2020/02_setup_LA_leg_2020.R
@@ -1,0 +1,35 @@
+###############################################################################
+# Set up redistricting simulation for `LA_leg_2020`
+# © ALARM Project, June 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg LA_leg_2020}")
+
+map_ssd <- redist_map(la_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = la_shp$adj)
+
+map_shd <- redist_map(la_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = la_shp$adj)
+
+# Fill missing 2010 assignments for zero-population placeholder VTDs
+# using their corresponding 2020 enacted district assignments
+map_ssd <- map_ssd |>
+  mutate(ssd_2010 = if_else(is.na(ssd_2010), ssd_2020, ssd_2010))
+map_shd <- map_shd |>
+  mutate(shd_2010 = if_else(is.na(shd_2010), shd_2020, shd_2010))
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_shd)))
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "LA_SSD_2020"
+attr(map_shd, "analysis_name") <- "LA_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/LA_2020/LA_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/LA_2020/LA_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/LA_leg_2020/03_sim_LA_shd_2020.R
+++ b/analyses/LA_leg_2020/03_sim_LA_shd_2020.R
@@ -1,0 +1,109 @@
+###############################################################################
+# Simulate plans for `LA_shd_2020` SHD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_shd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3) + 250
+
+constr <- redist_constr(map_shd) |>
+  add_constr_grp_hinge(15, vap_black, vap, 0.45) |>
+  add_constr_grp_hinge(10, vap_black, vap, 0.50) |>
+  add_constr_grp_hinge(4, vap_black, vap, 0.55) |>
+  add_constr_grp_inv_hinge(4, vap_black, vap, 0.78) |>
+  add_constr_polsby(strength = 1.8) |>
+  add_constr_total_splits(3.4, admin = county)
+
+plans <- redist_smc(
+  map_shd,
+  nsims = 2e3, runs = 5,
+  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+  counties = shd_2010,
+  constraints = constr,
+  pop_temper = 0.04,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_2020/LA_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_2020/LA_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+
+  validate_analysis(plans, map_shd)
+  summary(plans)
+
+  # core preservation
+  p_core <- plans |>
+    match_numbers(map_shd$shd_2010) |>
+    hist(pop_overlap)
+
+  print(p_core)
+
+  # enacted black VAP performance
+  enacted_perf <- plans |>
+    filter(draw == "shd_2020") |>
+    summarize(enacted_black_perf = sum(vap_black / total_vap > 0.3 & ndshare > 0.5))
+
+  print(enacted_perf)
+
+  # simulated black VAP performance
+  simulated_perf <- plans |>
+    subset_sampled() |>
+    group_by(draw) |>
+    summarize(n_black_perf = sum(vap_black / total_vap > 0.3 & ndshare > 0.5)) |>
+    count(n_black_perf)
+
+  print(simulated_perf)
+
+  # Black VAP performance plot
+  p_bvap <- redist.plot.distr_qtys(
+    plans,
+    vap_black / total_vap,
+    color_thresh = NULL,
+    color = ifelse(
+      subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+      "#3D77BB",
+      "#B25D4C"
+    ),
+    size = 0.5,
+    alpha = 0.5
+  ) +
+    scale_y_continuous("Percent Black by VAP") +
+    labs(title = "Louisiana Enacted House Plan versus Simulations") +
+    scale_color_manual(values = c(shd_2020 = "black")) +
+    theme_bw()
+
+  print(p_bvap)
+
+}
+
+

--- a/analyses/LA_leg_2020/03_sim_LA_ssd_2020.R
+++ b/analyses/LA_leg_2020/03_sim_LA_ssd_2020.R
@@ -1,0 +1,105 @@
+###############################################################################
+# Simulate plans for `LA_ssd_2020` SSD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg LA_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 550
+
+constr <- redist_constr(map_ssd) |>
+  add_constr_grp_hinge(-1, vap_black, vap, 0.50) |>
+  add_constr_grp_hinge(8,  vap_black, vap, 0.55) |>
+  add_constr_grp_hinge(6,  vap_black, vap, 0.60) |>
+  add_constr_grp_inv_hinge(1.5, vap_black, vap, 0.78)
+
+plans <- redist_smc(
+  map_ssd,
+  nsims = 2e3, runs = 5,
+  ncores = as.integer(Sys.getenv("SLURM_CPUS_PER_TASK")),
+  counties = ssd_2010,
+  constraints = constr,
+  pop_temper = 0.05,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/LA_2020/LA_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg LA_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/LA_2020/LA_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    # core preservation
+    p_core <- plans |>
+      match_numbers(map_ssd$ssd_2010) |>
+      hist(pop_overlap)
+
+    print(p_core)
+
+    # enacted black VAP performance
+    enacted_perf <- plans |>
+      filter(draw == "ssd_2020") |>
+      summarize(enacted_black_perf = sum(vap_black / total_vap > 0.3 & ndshare > 0.5))
+
+    print(enacted_perf)
+
+    # simulated black VAP performance
+    simulated_perf <- plans |>
+      subset_sampled() |>
+      group_by(draw) |>
+      summarize(n_black_perf = sum(vap_black / total_vap > 0.3 & ndshare > 0.5)) |>
+      count(n_black_perf)
+
+    print(simulated_perf)
+
+    # Black VAP performance plot
+    p_bvap <- redist.plot.distr_qtys(
+      plans,
+      vap_black / total_vap,
+      color_thresh = NULL,
+      color = ifelse(
+        subset_sampled(plans)$ndv > subset_sampled(plans)$nrv,
+        "#3D77BB",
+        "#B25D4C"
+      ),
+      size = 0.5,
+      alpha = 0.5
+    ) +
+      scale_y_continuous("Percent Black by VAP") +
+      labs(title = "Louisiana Enacted Senate Plan versus Simulations") +
+      scale_color_manual(values = c(ssd_2020 = "black")) +
+      theme_bw()
+
+    print(p_bvap)
+
+}

--- a/analyses/LA_leg_2020/doc_LA_leg_2020.md
+++ b/analyses/LA_leg_2020/doc_LA_leg_2020.md
@@ -1,0 +1,25 @@
+# 2020 Louisiana State House/Senate Districts
+
+## Redistricting requirements
+In Louisiana, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Louisiana must:
+
+1. be contiguous [NCSL 184]
+2. have equal populations [NCSL 24]
+3. preserve county and municipality boundaries as much as possible [NCSL 184]
+4. preserve cores of prior districts [NCSL 185]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%. To preserve the cores of prior districts, we use the previous SSDs and SHDs as county-like units in the counties argument, which limits splits of prior districts during simulation.
+
+## Data Sources
+Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+Four zero-population placeholder VTDs missing enacted Senate assignments were manually assigned to their corresponding districts. Two adjacency bridges were also added to address disconnected components caused by water separation or VTD geometry.
+
+## Simulation Notes
+We sample 10,000 districting plans for Louisiana's lower house across 5 independent runs of the SMC algorithm. 
+We introduce population tempering and impose Black VAP hinge, inverse-hinge, Polsby–Popper compactness, and county-split constraints. We increase the number of merge-split proposals per SMC step to 285.
+
+We sample 10,000 districting plans for Louisiana's upper house across 5 independent runs of the SMC algorithm. 
+We introduce population tempering and impose Black VAP hinge and inverse-hinge constraints. We increase the number of merge-split proposals per SMC step to 563.


### PR DESCRIPTION
## Redistricting requirements
In Louisiana, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Louisiana must:

1. be contiguous [NCSL 184]
2. have equal populations [NCSL 24]
3. preserve county and municipality boundaries as much as possible [NCSL 184]
4. preserve cores of prior districts [NCSL 185]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%. To preserve the cores of prior districts, we use the previous SSDs and SHDs as county-like units in the counties argument, which limits splits of prior districts during simulation.

## Data Sources
Data for Louisiana comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Four zero-population placeholder VTDs missing enacted Senate assignments were manually assigned to their corresponding districts. Two adjacency bridges were also added to address disconnected components caused by water separation or VTD geometry.

## Simulation Notes
We sample 10,000 districting plans for Louisiana's lower house across 5 independent runs of the SMC algorithm. 
We introduce population tempering and impose Black VAP hinge, inverse-hinge, Polsby–Popper compactness, and county-split constraints. We increase the number of merge-split proposals per SMC step to 285.

We sample 10,000 districting plans for Louisiana's upper house across 5 independent runs of the SMC algorithm. 
We introduce population tempering and impose Black VAP hinge and inverse-hinge constraints. We increase the number of merge-split proposals per SMC step to 563.

## Validation
### State Senate
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/63a8c2ed-0e76-41ef-9a39-3a5092cb6134" />

<img width="751" height="728" alt="image" src="https://github.com/user-attachments/assets/c8326c9b-9038-40cc-beeb-d8111fb84def" />

<img width="725" height="589" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/99b46649-72b6-458e-a283-e73337a05f7f" />

```
 enacted_black_perf
               <int>
1                 11

  n_black_perf    n
1            8   29
2            9  483
3           10 2753
4           11 4455
5           12 1942
6           13  315
7           14   23
```

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 39 districts on 3,540 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.05
Mergesplit Parameters:
• `total_ms_steps` = 38
• `mh_accept_per_smc` = 563
• `pair_rule` = uniform
Plan diversity 80% range: 0.34 to 0.50
32 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20 
              1.004               1.006               1.005               1.003               1.003               1.004 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits               e_dem               e_dvs 
              1.003               1.005               1.005               1.005               1.002               1.005 
               egap         muni_splits             ndshare                 ndv                 nrv               pbias 
              1.002               1.004               1.004               1.006               1.003               1.001 
           plan_dev            pop_aian           pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.000               1.003               1.009               1.006               1.004               1.005 
          pop_other         pop_overlap             pop_two           pop_white              pr_dem      pre_16_dem_cli 
              1.004               1.005               1.005               1.005               1.002               1.005 
     pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru      sos_18_dem_col      sos_18_dem_fre      sos_18_rep_ard 
              1.004               1.005               1.004               1.004               1.007               1.004 
     sos_18_rep_clo      sos_18_rep_cro      sos_18_rep_edm      sos_18_rep_ken      sos_18_rep_sto     sos_r18_dem_col 
              1.005               1.006               1.007               1.003               1.008               1.007 
    sos_r18_rep_ard total_county_splits   total_muni_splits           total_vap      uss_16_dem_cam      uss_16_dem_edw 
              1.003               1.001               1.002               1.001               1.006               1.005 
     uss_16_dem_fay      uss_16_dem_lan      uss_16_dem_men      uss_16_dem_pel      uss_16_dem_wil      uss_16_rep_bou 
              1.007               1.007               1.006               1.005               1.006               1.006 
     uss_16_rep_cao      uss_16_rep_cra      uss_16_rep_duk      uss_16_rep_fle      uss_16_rep_ken      uss_16_rep_man 
              1.007               1.005               1.009               1.006               1.004               1.003 
     uss_16_rep_mar      uss_16_rep_pat      uss_20_dem_edw      uss_20_dem_kni      uss_20_dem_per      uss_20_dem_pie 
              1.003               1.004               1.006               1.006               1.004               1.005 
     uss_20_dem_wen      uss_20_rep_cas      uss_20_rep_mur     uss_r16_dem_cam     uss_r16_rep_ken            vap_aian 
              1.004               1.004               1.003               1.008               1.003               1.004 
          vap_asian           vap_black            vap_hisp            vap_nhpi           vap_other             vap_two 
              1.008               1.005               1.003               1.004               1.003               1.005 
          vap_white 
              1.004 
• R-hat ≤ 1.05: 3049
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3049
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique    
Split 1          7 (0.3%)    100.0%        1.69 1,262 (100%)  * 
Split 2         40 (2.0%)     99.4%        1.72   164 ( 13%)  * 
Split 3        108 (5.4%)     97.5%        1.52   457 ( 36%)    
Split 4         65 (3.3%)     96.0%        1.53   612 ( 48%)  * 
Split 5       305 (15.3%)     95.8%        1.60   597 ( 47%)    
Split 6       411 (20.6%)     95.3%        1.42   790 ( 62%)    
Split 7       580 (29.0%)     94.6%        1.38   828 ( 65%)    
Split 8       470 (23.5%)     93.4%        1.34   916 ( 72%)    
Split 9       509 (25.4%)     92.3%        1.26   880 ( 70%)    
Split 10      895 (44.7%)     92.7%        1.26   965 ( 76%)    
Split 11      896 (44.8%)     90.6%        1.24   981 ( 78%)    
Split 12      995 (49.7%)     90.7%        1.16   991 ( 78%)    
Split 13    1,089 (54.4%)     88.3%        1.09 1,015 ( 80%)    
Split 14    1,100 (55.0%)     88.5%        1.08 1,053 ( 83%)    
Split 15    1,031 (51.5%)     86.0%        1.10 1,058 ( 84%)    
Split 16    1,101 (55.1%)     83.5%        1.17 1,014 ( 80%)    
Split 17    1,205 (60.3%)     83.7%        1.00 1,057 ( 84%)    
Split 18    1,212 (60.6%)     82.9%        0.95 1,085 ( 86%)    
Split 19    1,270 (63.5%)     80.8%        0.94 1,078 ( 85%)    
Split 20    1,234 (61.7%)     76.5%        0.86 1,079 ( 85%)    
Split 21    1,244 (62.2%)     77.0%        0.82 1,071 ( 85%)    
Split 22    1,314 (65.7%)     75.9%        0.82 1,116 ( 88%)    
Split 23    1,365 (68.3%)     73.5%        0.79 1,110 ( 88%)    
Split 24    1,375 (68.8%)     70.6%        0.81 1,125 ( 89%)    
Split 25    1,355 (67.8%)     69.1%        0.79 1,137 ( 90%)    
Split 26    1,384 (69.2%)     67.7%        0.78 1,116 ( 88%)    
Split 27    1,415 (70.8%)     64.8%        0.78 1,119 ( 89%)    
Split 28    1,474 (73.7%)     63.3%        0.78 1,115 ( 88%)    
Split 29    1,453 (72.6%)     62.1%        0.74 1,142 ( 90%)    
Split 30    1,511 (75.5%)     59.1%        0.72 1,137 ( 90%)    
Split 31    1,527 (76.3%)     57.0%        0.66 1,153 ( 91%)    
Split 32    1,553 (77.6%)     54.2%        0.65 1,128 ( 89%)    
Split 33    1,554 (77.7%)     52.2%        0.72 1,145 ( 91%)    
Split 34    1,587 (79.3%)     51.3%        0.67 1,124 ( 89%)    
Split 35    1,609 (80.5%)     49.0%        0.58 1,150 ( 91%)    
Split 36    1,673 (83.6%)     45.6%        0.56 1,131 ( 89%)    
Split 37    1,691 (84.6%)     45.9%        0.56 1,154 ( 91%)    
Split 38    1,719 (85.9%)     42.6%        0.44 1,087 ( 86%)    
Resample    1,719 (85.9%)       NA%          NA 1,688 (134%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1       8.0%               563
MS Step 2       7.7%              7319
MS Step 3       9.8%              7319
MS Step 4      11.5%              6193
MS Step 5      13.2%              5067
MS Step 6      15.0%              4504
MS Step 7      16.6%              3941
MS Step 8      18.3%              3941
MS Step 9      19.9%              3378
MS Step 10     21.4%              3378
MS Step 11     22.8%              2815
MS Step 12     24.1%              2815
MS Step 13     25.3%              2815
MS Step 14     26.4%              2252
MS Step 15     27.3%              2252
MS Step 16     28.1%              2252
MS Step 17     29.1%              2252
MS Step 18     29.7%              2252
MS Step 19     33.2%              2252
MS Step 20     31.4%              2252
MS Step 21     31.8%              2252
MS Step 22     32.3%              2252
MS Step 23     32.7%              2252
MS Step 24     33.2%              2252
MS Step 25     33.7%              2252
MS Step 26     34.0%              1689
MS Step 27     34.4%              1689
MS Step 28     34.6%              1689
MS Step 29     34.8%              1689
MS Step 30     35.0%              1689
MS Step 31     35.2%              1689
MS Step 32     35.3%              1689
MS Step 33     35.3%              1689
MS Step 34     35.5%              1689
MS Step 35     35.4%              1689
MS Step 36     35.3%              1689
MS Step 37     35.2%              1689
MS Step 38     35.1%              1689

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population tolerance. If the
acceptance rate drops quickly in the final splits, try increasing `pop_temper` by 0.01. If the weight variance (Log wgt.
sd) increases steadily or is particularly large for the "Resample" step, consider increasing `seq_alpha`. To visualize
what geographic areas may be causing problems, try running the following code. Highlighted areas are those that may be
causing the bottleneck.
    plot(<map object>, rowMeans(as.matrix(plans) == <bottleneck iteration>))
```

### State House
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/3144db80-137a-47a2-b69b-b32a51d956ab" />

<img width="687" height="641" alt="image" src="https://github.com/user-attachments/assets/edb2741d-b2dd-49a3-894c-a92df05e13eb" />

<img width="1035" height="643" alt="Louisians Enacted House Plan versus Simulations" src="https://github.com/user-attachments/assets/a5e61c27-b0b7-41e7-b6de-6f9b01a61401" />

```
nacted_black_perf
               <int>
1                 31

  n_black_perf    n
1           28  143
2           29 1302
3           30 3217
4           31 2547
5           32 2502
6           33  284
7           34    5
```

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 105 districts on 3,540 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.04
Mergesplit Parameters:
• `total_ms_steps` = 104
• `mh_accept_per_smc` = 285
• `pair_rule` = uniform
Plan diversity 80% range: 0.30 to 0.45
98 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
            ❌1.573             ❌1.482             ❌1.638              ❌1.58 
             arv_18              arv_20     comp_bbox_reock           comp_edge 
            ❌1.803             ❌1.438             ❌1.374             ❌1.474 
        comp_polsby       county_splits               e_dem               e_dvs 
            ❌1.378             ❌1.471             ❌1.392             ❌1.571 
               egap         muni_splits             ndshare                 ndv 
            ❌1.397             ❌1.122             ❌1.517             ❌1.428 
                nrv               pbias            plan_dev            pop_aian 
            ❌1.568             ❌1.365               1.023             ❌1.404 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
            ❌1.818             ❌1.735             ❌1.461             ❌1.303 
          pop_other         pop_overlap             pop_two           pop_white 
            ❌1.594             ❌1.605             ❌1.323              ❌1.69 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
            ❌1.622             ❌1.548             ❌1.549              ❌1.61 
     pre_20_rep_tru      sos_18_dem_col      sos_18_dem_fre      sos_18_rep_ard 
            ❌1.453             ❌1.483             ❌1.414             ❌1.672 
     sos_18_rep_clo      sos_18_rep_cro      sos_18_rep_edm      sos_18_rep_ken 
            ❌1.543             ❌1.404             ❌1.856             ❌1.761 
     sos_18_rep_sto     sos_r18_dem_col     sos_r18_rep_ard total_county_splits 
             ❌1.43             ❌1.685             ❌1.891             ❌1.169 
  total_muni_splits           total_vap      uss_16_dem_cam      uss_16_dem_edw 
            ❌1.274             ❌1.327             ❌1.866              ❌1.49 
     uss_16_dem_fay      uss_16_dem_lan      uss_16_dem_men      uss_16_dem_pel 
            ❌1.527             ❌1.474             ❌1.318             ❌1.204 
     uss_16_dem_wil      uss_16_rep_bou      uss_16_rep_cao      uss_16_rep_cra 
            ❌1.918                 ❌2             ❌1.565             ❌1.575 
     uss_16_rep_duk      uss_16_rep_fle      uss_16_rep_ken      uss_16_rep_man 
            ❌1.659             ❌1.793             ❌1.809             ❌1.802 
     uss_16_rep_mar      uss_16_rep_pat      uss_20_dem_edw      uss_20_dem_kni 
            ❌1.341             ❌1.289             ❌1.675             ❌1.666 
     uss_20_dem_per      uss_20_dem_pie      uss_20_dem_wen      uss_20_rep_cas 
            ❌1.619             ❌1.563              ❌1.39             ❌1.459 
     uss_20_rep_mur     uss_r16_dem_cam     uss_r16_rep_ken            vap_aian 
            ❌1.542             ❌1.567             ❌1.647             ❌1.339 
          vap_asian           vap_black            vap_hisp            vap_nhpi 
            ❌1.658             ❌1.675             ❌1.438             ❌1.486 
          vap_other             vap_two           vap_white 
             ❌1.64             ❌2.227             ❌1.691 
• R-hat ≤ 1.05: 1126
• 1.05 < R-hat ≤ 1.1: 1718
• R-hat > 1.1: 5353
• Total R-hats: 8197
✖ WARNING: Chains have not converged.
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
          Eff. samples (%) Acc. rate Log wgt. sd  Max. unique    
Split 1           5 (0.3%)    100.0%         9.4 1,236 ( 98%)  * 
Split 2          10 (0.5%)     99.8%        16.7    36 (  3%)  * 
Split 3          13 (0.6%)     98.0%        17.4    21 (  2%)  * 
Split 4          11 (0.6%)     98.8%        17.3    42 (  3%)  * 
Split 5          25 (1.3%)     98.0%        17.7    55 (  4%)  * 
Split 6          40 (2.0%)     97.1%        17.2    68 (  5%)  * 
Split 7          13 (0.6%)     97.8%        17.2    71 (  6%)  * 
Split 8          19 (1.0%)     95.4%        16.9    60 (  5%)  * 
Split 9          33 (1.7%)     97.0%        16.7    50 (  4%)  * 
Split 10         22 (1.1%)     96.7%        16.4    75 (  6%)  * 
Split 11         16 (0.8%)     96.9%        16.4    55 (  4%)  * 
Split 12         30 (1.5%)     94.7%        16.0    41 (  3%)  * 
Split 13         13 (0.6%)     93.5%        16.1    54 (  4%)  * 
Split 14         10 (0.5%)     95.1%        16.2    42 (  3%)  * 
Split 15         10 (0.5%)     96.7%        15.1    44 (  3%)  * 
Split 16         15 (0.8%)     96.4%        15.5    39 (  3%)  * 
Split 17         10 (0.5%)     97.7%        15.6    45 (  4%)  * 
Split 18          4 (0.2%)     98.9%        14.7    60 (  5%)  * 
Split 19          6 (0.3%)     98.3%        15.1    37 (  3%)  * 
Split 20          3 (0.1%)     96.0%        14.8    64 (  5%)  * 
Split 21         14 (0.7%)     96.3%        15.1    60 (  5%)  * 
Split 22         11 (0.6%)     94.8%        15.0    70 (  6%)  * 
Split 23          9 (0.4%)     96.8%        14.3   103 (  8%)  * 
Split 24         20 (1.0%)     98.1%        14.0   106 (  8%)  * 
Split 25         11 (0.5%)     98.0%        13.5   150 ( 12%)  * 
Split 26          3 (0.2%)     97.5%        14.1   138 ( 11%)  * 
Split 27          8 (0.4%)     92.8%        11.5   168 ( 13%)  * 
Split 28         67 (3.4%)     92.9%        10.3   180 ( 14%)  * 
Split 29         41 (2.1%)     92.1%         9.9   251 ( 20%)  * 
Split 30         67 (3.4%)     91.2%         9.5   248 ( 20%)  * 
Split 31         92 (4.6%)     91.1%         9.8   317 ( 25%)  * 
Split 32         84 (4.2%)     90.3%         9.2   317 ( 25%)  * 
Split 33        124 (6.2%)     90.4%         9.3   365 ( 29%)    
Split 34        136 (6.8%)     90.7%         8.6   369 ( 29%)    
Split 35        161 (8.1%)     90.5%         8.7   420 ( 33%)    
Split 36       200 (10.0%)     92.5%         8.0   420 ( 33%)    
Split 37       242 (12.1%)     90.7%         8.1   427 ( 34%)    
Split 38        189 (9.4%)     91.6%         8.0   480 ( 38%)    
Split 39       263 (13.2%)     90.7%         7.4   474 ( 37%)    
Split 40       256 (12.8%)     90.7%         7.2   509 ( 40%)    
Split 41       260 (13.0%)     90.0%         6.6   519 ( 41%)    
Split 42       217 (10.8%)     88.1%         6.5   561 ( 44%)    
Split 43       316 (15.8%)     88.7%         6.5   554 ( 44%)    
Split 44       320 (16.0%)     88.7%         6.3   566 ( 45%)    
Split 45       336 (16.8%)     85.9%         6.3   579 ( 46%)    
Split 46       377 (18.9%)     86.7%         6.3   610 ( 48%)    
Split 47       380 (19.0%)     85.8%         5.8   610 ( 48%)    
Split 48       395 (19.8%)     85.9%         6.1   633 ( 50%)    
Split 49       427 (21.4%)     84.5%         6.0   640 ( 51%)    
Split 50       432 (21.6%)     83.6%         5.9   659 ( 52%)    
Split 51       451 (22.6%)     80.9%         5.8   668 ( 53%)    
Split 52       458 (22.9%)     81.0%         5.5   650 ( 51%)    
Split 53       495 (24.7%)     80.3%         5.5   668 ( 53%)    
Split 54       449 (22.4%)     79.3%         5.4   682 ( 54%)    
Split 55       499 (25.0%)     79.6%         5.3   674 ( 53%)    
Split 56       456 (22.8%)     77.5%         5.6   673 ( 53%)    
Split 57       452 (22.6%)     76.6%         5.6   655 ( 52%)    
Split 58       498 (24.9%)     78.6%         5.5   664 ( 53%)    
Split 59       475 (23.7%)     76.5%         5.5   664 ( 53%)    
Split 60       470 (23.5%)     74.9%         5.4   675 ( 53%)    
Split 61       476 (23.8%)     72.0%         5.4   655 ( 52%)    
Split 62       491 (24.6%)     72.9%         5.1   681 ( 54%)    
Split 63       489 (24.5%)     70.9%         5.2   696 ( 55%)    
Split 64       481 (24.1%)     70.8%         5.4   689 ( 54%)    
Split 65       521 (26.0%)     69.8%         5.2   687 ( 54%)    
Split 66       515 (25.8%)     66.8%         5.5   720 ( 57%)    
Split 67       584 (29.2%)     67.5%         5.1   694 ( 55%)    
Split 68       567 (28.3%)     65.7%         5.2   715 ( 57%)    
Split 69       536 (26.8%)     64.5%         5.3   728 ( 58%)    
Split 70       522 (26.1%)     64.0%         5.1   729 ( 58%)    
Split 71       573 (28.6%)     62.1%         5.3   688 ( 54%)    
Split 72       551 (27.6%)     62.6%         5.2   729 ( 58%)    
Split 73       527 (26.4%)     60.7%         5.3   683 ( 54%)    
Split 74       583 (29.2%)     59.6%         5.0   712 ( 56%)    
Split 75       561 (28.0%)     60.5%         5.1   697 ( 55%)    
Split 76       595 (29.7%)     57.7%         4.8   748 ( 59%)    
Split 77       585 (29.2%)     57.1%         4.9   752 ( 59%)    
Split 78       604 (30.2%)     54.1%         4.8   722 ( 57%)    
Split 79       644 (32.2%)     54.8%         4.8   716 ( 57%)    
Split 80       616 (30.8%)     53.9%         4.5   763 ( 60%)    
Split 81       579 (29.0%)     51.1%         4.6   739 ( 58%)    
Split 82       669 (33.5%)     50.6%         4.5   751 ( 59%)    
Split 83       597 (29.8%)     47.6%         4.2   758 ( 60%)    
Split 84       650 (32.5%)     47.2%         3.9   728 ( 58%)    
Split 85       655 (32.7%)     44.9%         3.9   798 ( 63%)    
Split 86       695 (34.8%)     44.3%         4.0   749 ( 59%)    
Split 87       651 (32.5%)     44.0%         3.8   787 ( 62%)    
Split 88       671 (33.5%)     42.3%         3.5   753 ( 60%)    
Split 89       740 (37.0%)     40.8%         3.4   782 ( 62%)    
Split 90       720 (36.0%)     40.3%         3.4   817 ( 65%)    
Split 91       701 (35.0%)     40.0%         3.2   824 ( 65%)    
Split 92       748 (37.4%)     37.5%         3.1   840 ( 66%)    
Split 93       799 (40.0%)     35.7%         2.8   828 ( 65%)    
Split 94       822 (41.1%)     32.4%         3.1   873 ( 69%)    
Split 95       877 (43.9%)     30.4%         2.8   878 ( 69%)    
Split 96       916 (45.8%)     28.7%         2.9   902 ( 71%)    
Split 97       882 (44.1%)     27.2%         2.9   928 ( 73%)    
Split 98       947 (47.4%)     25.3%         2.9   907 ( 72%)    
Split 99       944 (47.2%)     24.4%         3.0   919 ( 73%)    
Split 100      942 (47.1%)     22.4%         3.0   887 ( 70%)    
Split 101      953 (47.7%)     18.8%         3.1   904 ( 72%)    
Split 102      902 (45.1%)     16.1%         3.1   833 ( 66%)    
Split 103      725 (36.3%)     13.8%         2.8   838 ( 66%)    
Split 104      583 (29.2%)     11.9%         2.0   709 ( 56%)    
Resample       583 (29.2%)       NA%          NA   875 ( 69%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
            Acc. rate MS Steps per Plan
MS Step 1        2.5%               285
MS Step 2        1.0%             11685
MS Step 3        3.1%             29355
MS Step 4        3.9%              9405
MS Step 5        5.1%              7410
MS Step 6        6.2%              5700
MS Step 7        7.8%              4845
MS Step 8        8.5%              3705
MS Step 9        8.0%              3420
MS Step 10       7.8%              3705
MS Step 11       7.2%              3705
MS Step 12       5.4%              3990
MS Step 13       5.7%              5415
MS Step 14       6.0%              5130
MS Step 15       6.1%              4845
MS Step 16       6.6%              4845
MS Step 17       6.0%              4560
MS Step 18       5.6%              4845
MS Step 19       5.6%              5130
MS Step 20       5.8%              5130
MS Step 21       5.4%              5130
MS Step 22       5.7%              5415
MS Step 23       5.9%              5130
MS Step 24       6.3%              5130
MS Step 25       6.8%              4560
MS Step 26       6.9%              4275
MS Step 27       8.2%              4275
MS Step 28       8.5%              3705
MS Step 29       9.0%              3420
MS Step 30       9.2%              3420
MS Step 31       9.4%              3135
MS Step 32       9.6%              3135
MS Step 33       9.7%              3135
MS Step 34      10.2%              3135
MS Step 35      10.5%              2850
MS Step 36      11.0%              2850
MS Step 37      11.4%              2850
MS Step 38      11.6%              2565
MS Step 39      11.7%              2565
MS Step 40      11.7%              2565
MS Step 41      11.7%              2565
MS Step 42      11.7%              2565
MS Step 43      11.6%              2565
MS Step 44      11.8%              2565
MS Step 45      12.2%              2565
MS Step 46      12.5%              2565
MS Step 47      12.8%              2565
MS Step 48      13.0%              2280
MS Step 49      13.4%              2280
MS Step 50      13.8%              2280
MS Step 51      14.1%              2280
MS Step 52      16.2%              2280
MS Step 53      15.4%              1995
MS Step 54      15.3%              1995
MS Step 55      15.6%              1995
MS Step 56      15.9%              1995
MS Step 57      16.3%              1995
MS Step 58      16.6%              1995
MS Step 59      16.9%              1995
MS Step 60      17.1%              1710
MS Step 61      17.4%              1710
MS Step 62      17.6%              1710
MS Step 63      17.8%              1710
MS Step 64      18.0%              1710
MS Step 65      18.1%              1710
MS Step 66      18.4%              1710
MS Step 67      18.9%              1710
MS Step 68      19.0%              1710
MS Step 69      19.2%              1710
MS Step 70      19.4%              1710
MS Step 71      19.6%              1710
MS Step 72      19.9%              1710
MS Step 73      20.0%              1710
MS Step 74      20.3%              1710
MS Step 75      20.6%              1425
MS Step 76      20.9%              1425
MS Step 77      21.1%              1425
MS Step 78      21.4%              1425
MS Step 79      21.6%              1425
MS Step 80      21.8%              1425
MS Step 81      22.0%              1425
MS Step 82      22.2%              1425
MS Step 83      22.4%              1425
MS Step 84      22.7%              1425
MS Step 85      22.8%              1425
MS Step 86      23.1%              1425
MS Step 87      23.1%              1425
MS Step 88      23.3%              1425
MS Step 89      23.5%              1425
MS Step 90      23.7%              1425
MS Step 91      23.8%              1425
MS Step 92      24.0%              1425
MS Step 93      24.1%              1425
MS Step 94      24.1%              1425
MS Step 95      24.1%              1425
MS Step 96      24.2%              1425
MS Step 97      24.3%              1425
MS Step 98      24.4%              1425
MS Step 99      24.4%              1425
MS Step 100     24.4%              1425
MS Step 101     24.5%              1425
MS Step 102     24.4%              1425
MS Step 103     24.4%              1425
MS Step 104     24.4%              1425

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs.
of the log weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary
statistics should be between 1 and 1.05.
• SMC convergence: Increase the number of samples. If you are experiencing low plan diversity or
bottlenecks as well, address those issues first.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population
tolerance. If the acceptance rate drops quickly in the final splits, try increasing `pop_temper`
by 0.01. If the weight variance (Log wgt. sd) increases steadily or is particularly large for the
"Resample" step, consider increasing `seq_alpha`. To visualize what geographic areas may be
causing problems, try running the following code. Highlighted areas are those that may be causing
the bottleneck.

```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited
