### PR TITLE
 2020 Nevada State House/Senate Districts

### DIFF
--- a/analyses/NV_leg_2020/01_prep_NV_leg_2020.R
+++ b/analyses/NV_leg_2020/01_prep_NV_leg_2020.R
@@ -1,0 +1,95 @@
+###############################################################################
+# Download and prepare data for `NV_leg_2020` analysis
+# © ALARM Project, June 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg NV_leg_2020}")
+
+path_data <- download_redistricting_file("NV", "data-raw/NV", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/NV_2020/shp_vtd.rds"
+perim_path <- "data-out/NV_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong NV} shapefile")
+    # read in redistricting data
+    nv_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$NV)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("NV", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("NV"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("NV", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("NV"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("NV", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("NV"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    nv_shp <- nv_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    nv_shp <- nv_shp |>
+        left_join(y = leg_from_baf(state = "NV"), by = "GEOID")
+
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nv_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nv_shp <- rmapshaper::ms_simplify(nv_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nv_shp$adj <- adjacency(nv_shp)
+
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(nv_shp$adj, nv_shp$ssd_2020)
+    ccm(nv_shp$adj, nv_shp$shd_2020)
+
+    nv_shp <- nv_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(nv_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nv_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong NV} shapefile")
+}
+
+redistio::draw(nv_shp, nv_shp$ssd_2020)
+redistio::draw(nv_shp, nv_shp$shd_2020)

--- a/analyses/NV_leg_2020/02_setup_NV_leg_2020.R
+++ b/analyses/NV_leg_2020/02_setup_NV_leg_2020.R
@@ -1,0 +1,28 @@
+###############################################################################
+# Set up redistricting simulation for `NV_leg_2020`
+# © ALARM Project, June 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg NV_leg_2020}")
+
+map_ssd <- redist_map(nv_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = nv_shp$adj)
+
+map_shd <- redist_map(nv_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = nv_shp$adj)
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)*12))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "NV_SSD_2020"
+attr(map_shd, "analysis_name") <- "NV_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/NV_2020/NV_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/NV_2020/NV_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/NV_leg_2020/03_sim_NV_shd_2020.R
+++ b/analyses/NV_leg_2020/03_sim_NV_shd_2020.R
@@ -1,0 +1,209 @@
+###############################################################################
+# Simulate plans for `NV_shd_2020` SHD
+# © ALARM Project, June 2026
+###############################################################################
+
+library(foreach)
+library(doParallel)
+library(doRNG)
+
+# Nested SMC function -----
+nested_smc <- function(plans, map_ssd, map_shd, shp,
+                       inner_nsims = 2000, inner_runs = 1, outer_runs = 5,
+                       year = 2020, state, max_split_tries = 100000,
+                       ncores = 60) {
+
+    library(foreach)
+    library(doParallel)
+    library(doRNG)
+
+    shd_col <- paste0("shd_", year)
+    ssd_col <- paste0("ssd_", year)
+
+    # Generate district assignment matrix
+    sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+
+    # Create shd map object
+    map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
+        ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
+    map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+    # Simulation hyperparameters
+    inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
+    final_sims <- ncol(sample_ssd_matrix)
+    stopifnot(final_sims %% outer_runs == 0)
+
+    mh_accept_per_smc <- ceiling(n_distinct(map_shd[[shd_col]])/3)
+
+    # Set up log file
+    dir.create(sprintf("data-out/%s_%s", state, year), recursive = TRUE, showWarnings = FALSE)
+    logfile <- sprintf("data-out/%s_%s/nested_log.txt", state, year)
+    file.create(logfile)
+
+    # Set up parallelization
+    cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
+        useXDR = .Platform$endian != "little")
+    registerDoParallel(cl)
+
+    # Make sure the fifty.states package is loaded on each worker
+    clusterEvalQ(cl, {
+        devtools::load_all("/n/home08/mquintero/50StatesALARM")
+    })
+
+    # Outer loop: senate simulations
+    plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
+        .packages = c("tidyverse", "redist")) %dorng% {
+
+        t_outer_start <- Sys.time()
+        map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+        plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
+        failed <- FALSE
+
+        # Inner loop: simulated senate districts
+        for (j in 1:max(map_shd_iterate$ssd_sim)) {
+            m <- map_shd_iterate %>% filter(ssd_sim == j)
+            map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"), ndists = inner_splits, adj = m$adj)
+
+            output <- capture.output(
+                {
+                    result <- tryCatch(
+                        {
+                            redist_smc(
+                                map_j,
+                                nsims = inner_nsims, runs = inner_runs,
+                                counties = ssd_sim,
+                                sampling_space = "linking_edge",
+                                ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+                                split_params = list(splitting_schedule = "any_valid_sizes"),
+                                verbose = TRUE,
+                                control = list(max_split_tries = max_split_tries),
+                                ncores = 1
+                            )
+                        },
+                        error = function(e) NULL)
+                },
+                type = "output")
+
+            # Catch fail-to-split or outright error
+            if (is.null(result) || any(grepl("Failed to split", output))) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
+                break
+            }
+
+            plans_j <- result %>% filter(draw == inner_nsims*inner_runs)
+            plans_j$dist_keep <- TRUE
+            plan_list[[j]] <- list(map = map_j, plans = plans_j)
+        }
+
+        if (failed) {
+            # Return dummy plan so foreach/.combine doesn't break; filtered out later via `survive`
+            prep_mat <- rep(1:n_distinct(map_shd[[shd_col]]), length.out = nrow(map_shd_iterate))
+            plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+            plans_dummy$draw <- as.factor(99999)
+            return(plans_dummy)
+        }
+
+        # Combine into single state-wide plan
+        prep_mat <- prep_particles(map = map_shd_iterate, map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims,
+            " | TOTAL outer time:", round(as.numeric(Sys.time() - t_outer_start), 2), "sec\n",
+            file = logfile, append = TRUE)
+
+        plans_i
+    }
+
+    stopCluster(cl)
+
+    # Determine effective sample size (drop failed/dummy plans)
+    survive <- plans_shd %>%
+        as.data.frame() %>%
+        filter(district == 1) %>%
+        mutate(survive = ifelse(draw != 99999, TRUE, FALSE)) %>%
+        dplyr::select(survive)
+
+    survive_all <- plans_shd %>%
+        as.data.frame() %>%
+        mutate(survive_all = ifelse(draw != 99999, TRUE, FALSE)) %>%
+        dplyr::select(survive_all)
+
+    plans_shd_matrix <- get_plans_matrix(plans_shd)
+    plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+
+    plans_shd <- redist_plans(plans = plans_shd_matrix, map = map_shd, algorithm = "smc")
+
+    # Add draw and chain numbering
+    plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+    full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+    plans_shd$chain <- full_chain[survive_all$survive_all]
+
+    # Add enacted plan
+    plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
+
+    return(plans_shd)
+}
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NV_shd_2020}")
+
+set.seed(2020)
+
+plans_shd <- nested_smc(
+    plans = plans,
+    map_ssd = map_ssd,
+    map_shd = map_shd,
+    shp = nv_shp,
+    inner_nsims = 2000,
+    inner_runs = 1,
+    outer_runs = 5,
+    year = 2020,
+    state = "NV",
+    ncores = 60
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans_shd |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NV_2020/NV_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NV_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NV_2020/NV_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+    redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Hispanic by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020_prop = "black"))
+
+}

--- a/analyses/NV_leg_2020/03_sim_NV_ssd_2020.R
+++ b/analyses/NV_leg_2020/03_sim_NV_ssd_2020.R
@@ -1,0 +1,69 @@
+###############################################################################
+# Simulate plans for `NV_ssd_2020` SSD
+# © ALARM Project, June 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg NV_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 15
+
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(strength = 3, admin = map_ssd$county)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 2e3, runs = 5,
+    pop_temper = 0.01,
+    counties = pseudo_county,
+    constraints = constr,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE,
+    ncores = 64
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/NV_2020/NV_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg NV_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/NV_2020/NV_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+    redist.plot.distr_qtys(plans, vap_hisp/total_vap,
+        color_thresh = NULL,
+        color = ifelse(subset_sampled(plans)$ndv > subset_sampled(plans)$nrv, "#3D77BB", "#B25D4C"),
+        size = 0.5, alpha = 0.5) +
+        scale_y_continuous("Percent Hispanic by VAP") +
+        labs(title = "Approximate Performance") +
+        scale_color_manual(values = c(cd_2020_prop = "black"))
+}

--- a/analyses/NV_leg_2020/doc_NV_leg_2020.md
+++ b/analyses/NV_leg_2020/doc_NV_leg_2020.md
@@ -1,0 +1,37 @@
+# 2020 Nevada State House/Senate Districts
+
+## Redistricting requirements
+In Nevada, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Nevada must:
+
+1. be contiguous
+2. have equal populations
+3. be geographically compact
+4. preserve county and municipality boundaries as much as possible (preserve political subdivisions)
+5. preserve communities of interest
+6. avoid pairing incumbents
+7. House Nested in Senate or Congress
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%. For Nevada's upper house,
+convergence required a total county split constraint with strength 3 and an
+increase to the target population size of pseudo-counties by a magnitude of
+12.
+
+## Data Sources
+Data for Nevada comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample districting plans for Nevada's lower house using theTop-Down Nested State House District technique 
+for the SMC algorithm across 5 outer runs with 2,000 inner simulations each, with each house-district
+plan simulated within an already-sampled upper house plan to enforce
+nesting of house districts within senate districts. No additional
+constraints were used. The final sample contains 9,460 successfully
+sampled plans.
+
+
+We sample 10,000 districting plans for Nevada's upper house across 5
+independent runs of the SMC algorithm, using the constraints described above.


### PR DESCRIPTION
## Redistricting requirements
In Nevada, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Nevada must:

1. be contiguous
2. have equal populations
3. be geographically compact
4. preserve county and municipality boundaries as much as possible (preserve political subdivisions)
5. preserve communities of interest
6. avoid pairing incumbents
7. House Nested in Senate or Congress


### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%. For Nevada's upper house,
convergence required a total county split constraint with strength 3, an
increase to the target population size of pseudo-counties by a magnitude of
12, and a population tempering value of 0.01.

## Data Sources
Data for Nevada comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample districting plans for Nevada's lower house using theTop-Down Nested State House District technique 
for the SMC algorithm across 5 outer runs with 2,000 inner simulations each, with each house-district
plan simulated within an already-sampled upper house plan to enforce
nesting of house districts within senate districts. No additional
constraints were used. The final sample contains 9,460 successfully
sampled plans.


We sample 10,000 districting plans for Nevada's upper house across 5
independent runs of the SMC algorithm, using the constraints described above.


## Validation

<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/bbf257b4-90e2-4300-8c7d-b8b73b969aac" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 21
                 districts on 2,102 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.01
Mergesplit Parameters:
• `total_ms_steps` = 20
• `mh_accept_per_smc` = 22
• `pair_rule` = uniform
Plan diversity 80% range: 0.66 to 0.84
12 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.016               1.015               1.014               1.006               1.007 
             arv_20      atg_18_dem_for      atg_18_rep_dun     comp_bbox_reock           comp_edge 
              1.007               1.013               1.007               1.007               1.002 
        comp_polsby       county_splits               e_dem               e_dvs                egap 
              1.006               1.015               1.003               1.017               1.002 
     gov_18_dem_sis      gov_18_rep_lax         muni_splits             ndshare                 ndv 
              1.015               1.007               1.001               1.017               1.015 
                nrv               pbias            plan_dev            pop_aian           pop_asian 
              1.007               1.007               1.000               1.024               1.018 
          pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.010               1.008               1.012               1.005               1.008 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru 
              1.011               1.009               1.005               1.014               1.005 
     pre_20_dem_bid      pre_20_rep_tru      sos_18_dem_ara      sos_18_rep_ceg total_county_splits 
              1.014               1.007               1.018               1.006               1.012 
  total_muni_splits           total_vap      uss_16_dem_cor      uss_16_rep_hec      uss_18_dem_ros 
              1.007               1.003               1.017               1.007               1.015 
     uss_18_rep_hel            vap_aian           vap_asian           vap_black            vap_hisp 
              1.007               1.024               1.016               1.009               1.012 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.011               1.003               1.011               1.007 
• R-hat ≤ 1.05: 1122
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1122
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       680 (34.0%)    100.0%        1.08 1,287 (102%) 
Split 2       287 (14.3%)     95.6%        1.21   936 ( 74%) 
Split 3       621 (31.1%)     92.6%        1.70   828 ( 65%) 
Split 4       997 (49.8%)     85.5%        1.60   871 ( 69%) 
Split 5     1,061 (53.0%)     81.3%        1.59   953 ( 75%) 
Split 6     1,123 (56.1%)     76.9%        1.46 1,031 ( 82%) 
Split 7     1,197 (59.8%)     71.9%        1.40 1,067 ( 84%) 
Split 8     1,251 (62.6%)     66.4%        1.31 1,052 ( 83%) 
Split 9     1,232 (61.6%)     62.3%        1.30 1,040 ( 82%) 
Split 10    1,279 (64.0%)     59.3%        1.23 1,051 ( 83%) 
Split 11    1,323 (66.1%)     56.7%        1.16 1,054 ( 83%) 
Split 12    1,301 (65.1%)     54.2%        1.14 1,071 ( 85%) 
Split 13    1,295 (64.7%)     51.2%        1.10 1,039 ( 82%) 
Split 14    1,295 (64.8%)     48.9%        1.07 1,048 ( 83%) 
Split 15    1,309 (65.5%)     48.4%        1.05 1,030 ( 81%) 
Split 16    1,298 (64.9%)     45.7%        1.02   996 ( 79%) 
Split 17    1,378 (68.9%)     44.4%        1.00 1,036 ( 82%) 
Split 18    1,468 (73.4%)     40.2%        1.01 1,052 ( 83%) 
Split 19    1,847 (92.4%)     32.7%        0.36 1,059 ( 84%) 
Split 20    1,878 (93.9%)     30.0%        0.28 1,121 ( 89%) 
Resample    1,878 (93.9%)       NA%          NA 1,802 (143%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      46.2%                22
MS Step 2      42.2%                66
MS Step 3      42.7%                66
MS Step 4      43.5%                66
MS Step 5      43.8%                66
MS Step 6      43.9%                66
MS Step 7      43.3%                66
MS Step 8      42.7%                66
MS Step 9      41.8%                66
MS Step 10     40.8%                66
MS Step 11     39.5%                66
MS Step 12     38.2%                66
MS Step 13     37.1%                66
MS Step 14     35.9%                66
MS Step 15     34.9%                66
MS Step 16     34.3%                66
MS Step 17     33.4%                66
MS Step 18     32.6%                66
MS Step 19     31.8%                88
MS Step 20     30.8%                88

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between
1 and 1.05.
```
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/1a2c6419-3977-4317-b91e-68d1059bf605" />

```
SMC: 9,460 sampled plans of 42
                 districts on 2,102 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.80 to 0.92
29 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.010               1.006               1.006               1.006               1.004 
             arv_20      atg_18_dem_for      atg_18_rep_dun     comp_bbox_reock           comp_edge 
              1.004               1.008               1.004               1.002               1.003 
        comp_polsby       county_splits               e_dem               e_dvs                egap 
              1.002               1.007               1.000               1.010               1.000 
     gov_18_dem_sis      gov_18_rep_lax         muni_splits             ndshare                 ndv 
              1.007               1.005               1.000               1.010               1.008 
                nrv               pbias            plan_dev            pop_aian           pop_asian 
              1.005               1.006               1.000               1.004               1.008 
          pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.008               1.003               1.006               1.003               1.008 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru 
              1.005               1.005               1.001               1.010               1.007 
     pre_20_dem_bid      pre_20_rep_tru      sos_18_dem_ara      sos_18_rep_ceg total_county_splits 
              1.006               1.004               1.004               1.005               1.007 
  total_muni_splits           total_vap      uss_16_dem_cor      uss_16_rep_hec      uss_18_dem_ros 
              1.002               1.003               1.010               1.005               1.006 
     uss_18_rep_hel            vap_aian           vap_asian           vap_black            vap_hisp 
              1.005               1.004               1.008               1.007               1.005 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.008               1.003               1.005               1.009 
• R-hat ≤ 1.05: 2239
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2239
•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between
1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan
