### PR TITLE
2020 Minnesota State House/Senate Districts 

### DIFF
--- a/analyses/MN_leg_2020/01_prep_MN_leg_2020.R
+++ b/analyses/MN_leg_2020/01_prep_MN_leg_2020.R
@@ -1,0 +1,99 @@
+###############################################################################
+# Download and prepare data for `MN_leg_2020` analysis
+# © ALARM Project, December 2025
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MN_leg_2020}")
+
+path_data <- download_redistricting_file("MN", "data-raw/MN", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MN_2020/shp_vtd.rds"
+perim_path <- "data-out/MN_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MN} shapefile")
+    # read in redistricting data
+    mn_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$MN)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("MN", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("MN"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("MN", "SLDU", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("MN"), vtd),
+            ssd_2010 = as.integer(sldu))
+    d_shd <- make_from_baf("MN", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("MN"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    mn_shp <- mn_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    mn_shp <- mn_shp |>
+        left_join(y = leg_from_baf(state = "MN"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = mn_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        mn_shp <- rmapshaper::ms_simplify(mn_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    mn_shp$adj <- adjacency(mn_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(mn_shp$adj, mn_shp$ssd_2020)
+    ccm(mn_shp$adj, mn_shp$shd_2020)
+
+    mn_shp <- mn_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(mn_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    mn_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MN} shapefile")
+}
+
+# Function to fix irregular Minnesota shd district names
+mn_shd_numbering <- function(x) {
+    num <- as.integer(sub("[A-Z]", "", x))
+    letter <- substr(x, nchar(x), nchar(x))
+    2*num - ifelse(letter == "A", 1L, 0L)
+}
+
+mn_shp$shd_2020 <- mn_shd_numbering(mn_shp$shd_2020)

--- a/analyses/MN_leg_2020/02_setup_MN_leg_2020.R
+++ b/analyses/MN_leg_2020/02_setup_MN_leg_2020.R
@@ -1,0 +1,29 @@
+###############################################################################
+# Set up redistricting simulation for `MN_leg_2020`
+# © ALARM Project, December 2025
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MN_leg_2020}")
+
+map_ssd <- redist_map(mn_shp, pop_tol = 0.03,
+    existing_plan = ssd_2020, adj = mn_shp$adj)
+
+map_shd <- redist_map(mn_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = mn_shp$adj)
+
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "MN_SSD_2020"
+attr(map_shd, "analysis_name") <- "MN_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/MN_2020/MN_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/MN_2020/MN_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MN_leg_2020/03_sim_MN_shd_2020.R
+++ b/analyses/MN_leg_2020/03_sim_MN_shd_2020.R
@@ -1,0 +1,208 @@
+###############################################################################
+# Simulate plans for `MN_shd_2020` SHD
+# © ALARM Project, December 2025
+###############################################################################
+nested_smc <- function(plans, map_ssd, map_shd, shp, inner_nsims = 50, inner_runs = 1, outer_runs = 5, year = 2020, state, max_split_tries = 100000, ncores = 8) {
+
+    library(foreach)
+    library(doParallel)
+    library(doRNG)
+
+    shd_col <- paste0("shd_", year)
+    ssd_col <- paste0("ssd_", year)
+
+    # Generate district assignment matrix
+    sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+
+    # Create shd map object
+    map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
+        ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
+
+    # Unique ID for each row, will use later to reconnect pieces
+    map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+    # Simulation hyperparameters
+    inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
+    final_sims <- ncol(sample_ssd_matrix)
+
+    # Set up log file
+    logfile <- sprintf("data-out/MN_2020/nested_log.txt", state, year)
+    file.create(logfile)
+
+    # Set up parallelization
+    cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
+        useXDR = .Platform$endian != "little")
+
+    registerDoParallel(cl)
+
+    # Outer loop: senate simulations
+    plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
+        .export = c("prep_particles", "rep_cols", "rep_col"),
+        .packages = c("tidyverse", "redist")) %dorng% {
+        # mh_accept_per_smc <- 1
+        devtools::load_all()
+
+        # Add senate district assignment from simulation i
+        map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+
+        plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
+
+        failed <- FALSE
+
+        # Inner loop: simulated senate districts
+        for (j in 1:max(map_shd_iterate$ssd_sim)) {
+            m <- map_shd_iterate %>%
+                filter(ssd_sim == j)
+            map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+                ndists = inner_splits, adj = m$adj)
+
+
+            # Constraint
+            constr <- redist_constr(map_j) %>%
+                add_constr_total_plan_splits(strength = 3.3, admin = map_j$county_muni)
+
+
+            output <- capture.output(
+                {
+                    result <- tryCatch(
+                        {
+                            plans_j <- redist_smc(
+                                map_j,
+                                nsims = inner_nsims, runs = inner_runs,
+                                counties = county,
+                                sampling_space = "linking_edge",
+                                constraints = constr,
+                                pop_temper = 0.02,
+                                # ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+                                split_params = list(splitting_schedule = "any_valid_sizes"),
+                                verbose = TRUE,
+                                control = list(max_split_tries = max_split_tries)
+                            )
+
+                            # Catch error
+                        },
+                        error = function(e) {
+
+                            NULL
+                        })
+                },
+                type = "output")
+
+            # Catch fail to split warning
+            if (is.null(result) || any(grepl("Failed to split", output))) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
+                break
+            }
+
+            plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+            plans_j$dist_keep <- TRUE
+            plan_list[[j]] <- list(map = map_j, plans = plans_j)
+        }
+
+        if (failed) {
+            # Return dummy plan
+            prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+            plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+            plans_dummy$draw <- as.factor(99999)
+
+            return(plans_dummy)
+        }
+
+        # Combine into single state-wide plan
+        prep_mat <- prep_particles(map = map_shd_iterate,
+            map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
+
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+
+        # Counter for log file
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims, file = logfile, append = TRUE)
+
+        plans_i
+
+    }
+
+    stopCluster(cl)
+
+    # Determine effective sample size
+    survive <- plans_shd %>%
+        as.data.frame() %>%
+        filter(district == 1) %>%
+        mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive)
+
+    survive_all <- plans_shd %>%
+        as.data.frame() %>%
+        mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive_all)
+
+    saveRDS(survive_all, "data-out/MN_2020/survive_all.rds")
+
+    plans_shd_matrix <- get_plans_matrix(plans_shd)
+    plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+
+    plans_shd <- redist_plans(plans = plans_shd_matrix,
+        map = map_shd,
+        algorithm = "smc")
+
+    # Add draw and chain numbering
+    plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+    full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+
+    plans_shd$chain <- full_chain[survive_all$survive_all]
+
+    # Add enacted plan
+    plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
+
+    return(plans_shd)
+
+}
+
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MN_shd_2020}")
+
+set.seed(2020)
+
+# mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3)
+
+plans <- readRDS("data-raw/MN_2020/MN_ssd_2020_plans_oversample.rds")
+
+plans <- nested_smc(plans, map_ssd, map_shd, shp = mn_shp, state = "MN", ncores = 64)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MN_2020/MN_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MN_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MN_2020/MN_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+}

--- a/analyses/MN_leg_2020/03_sim_MN_ssd_2020.R
+++ b/analyses/MN_leg_2020/03_sim_MN_ssd_2020.R
@@ -1,0 +1,65 @@
+###############################################################################
+# Simulate plans for `MN_ssd_2020` SSD
+# © ALARM Project, December 2025
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MN_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 130
+
+constr <- redist_constr(map_ssd) %>%
+    add_constr_total_plan_splits(strength = 1.85, admin = map_ssd$county_muni)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 7500, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE,
+    constraints = constr,
+    pop_temper = 0.02,
+    ncores = 64
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- match_numbers(plans, "ssd_2020")
+
+write_rds(plans, here("data-raw/MN_2020/MN_ssd_2020_plans_oversample.rds"), compress = "xz")
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/MN_2020/MN_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MN_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MN_2020/MN_ssd_2020_stats_tol03.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+}

--- a/analyses/MN_leg_2020/doc_MN_leg_2020.md
+++ b/analyses/MN_leg_2020/doc_MN_leg_2020.md
@@ -1,7 +1,7 @@
 # 2020 Minnesota State House/Senate Districts
 
 ## Redistricting requirements
-In Minnesota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+In Minnesota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Minnesota must:
 
 1. be contiguous [NCSL 184]
 1. have equal populations [NCSL 24]

--- a/analyses/MN_leg_2020/doc_MN_leg_2020.md
+++ b/analyses/MN_leg_2020/doc_MN_leg_2020.md
@@ -1,0 +1,31 @@
+# 2020 Minnesota State House/Senate Districts
+
+## Redistricting requirements
+In Minnesota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf) and impose the following constraints. In our simulations, legislative districts must:
+
+1. be contiguous [NCSL 184]
+1. have equal populations [NCSL 24]
+1. preserve county and municipality boundaries as much as possible [NCSL 184]
+1. preserve communities of interest [NCSL 184]
+1. avoid incumbent pairings [NCSL 185]
+1. not favor incumbents [NCSL 185]
+1. have House districts nested inside Senate districts [NCSL 185]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Minnesota comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+No manual pre-processing decisions were necessary.
+
+## Simulation Notes
+We sample 37,500 districting plans for Minnesota's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+We impose a total municipality splits constraint, and increase the number of merge-split proposals per SMC step (153).
+
+We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 37,500 upper house districts.
+11,783 districting plans remaining in the surviving sample.
+We then thinned the number of samples to 10,000.
+We impose a total municipality splits constraint on the inner-simulations.


### PR DESCRIPTION
# 2020 Minnesota State House/Senate Districts

## Redistricting requirements
In Minnesota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Minnesota must:

1. be contiguous [NCSL 184]
1. have equal populations [NCSL 24]
1. preserve county and municipality boundaries as much as possible [NCSL 184]
1. preserve communities of interest [NCSL 184]
1. avoid incumbent pairings [NCSL 185]
1. not favor incumbents [NCSL 185]
1. have House districts nested inside Senate districts [NCSL 185]

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Minnesota comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
No manual pre-processing decisions were necessary.

## Simulation Notes
We sample 37,500 districting plans for Minnesota's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
We impose a total municipality splits constraint, and increase the number of merge-split proposals per SMC step (153).

We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 37,500 upper house districts.
11,783 districting plans remain in the surviving sample.
We then thinned the number of samples to 10,000.
We impose a total municipality splits constraint on the inner-simulations.

## Validation

**State Senate**

<img width="3000" height="5400" alt="validation_20260804_1613" src="https://github.com/user-attachments/assets/6bd04a42-8c8a-49ed-a8c5-ea74e7f8168d" />



```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 67 districts on 4,110 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.02
Mergesplit Parameters:
• `total_ms_steps` = 66
• `mh_accept_per_smc` = 153
• `pair_rule` = uniform
Plan diversity 80% range: 0.71 to 0.81
38 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.012               1.009               1.009               1.007 
             arv_18              arv_20      atg_18_dem_ell      atg_18_rep_war 
              1.006               1.008               1.013               1.006 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.006               1.005               1.006               1.004 
              e_dem               e_dvs                egap      gov_18_dem_wal 
              1.000               1.010               1.001               1.008 
     gov_18_rep_joh         muni_splits             ndshare                 ndv 
              1.005               1.005               1.010               1.011 
                nrv               pbias            plan_dev            pop_aian 
              1.007               1.004               1.000               1.008 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.012               1.009               1.009               1.007 
          pop_other         pop_overlap             pop_two           pop_white 
              1.004               1.003               1.005               1.005 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.008               1.012               1.007               1.012 
     pre_20_rep_tru      sos_18_dem_sim      sos_18_rep_how total_county_splits 
              1.005               1.012               1.006               1.011 
  total_muni_splits           total_vap      uss_18_dem_klo      uss_18_rep_new 
              1.003               1.003               1.005               1.008 
     uss_20_dem_smi      uss_20_rep_lew            vap_aian           vap_asian 
              1.008               1.006               1.006               1.010 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.008               1.008               1.013               1.007 
            vap_two           vap_white 
              1.009               1.004 
• R-hat ≤ 1.05: 3580
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3580
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1       792 (10.6%)    100.0%        1.73 4,732 (100%) 
Split 2     1,136 (15.2%)     98.1%        1.42 2,895 ( 61%) 
Split 3     2,818 (37.6%)     96.8%        1.21 3,216 ( 68%) 
Split 4     3,639 (48.5%)     95.4%        1.08 3,646 ( 77%) 
Split 5     3,526 (47.0%)     93.2%        1.01 3,809 ( 80%) 
Split 6     4,469 (59.6%)     91.7%        0.95 3,888 ( 82%) 
Split 7     4,610 (61.5%)     89.8%        0.88 3,991 ( 84%) 
Split 8     4,823 (64.3%)     88.1%        0.85 4,118 ( 87%) 
Split 9     4,949 (66.0%)     85.8%        0.79 4,122 ( 87%) 
Split 10    5,170 (68.9%)     84.7%        0.74 4,172 ( 88%) 
Split 11    5,384 (71.8%)     82.3%        0.72 4,263 ( 90%) 
Split 12    5,411 (72.1%)     81.3%        0.69 4,293 ( 91%) 
Split 13    5,636 (75.1%)     79.0%        0.66 4,349 ( 92%) 
Split 14    5,656 (75.4%)     77.7%        0.62 4,369 ( 92%) 
Split 15    5,779 (77.1%)     75.8%        0.62 4,364 ( 92%) 
Split 16    5,863 (78.2%)     74.4%        0.58 4,379 ( 92%) 
Split 17    5,944 (79.3%)     72.1%        0.57 4,392 ( 93%) 
Split 18    6,034 (80.5%)     70.9%        0.54 4,394 ( 93%) 
Split 19    6,070 (80.9%)     68.7%        0.54 4,460 ( 94%) 
Split 20    6,159 (82.1%)     67.5%        0.52 4,427 ( 93%) 
Split 21    6,221 (82.9%)     67.4%        0.50 4,441 ( 94%) 
Split 22    6,293 (83.9%)     64.1%        0.48 4,446 ( 94%) 
Split 23    6,323 (84.3%)     62.8%        0.47 4,520 ( 95%) 
Split 24    6,421 (85.6%)     62.0%        0.45 4,459 ( 94%) 
Split 25    6,436 (85.8%)     59.9%        0.44 4,508 ( 95%) 
Split 26    6,467 (86.2%)     58.8%        0.43 4,488 ( 95%) 
Split 27    6,490 (86.5%)     57.4%        0.43 4,520 ( 95%) 
Split 28    6,543 (87.2%)     56.5%        0.42 4,483 ( 95%) 
Split 29    6,571 (87.6%)     54.8%        0.41 4,549 ( 96%) 
Split 30    6,611 (88.1%)     53.6%        0.38 4,525 ( 95%) 
Split 31    6,653 (88.7%)     52.8%        0.38 4,551 ( 96%) 
Split 32    6,659 (88.8%)     51.4%        0.38 4,518 ( 95%) 
Split 33    6,704 (89.4%)     50.7%        0.37 4,548 ( 96%) 
Split 34    6,745 (89.9%)     47.9%        0.36 4,533 ( 96%) 
Split 35    6,773 (90.3%)     48.1%        0.35 4,578 ( 97%) 
Split 36    6,822 (91.0%)     47.8%        0.34 4,577 ( 97%) 
Split 37    6,812 (90.8%)     45.8%        0.34 4,554 ( 96%) 
Split 38    6,874 (91.6%)     44.9%        0.32 4,580 ( 97%) 
Split 39    6,877 (91.7%)     43.6%        0.32 4,610 ( 97%) 
Split 40    6,910 (92.1%)     43.4%        0.31 4,593 ( 97%) 
Split 41    6,909 (92.1%)     42.0%        0.31 4,522 ( 95%) 
Split 42    6,937 (92.5%)     40.9%        0.30 4,571 ( 96%) 
Split 43    6,979 (93.1%)     39.7%        0.29 4,610 ( 97%) 
Split 44    6,983 (93.1%)     39.6%        0.29 4,584 ( 97%) 
Split 45    7,003 (93.4%)     38.1%        0.28 4,588 ( 97%) 
Split 46    7,029 (93.7%)     37.6%        0.27 4,594 ( 97%) 
Split 47    7,035 (93.8%)     36.8%        0.27 4,580 ( 97%) 
Split 48    7,047 (94.0%)     36.0%        0.27 4,586 ( 97%) 
Split 49    7,066 (94.2%)     35.2%        0.26 4,645 ( 98%) 
Split 50    7,080 (94.4%)     34.5%        0.26 4,596 ( 97%) 
Split 51    7,087 (94.5%)     33.0%        0.25 4,579 ( 97%) 
Split 52    7,112 (94.8%)     32.6%        0.24 4,628 ( 98%) 
Split 53    7,111 (94.8%)     31.5%        0.25 4,601 ( 97%) 
Split 54    7,110 (94.8%)     31.2%        0.24 4,610 ( 97%) 
Split 55    7,141 (95.2%)     30.0%        0.24 4,548 ( 96%) 
Split 56    7,143 (95.2%)     29.4%        0.23 4,610 ( 97%) 
Split 57    7,157 (95.4%)     28.2%        0.23 4,609 ( 97%) 
Split 58    7,147 (95.3%)     27.5%        0.23 4,544 ( 96%) 
Split 59    7,178 (95.7%)     27.3%        0.22 4,591 ( 97%) 
Split 60    7,179 (95.7%)     25.8%        0.22 4,545 ( 96%) 
Split 61    7,177 (95.7%)     25.9%        0.22 4,525 ( 95%) 
Split 62    7,191 (95.9%)     24.2%        0.21 4,475 ( 94%) 
Split 63    7,201 (96.0%)     24.0%        0.21 4,485 ( 95%) 
Split 64    7,216 (96.2%)     23.1%        0.21 4,448 ( 94%) 
Split 65    7,259 (96.8%)     22.4%        0.19 4,342 ( 92%) 
Split 66    7,339 (97.9%)     21.0%        0.15 4,086 ( 86%) 
Resample    7,339 (97.9%)       NA%          NA 7,076 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      31.8%               153
MS Step 2      33.7%               612
MS Step 3      35.9%               459
MS Step 4      37.1%               459
MS Step 5      37.7%               459
MS Step 6      38.3%               459
MS Step 7      38.4%               459
MS Step 8      38.6%               459
MS Step 9      38.6%               459
MS Step 10     38.6%               459
MS Step 11     38.3%               459
MS Step 12     38.2%               459
MS Step 13     38.1%               459
MS Step 14     37.8%               459
MS Step 15     37.7%               459
MS Step 16     37.5%               459
MS Step 17     37.4%               459
MS Step 18     37.1%               459
MS Step 19     36.9%               459
MS Step 20     36.6%               459
MS Step 21     36.3%               459
MS Step 22     36.0%               459
MS Step 23     35.9%               459
MS Step 24     35.5%               459
MS Step 25     35.3%               459
MS Step 26     35.0%               459
MS Step 27     34.8%               459
MS Step 28     34.5%               459
MS Step 29     34.2%               459
MS Step 30     34.0%               459
MS Step 31     33.7%               459
MS Step 32     33.5%               459
MS Step 33     34.0%               459
MS Step 34     33.2%               459
MS Step 35     32.8%               612
MS Step 36     32.5%               612
MS Step 37     32.3%               612
MS Step 38     32.1%               612
MS Step 39     31.8%               612
MS Step 40     31.6%               612
MS Step 41     31.3%               612
MS Step 42     31.2%               612
MS Step 43     30.9%               612
MS Step 44     30.6%               612
MS Step 45     30.5%               612
MS Step 46     30.2%               612
MS Step 47     30.0%               612
MS Step 48     29.8%               612
MS Step 49     29.6%               612
MS Step 50     29.3%               612
MS Step 51     29.0%               612
MS Step 52     28.8%               612
MS Step 53     28.6%               612
MS Step 54     28.4%               612
MS Step 55     28.1%               612
MS Step 56     27.9%               612
MS Step 57     27.6%               612
MS Step 58     27.4%               612
MS Step 59     27.1%               612
MS Step 60     26.9%               612
MS Step 61     26.7%               612
MS Step 62     26.5%               612
MS Step 63     26.2%               612
MS Step 64     25.9%               612
MS Step 65     25.7%               612
MS Step 66     25.5%               612
```

**State House**

<img width="3000" height="5400" alt="validation_20260805_2005" src="https://github.com/user-attachments/assets/cc1b5fd2-af04-4873-b1af-7d217ccadcd9" />

```
SMC: 10,000 sampled plans of 134 districts on 4,110 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.75 to 0.82
87 rhat values are `NA`
Largest R-hat values for ordered summary statistics:
             adv_16              adv_18              adv_20              arv_16 
              1.003               1.004               1.004               1.006 
             arv_18              arv_20      atg_18_dem_ell      atg_18_rep_war 
              1.006               1.005               1.004               1.006 
    comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.003               1.000               1.002               1.001 
              e_dem               e_dvs                egap      gov_18_dem_wal 
              1.003               1.009               1.002               1.005 
     gov_18_rep_joh         muni_splits             ndshare                 ndv 
              1.006               1.001               1.010               1.004 
                nrv               pbias            plan_dev            pop_aian 
              1.003               1.002               1.000               1.004 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.013               1.004               1.005               1.013 
          pop_other         pop_overlap             pop_two           pop_white 
              1.004               1.005               1.003               1.005 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.005               1.003               1.006               1.004 
     pre_20_rep_tru      sos_18_dem_sim      sos_18_rep_how total_county_splits 
              1.006               1.004               1.005               1.006 
  total_muni_splits           total_vap      uss_18_dem_klo      uss_18_rep_new 
              1.002               1.001               1.005               1.003 
     uss_20_dem_smi      uss_20_rep_lew            vap_aian           vap_asian 
              1.004               1.004               1.004               1.006 
          vap_black            vap_hisp            vap_nhpi           vap_other 
              1.006               1.005               1.014               1.009 
            vap_two           vap_white 
              1.003               1.004 
• R-hat ≤ 1.05: 7149
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 7149
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@christopherkenny 