### PR TITLE
2020 North Dakota State House/Senate Districts

### DIFF
--- a/analyses/ND_leg_2020/01_prep_ND_leg_2020.R
+++ b/analyses/ND_leg_2020/01_prep_ND_leg_2020.R
@@ -1,0 +1,173 @@
+###############################################################################
+# Download and prepare data for `ND_leg_2020` analysis
+# © ALARM Project, July 2026
+###############################################################################
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg ND_leg_2020}")
+
+path_data <- download_redistricting_file("ND", "data-raw/ND", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/ND_2020/shp_vtd.rds"
+perim_path <- "data-out/ND_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong ND} shapefile")
+    # block-level redistricting data
+    nd_shp <- PL94171::pl_read(PL94171::pl_url("ND", year = 2020)) |>
+        PL94171::pl_subset(sumlev = "750") |>
+        PL94171::pl_select_standard() |>
+        rename(GEOID20 = GEOID) |>
+        left_join(y = tigris::blocks("ND", year = 2020), by = "GEOID20") |>
+        st_as_sf() |>
+        st_transform(EPSG$ND) |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add block-level geographic assignments from 2020 BAFs
+    baf_2020 <- PL94171::pl_get_baf("ND", cache_to = here("data-raw/ND/ND_baf.rds"))
+    d_muni <- baf_2020$INCPLACE_CDP |>
+        rename(GEOID = BLOCKID, muni = PLACEFP)
+    d_ssd <- baf_2020$SLDU |>
+        transmute(GEOID = BLOCKID,
+            ssd_2010 = as.integer(DISTRICT))
+    d_shd <- baf_2020$SLDL |>
+        transmute(GEOID = BLOCKID,
+            shd_2010 = as.integer(DISTRICT))
+    d_vtd <- baf_2020$VTD |>
+        transmute(GEOID = BLOCKID,
+            vtd_2020 = paste0(censable::match_fips("ND"), COUNTYFP, DISTRICT))
+
+    # Add census AIAN-area assignment: fort berthold reservation (4A) (AIANNHCE == "1160")
+    d_aiannh <- baf_2020$AIANNH |>
+        transmute(GEOID = BLOCKID, aiannh = AIANNHCE, fort_berthold = coalesce(AIANNHCE == "1160", FALSE))
+
+    nd_shp <- nd_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        left_join(d_vtd, by = "GEOID") |>
+        left_join(d_aiannh, by = "GEOID") |>
+        mutate(
+            county = paste0(censable::match_fips("ND"), county),
+            county_muni = if_else(is.na(muni), county, stringr::str_c(county, muni))
+        )
+
+    # add the enacted plan
+    d_ssd_2020 <- baf::baf(state = "ND", year = 2023, geographies = "ssd")$SSD2022 |>
+        transmute(GEOID, ssd_2020 = as.integer(SLDUST))
+    d_shd_2020 <- baf::baf(state = "ND", year = 2023, geographies = "shd")$SHD2022 |>
+        transmute(GEOID, shd_2020 = SLDLST)
+
+    nd_shp <- nd_shp |>
+        left_join(d_ssd_2020, by = "GEOID") |>
+        left_join(d_shd_2020, by = "GEOID")
+
+    # Create units for VTDs that cross enacted SSD/SHD boundaries
+    # or the Fort Berthold Reservation boundary.
+    split_vtds <- nd_shp |>
+        st_drop_geometry() |>
+        group_by(vtd_2020) |>
+        summarize(
+            split_vtd = n_distinct(ssd_2020) > 1L | n_distinct(shd_2020) > 1L |
+                n_distinct(fort_berthold) > 1L,
+            .groups = "drop"
+        )
+
+    vtd_elections <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        rename(vtd_2020 = GEOID20) |>
+        select(vtd_2020, pre_16_rep_tru:ndv)
+    election_cols <- setdiff(names(vtd_elections), "vtd_2020")
+
+    nd_shp <- nd_shp |>
+        left_join(split_vtds, by = "vtd_2020") |>
+        group_by(vtd_2020) |>
+        mutate(vtd_block_pop = sum(pop, na.rm = TRUE)) |>
+        ungroup() |>
+        left_join(vtd_elections, by = "vtd_2020") |>
+        mutate(
+            unit_id = if_else(
+                split_vtd,
+                stringr::str_c(vtd_2020, "_",
+                    stringr::str_pad(ssd_2020, 2, "left", "0"), "_",
+                    shd_2020, "_",
+                    if_else(fort_berthold, "FB", "NONFB")),
+                vtd_2020
+            ),
+            block_pop_share = if_else(vtd_block_pop > 0, pop/vtd_block_pop, 0)
+        ) |>
+        mutate(across(all_of(election_cols), ~ coalesce(.x, 0)*block_pop_share))
+
+    nd_shp <- nd_shp |>
+        group_by(unit_id) |>
+        summarize(
+            vtd_2020 = Mode(vtd_2020),
+            split_vtd = any(split_vtd),
+            aiannh = Mode(aiannh),
+            fort_berthold = any(fort_berthold),
+            ssd_2010 = Mode(ssd_2010),
+            shd_2010 = Mode(shd_2010),
+            ssd_2020 = Mode(ssd_2020),
+            shd_2020 = Mode(shd_2020),
+            muni = Mode(muni),
+            county_muni = Mode(county_muni),
+            state = Mode(state),
+            county = Mode(county),
+            across(any_of(c(
+                "pop", "pop_hisp", "pop_white", "pop_black", "pop_aian",
+                "pop_asian", "pop_nhpi", "pop_other", "pop_two",
+                "vap", "vap_hisp", "vap_white", "vap_black", "vap_aian",
+                "vap_asian", "vap_nhpi", "vap_other", "vap_two",
+                "ALAND20", "AWATER20", election_cols
+            )), \(x) sum(x, na.rm = TRUE)),
+            geometry = st_union(geometry),
+            .groups = "drop"
+        ) |>
+        rename(GEOID = unit_id, area_land = ALAND20, area_water = AWATER20) |>
+        relocate(muni, county_muni, vtd_2020, split_vtd, ssd_2010, shd_2010,
+            ssd_2020, shd_2020, .after = county)
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = nd_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        nd_shp <- rmapshaper::ms_simplify(nd_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    nd_shp$adj <- adjacency(nd_shp)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(nd_shp$adj, nd_shp$ssd_2020)
+    ccm(nd_shp$adj, nd_shp$shd_2020)
+
+    nd_shp <- nd_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(nd_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    nd_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong ND} shapefile")
+}

--- a/analyses/ND_leg_2020/02_setup_ND_leg_2020.R
+++ b/analyses/ND_leg_2020/02_setup_ND_leg_2020.R
@@ -1,0 +1,47 @@
+###############################################################################
+# Set up redistricting simulation for `ND_leg_2020`
+# © ALARM Project, July 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg ND_leg_2020}")
+
+# Recode the enacted House labels to numeric IDs.
+# (ND has character House labels like 04A/04B and 09A/09B)
+shd_lookup <- nd_shp |>
+    st_drop_geometry() |>
+    distinct(shd_2020) |>
+    arrange(shd_2020) |>
+    mutate(shd_2020_id = row_number())
+
+nd_shp <- nd_shp |>
+    left_join(shd_lookup, by = "shd_2020")
+
+map_ssd <- redist_map(nd_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = nd_shp$adj)
+
+map_shd <- redist_map(nd_shp, pop_tol = 0.05,
+    existing_plan = shd_2020_id, adj = nd_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+map_ssd <- map_ssd |>
+    mutate(reservation_core_id = if_else(fort_berthold, "fort_berthold_reservation",
+        paste0("unit_", row_number())))
+map_ssd_cores <- merge_by(map_ssd, reservation_core_id, drop_geom = FALSE)
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "ND_SSD_2020"
+attr(map_shd, "analysis_name") <- "ND_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/ND_2020/ND_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/ND_2020/ND_leg_2020_map_shd.rds", compress = "xz")
+write_rds(map_ssd_cores, "data-out/ND_2020/ND_leg_2020_map_ssd_cores.rds", compress = "xz")
+cli_process_done()

--- a/analyses/ND_leg_2020/03_sim_ND_shd_2020.R
+++ b/analyses/ND_leg_2020/03_sim_ND_shd_2020.R
@@ -1,0 +1,220 @@
+###############################################################################
+# Simulate plans for `ND_shd_2020` SHD
+# © ALARM Project, July 2026
+###############################################################################
+
+plans <- read_rds(here("data-out/ND_2020/ND_ssd_2020_plans5000.rds"))
+
+`%notin%` <- Negate(`%in%`)
+
+n_ssd <- n_distinct(nd_shp$ssd_2020)
+inner_nsims <- 50
+inner_runs <- 1
+outer_runs <- 5
+max_split_tries <- 100000
+split_ssds <- c(4L, 9L)
+
+year <- 2020
+shd_col <- paste0("shd_", year)
+ssd_col <- paste0("ssd_", year)
+
+# Generate district assignment matrix
+sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+final_sims <- ncol(sample_ssd_matrix)
+
+# Create shd map object
+map_shd_iterate <- redist_map(nd_shp, pop_tol = 0.05,
+    ndists = 94, adj = nd_shp$adj)
+
+# Unique ID for each row, will use later to reconnect pieces
+map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+map_shd_iterate_dummy <- map_shd_iterate
+
+# Assign arbitrary bounds
+attr(map_shd_iterate_dummy, "pop_bounds") <- c(1, 8288, 40000)
+
+# run the nested simulation
+cli_process_start("Running simulations for {.pkg ND_shd_2020}")
+
+set.seed(2020)
+
+for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
+    # Add senate district assignment from simulation i
+    map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+
+    plan_list <- vector("list", 3)
+
+    failed <- FALSE
+
+    # Iterate through SSD districts 4 and 9, to be split
+    for (j in c(1, 2)) {
+
+        dist <- case_when(j == 1 ~ 4,
+            j == 2 ~ 9,
+            TRUE ~ NA)
+
+        m <- map_shd_iterate %>%
+            filter(ssd_sim == dist)
+        map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+            ndists = 2, adj = m$adj)
+
+        output <- capture.output(
+            {
+                result <- tryCatch(
+                    {
+
+                        plans_j <- redist_smc(
+                            map_j,
+                            nsims = inner_nsims, runs = inner_runs,
+                            counties = county,
+                            sampling_space = "linking_edge",
+                            split_params = list(splitting_schedule = "any_valid_sizes"),
+                            verbose = TRUE,
+                            control = list(max_split_tries = max_split_tries))
+
+                        # Catch error
+                    },
+                    error = function(e) {
+                        NULL
+                    })
+            },
+            type = "output")
+
+        # Catch fail to split warning
+        if (is.null(result) || any(grepl("Failed to split", output))) {
+            failed <- TRUE
+            cat("\nFAILURE at outer i =", i, "inner j =", j, "\n")
+            break
+        }
+
+        plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+        plans_j$dist_keep <- TRUE
+        plan_list[[j]] <- list(map = map_j, plans = plans_j)
+    }
+    if (failed) {
+        # Return dummy plan
+        prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+        plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate_dummy, algorithm = "smc")
+        plans_dummy$draw <- as.factor(99999)
+
+        plans_i <- plans_dummy
+    }
+
+    # Create plans object for remaining districts
+    if (!failed) {
+        m <- map_shd_iterate %>%
+            filter(ssd_sim %notin% c(4, 9))
+
+        # Custom adjacency edits because remaining adjacency graph is non-contiguous
+        if (i == 10876) {
+            m$adj <- m$adj |>
+                geomander::add_edge(383, 278)
+        }
+
+        if (i == 22725) {
+            m$adj <- m$adj |>
+                geomander::add_edge(379, 22)
+        }
+
+        map_j <- redist_map(m, pop_bounds = attr(map_ssd, "pop_bounds"),
+            ndists = 45, adj = m$adj)
+
+
+        remaining_assignment <- map_shd_iterate$ssd_sim[map_shd_iterate$ssd_sim %notin% c(4, 9)]
+        remaining_assignment <- case_when(remaining_assignment == 46 ~ 4,
+            remaining_assignment == 47 ~ 9,
+            TRUE ~ remaining_assignment)
+
+
+        plans_j <- redist_plans(plans = matrix(remaining_assignment),
+            map = map_j,
+            algorithm = "smc")
+
+        plans_j$dist_keep <- TRUE
+        plan_list[[3]] <- list(map = map_j, plans = plans_j)
+
+
+        # Combine sub plans
+        prep_mat <- prep_particles(map = map_shd_iterate,
+            map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
+
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate_dummy, algorithm = "smc")
+
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)
+    }
+
+    if (i == 1) {
+        plans_shd <- plans_i
+    } else {
+        plans_shd <- rbind(plans_shd, plans_i)
+    }
+}
+
+# Survival rate
+survive <- plans_shd %>%
+    as.data.frame() %>%
+    filter(district == 1) %>%
+    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+    dplyr::select(survive)
+
+# Sample size
+sum(survive$survive)
+
+survive_all <- plans_shd %>%
+    as.data.frame() %>%
+    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+    dplyr::select(survive_all)
+
+plans_shd_matrix <- get_plans_matrix(plans_shd)
+plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+
+plans_shd <- redist_plans(plans = plans_shd_matrix,
+    map = map_shd,
+    algorithm = "smc")
+
+# Add draw and chain numbering
+plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+
+plans_shd$chain <- full_chain[survive_all$survive_all]
+
+# Add enacted plan
+map_shd[[shd_col]]
+
+plans_shd <- add_reference(plans_shd, ref_plan = as.integer(factor(map_shd[[shd_col]])), name = shd_col)
+
+plans <- plans_shd |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/ND_2020/ND_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg ND_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/ND_2020/ND_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+}

--- a/analyses/ND_leg_2020/03_sim_ND_shd_2020.R
+++ b/analyses/ND_leg_2020/03_sim_ND_shd_2020.R
@@ -32,6 +32,8 @@ map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
 map_shd_iterate_dummy <- map_shd_iterate
 
 # Assign arbitrary bounds
+# (most districts elect two members, but the subdistricts elect one.
+# Bounds prevent redist from rejecting the combined map)
 attr(map_shd_iterate_dummy, "pop_bounds") <- c(1, 8288, 40000)
 
 # run the nested simulation
@@ -39,10 +41,15 @@ cli_process_start("Running simulations for {.pkg ND_shd_2020}")
 
 set.seed(2020)
 
+# For each sampled Senate plan i, split simulated Senate districts 4 and 9
+# into two House subdistricts each, leave the remaining 45 Senate districts unchanged,
+# and recombine them into one statewide House plan.
 for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
+
     # Add senate district assignment from simulation i
     map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
 
+    # Completed House plan combines three pieces
     plan_list <- vector("list", 3)
 
     failed <- FALSE
@@ -54,7 +61,7 @@ for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
             j == 2 ~ 9,
             TRUE ~ NA)
 
-        m <- map_shd_iterate %>%
+        m <- map_shd_iterate |>
             filter(ssd_sim == dist)
         map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
             ndists = 2, adj = m$adj)
@@ -88,7 +95,7 @@ for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
             break
         }
 
-        plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+        plans_j <- plans_j |> filter(draw == inner_nsims*inner_runs)
         plans_j$dist_keep <- TRUE
         plan_list[[j]] <- list(map = map_j, plans = plans_j)
     }
@@ -101,12 +108,13 @@ for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
         plans_i <- plans_dummy
     }
 
-    # Create plans object for remaining districts
+    # If both required splits succeeded, create plans object for remaining 45 districts
     if (!failed) {
-        m <- map_shd_iterate %>%
+        m <- map_shd_iterate |>
             filter(ssd_sim %notin% c(4, 9))
 
-        # Custom adjacency edits because remaining adjacency graph is non-contiguous
+        # In some outer simulations, removing districts 4 and 9 disconnects the remaining adjacency graph.
+        # Add temporary edges to keep the adjacency graph connected
         if (i == 10876) {
             m$adj <- m$adj |>
                 geomander::add_edge(383, 278)
@@ -120,22 +128,20 @@ for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
         map_j <- redist_map(m, pop_bounds = attr(map_ssd, "pop_bounds"),
             ndists = 45, adj = m$adj)
 
-
         remaining_assignment <- map_shd_iterate$ssd_sim[map_shd_iterate$ssd_sim %notin% c(4, 9)]
         remaining_assignment <- case_when(remaining_assignment == 46 ~ 4,
             remaining_assignment == 47 ~ 9,
             TRUE ~ remaining_assignment)
-
 
         plans_j <- redist_plans(plans = matrix(remaining_assignment),
             map = map_j,
             algorithm = "smc")
 
         plans_j$dist_keep <- TRUE
+
         plan_list[[3]] <- list(map = map_j, plans = plans_j)
 
-
-        # Combine sub plans
+        # Combine the two simulated district splits with the 45 unchanged districts
         prep_mat <- prep_particles(map = map_shd_iterate,
             map_plan_list = plan_list,
             uid = row_id, dist_keep = dist_keep, nsims = 1)
@@ -153,20 +159,21 @@ for (i in 1:(nrow(plans[plans$draw != "ssd_2020", ])/n_ssd)) {
 }
 
 # Survival rate
-survive <- plans_shd %>%
-    as.data.frame() %>%
-    filter(district == 1) %>%
-    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+survive <- plans_shd |>
+    as.data.frame() |>
+    filter(district == 1) |>
+    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) |>
     dplyr::select(survive)
 
 # Sample size
 sum(survive$survive)
 
-survive_all <- plans_shd %>%
-    as.data.frame() %>%
-    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+survive_all <- plans_shd |>
+    as.data.frame() |>
+    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) |>
     dplyr::select(survive_all)
 
+# retain successful outer simulations only
 plans_shd_matrix <- get_plans_matrix(plans_shd)
 plans_shd_matrix <- plans_shd_matrix[, survive$survive]
 

--- a/analyses/ND_leg_2020/03_sim_ND_ssd_2020.R
+++ b/analyses/ND_leg_2020/03_sim_ND_ssd_2020.R
@@ -1,0 +1,62 @@
+###############################################################################
+# Simulate plans for `ND_ssd_2020` SSD
+# © ALARM Project, July 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg ND_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd_cores$ssd_2020)/3) + 120
+
+constr <- redist_constr(map_ssd_cores) |>
+    add_constr_total_splits(strength = 1.2, admin = county) |>
+    add_constr_total_splits(strength = 0.3, admin = muni) |>
+    add_constr_polsby(strength = 1.5)
+
+plans_full <- redist_smc(
+    map_ssd_cores,
+    nsims = 5000, runs = 5,
+    counties = pseudo_county,
+    constraints = constr,
+    ncores = 0,
+    pop_temper = 0.04,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+) |> pullback(map_ssd)
+
+plans <- plans_full |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+plans_full <- match_numbers(plans_full, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans_full, here("data-out/ND_2020/ND_ssd_2020_plans5000.rds"), compress = "xz")
+write_rds(plans, here("data-out/ND_2020/ND_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg ND_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/ND_2020/ND_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/ND_leg_2020/doc_ND_leg_2020.md
+++ b/analyses/ND_leg_2020/doc_ND_leg_2020.md
@@ -1,15 +1,14 @@
 # 2020 North Dakota State House/Senate Districts
 
 ## Redistricting requirements
-In North Dakota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in North Dakota must:
+In North Dakota, state legislative districts must, under the [N.D. Century Code §§ 54-03-01.5 and 54-03-01.14](https://ndlegis.gov/cencode/t54c03.pdf):
 
-1. be contiguous [NCSL186]
-1. have equal populations [NCSL 24]
-1. be geographically compact [NCSL 186]
-1. House nested in Senate or Congress [NCSL 187]
-
-([N.D. Century Code § 54-03-01.14](https://ndlegis.gov/cencode/t54c03.pdf#nameddest=54-03-01p14): "Each legislative district is entitled to one senator and two representatives. Districts 4 and 9
-are divided into subdistricts, and one representative must be elected from each subdistrict.")
+1. be contiguous (§ 54-03-01.5(4))
+2. be geographically compact (§ 54-03-01.5(4))
+3. be as nearly equal in population as is practicable (§ 54-03-01.5(5))
+4. provide for one senator and two representatives in each senatorial district, 
+   with the representatives elected at large except in Districts 4 and 9, 
+   which are each divided into two single-member subdistricts (§§ 54-03-01.5(1)-(2) and 54-03-01.14).
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 5.0%.

--- a/analyses/ND_leg_2020/doc_ND_leg_2020.md
+++ b/analyses/ND_leg_2020/doc_ND_leg_2020.md
@@ -8,6 +8,9 @@ In North Dakota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl
 1. be geographically compact [NCSL 186]
 1. House nested in Senate or Congress [NCSL 187]
 
+([N.D. Century Code § 54-03-01.14](https://ndlegis.gov/cencode/t54c03.pdf#nameddest=54-03-01p14): "Each legislative district is entitled to one senator and two representatives. Districts 4 and 9
+are divided into subdistricts, and one representative must be elected from each subdistrict.")
+
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 5.0%.
 

--- a/analyses/ND_leg_2020/doc_ND_leg_2020.md
+++ b/analyses/ND_leg_2020/doc_ND_leg_2020.md
@@ -1,0 +1,29 @@
+# 2020 North Dakota State House/Senate Districts
+
+## Redistricting requirements
+In North Dakota, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in North Dakota must:
+
+1. be contiguous [NCSL186]
+1. have equal populations [NCSL 24]
+1. be geographically compact [NCSL 186]
+1. House nested in Senate or Congress [NCSL 187]
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for North Dakota comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+One VTD exceeded the population limit for a simulation unit, and several VTDs crossed enacted SSD or SHD boundaries. We use 2020 Census blocks and block assignment files to divide these VTDs and create a common geography for the nested simulations. 
+We also divide VTDs along the Fort Berthold Reservation boundary and merge the reservation pieces into a single SSD sampling unit. This helps better represent the AIAN VAP distribution associated with enacted District 4A.
+
+## Simulation Notes
+We sample 25,000 districting plans for North Dakota's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+We impose total county- and municipality- constraints, Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (136).
+
+We use the top-down nested procedure to sample North Dakota's lower house districts.
+For each of the 25,000 sampled Senate plans, we run 50 inner SMC simulations within simulated Senate District 4 and another 50 within simulated Senate District 9. One successful split is retained for each district. The remaining 45 simulated Senate districts are carried forward as two-member House districts without an additional inner simulation.
+17,636 districting plans remaining in the surviving sample.
+We then thinned the number of samples to 10,000.


### PR DESCRIPTION
## Redistricting requirements
In North Dakota, state legislative districts must, under the [N.D. Century Code §§ 54-03-01.5 and 54-03-01.14](https://ndlegis.gov/cencode/t54c03.pdf):

1. be contiguous (§ 54-03-01.5(4))
2. be geographically compact (§ 54-03-01.5(4))
3. be as nearly equal in population as is practicable (§ 54-03-01.5(5))
4. provide for one senator and two representatives in each senatorial district, 
   with the representatives elected at large except in Districts 4 and 9, 
   which are each divided into two single-member subdistricts (§§ 54-03-01.5(1)-(2) and 54-03-01.14).

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for North Dakota comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
One VTD exceeded the population limit for a simulation unit, and several VTDs crossed enacted SSD or SHD boundaries. We use 2020 Census blocks and block assignment files to divide these VTDs and create a common geography for the nested simulations. 
We also divide VTDs along the Fort Berthold Reservation boundary and merge the reservation pieces into a single SSD sampling unit. This helps better represent the AIAN VAP distribution associated with enacted District 4A.

## Simulation Notes
We sample 25,000 districting plans for North Dakota's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
We impose total county- and municipality- constraints, Polsby-Popper compactness constraint, and increase the number of merge-split proposals per SMC step (136).

We use the top-down nested procedure to sample North Dakota's lower house districts.
For each of the 25,000 sampled Senate plans, we run 50 inner SMC simulations within simulated Senate District 4 and another 50 within simulated Senate District 9. One successful split is retained for each district. The remaining 45 simulated Senate districts are carried forward as two-member House districts without an additional inner simulation.
17,636 districting plans remaining in the surviving sample.
We then thinned the number of samples to 10,000.

## Validation
### State Senate
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/27f6d6be-9735-40ff-9845-06b8eef3c7fd" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 47
                 districts on 534 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0.04
Mergesplit Parameters:
• `total_ms_steps` = 46
• `mh_accept_per_smc` = 136
• `pair_rule` = uniform
Plan diversity 80% range: 0.47 to 0.63
33 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20      atg_18_dem_tho 
              1.010               1.010               1.021               1.012               1.011               1.013               1.013 
     atg_18_rep_ste     comp_bbox_reock           comp_edge         comp_polsby       county_splits               e_dem               e_dvs 
              1.012               1.010               1.005               1.014               1.001               1.003               1.018 
               egap      gov_16_dem_nel      gov_16_rep_bur      gov_20_dem_len      gov_20_rep_bur         muni_splits             ndshare 
              1.002               1.011               1.012               1.020               1.011               1.003               1.020 
                ndv                 nrv               pbias            plan_dev            pop_aian           pop_asian           pop_black 
              1.010               1.010               1.004               1.005               1.012               1.010               1.014 
           pop_hisp            pop_nhpi           pop_other         pop_overlap             pop_two           pop_white              pr_dem 
              1.013               1.007               1.012               1.018               1.011               1.012               1.005 
     pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru      sos_18_dem_bos total_county_splits   total_muni_splits 
              1.010               1.012               1.020               1.014               1.011               1.002               1.002 
          total_vap      uss_16_dem_gla      uss_16_rep_hoe      uss_18_dem_hei      uss_18_rep_cra            vap_aian           vap_asian 
              1.005               1.011               1.010               1.011               1.014               1.020               1.012 
          vap_black            vap_hisp            vap_nhpi           vap_other             vap_two           vap_white 
              1.015               1.012               1.008               1.012               1.014               1.014 
• R-hat ≤ 1.05: 2552
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2552
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1        450 (9.0%)    100.0%        2.04 3,139 ( 99%) 
Split 2        420 (8.4%)     96.7%        2.85 1,660 ( 53%) 
Split 3       998 (20.0%)     93.8%        2.31 1,680 ( 53%) 
Split 4     1,637 (32.7%)     90.1%        2.02 2,012 ( 64%) 
Split 5     2,120 (42.4%)     85.5%        1.78 2,273 ( 72%) 
Split 6     2,555 (51.1%)     83.1%        1.56 2,402 ( 76%) 
Split 7     2,696 (53.9%)     80.7%        1.37 2,494 ( 79%) 
Split 8     2,942 (58.8%)     79.6%        1.21 2,589 ( 82%) 
Split 9     3,163 (63.3%)     75.7%        1.10 2,659 ( 84%) 
Split 10    3,295 (65.9%)     73.2%        0.97 2,697 ( 85%) 
Split 11    3,447 (68.9%)     70.8%        0.91 2,767 ( 88%) 
Split 12    3,515 (70.3%)     68.1%        0.88 2,783 ( 88%) 
Split 13    3,694 (73.9%)     66.2%        0.79 2,830 ( 90%) 
Split 14    3,801 (76.0%)     62.6%        0.70 2,864 ( 91%) 
Split 15    3,875 (77.5%)     61.6%        0.68 2,869 ( 91%) 
Split 16    3,895 (77.9%)     60.1%        0.67 2,892 ( 92%) 
Split 17    3,967 (79.3%)     58.0%        0.62 2,902 ( 92%) 
Split 18    4,070 (81.4%)     56.1%        0.60 2,920 ( 92%) 
Split 19    4,120 (82.4%)     53.5%        0.56 2,943 ( 93%) 
Split 20    4,158 (83.2%)     52.4%        0.55 2,995 ( 95%) 
Split 21    4,211 (84.2%)     49.4%        0.51 2,938 ( 93%) 
Split 22    4,257 (85.1%)     48.5%        0.49 2,952 ( 93%) 
Split 23    4,278 (85.6%)     46.4%        0.48 2,970 ( 94%) 
Split 24    4,336 (86.7%)     44.2%        0.46 3,021 ( 96%) 
Split 25    4,364 (87.3%)     43.5%        0.44 2,957 ( 94%) 
Split 26    4,386 (87.7%)     41.0%        0.44 2,971 ( 94%) 
Split 27    4,440 (88.8%)     39.8%        0.41 3,019 ( 96%) 
Split 28    4,461 (89.2%)     37.9%        0.40 2,984 ( 94%) 
Split 29    4,481 (89.6%)     37.2%        0.38 2,973 ( 94%) 
Split 30    4,504 (90.1%)     35.8%        0.38 2,986 ( 94%) 
Split 31    4,515 (90.3%)     33.9%        0.37 2,973 ( 94%) 
Split 32    4,536 (90.7%)     31.8%        0.36 3,053 ( 97%) 
Split 33    4,572 (91.4%)     30.6%        0.34 2,969 ( 94%) 
Split 34    4,591 (91.8%)     30.1%        0.32 3,005 ( 95%) 
Split 35    4,594 (91.9%)     28.3%        0.33 2,968 ( 94%) 
Split 36    4,625 (92.5%)     26.7%        0.32 3,004 ( 95%) 
Split 37    4,628 (92.6%)     26.2%        0.31 2,999 ( 95%) 
Split 38    4,656 (93.1%)     24.3%        0.30 2,971 ( 94%) 
Split 39    4,667 (93.3%)     22.8%        0.30 2,954 ( 93%) 
Split 40    4,687 (93.7%)     22.0%        0.28 2,986 ( 94%) 
Split 41    4,702 (94.0%)     21.2%        0.27 2,914 ( 92%) 
Split 42    4,726 (94.5%)     20.2%        0.26 2,861 ( 91%) 
Split 43    4,743 (94.9%)     18.7%        0.25 2,838 ( 90%) 
Split 44    4,758 (95.2%)     17.3%        0.24 2,771 ( 88%) 
Split 45    4,781 (95.6%)     16.5%        0.23 2,544 ( 80%) 
Split 46    4,882 (97.6%)     15.1%        0.16 2,129 ( 67%) 
Resample    4,882 (97.6%)       NA%          NA 4,697 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      26.1%               136
MS Step 2      26.2%               544
MS Step 3      28.5%               544
MS Step 4      30.4%               544
MS Step 5      31.9%               544
MS Step 6      33.1%               544
MS Step 7      34.1%               544
MS Step 8      35.2%               408
MS Step 9      35.9%               408
MS Step 10     36.5%               408
MS Step 11     36.9%               408
MS Step 12     37.2%               408
MS Step 13     37.8%               408
MS Step 14     37.9%               408
MS Step 15     38.2%               408
MS Step 16     38.3%               408
MS Step 17     38.5%               408
MS Step 18     38.6%               408
MS Step 19     38.7%               408
MS Step 20     38.6%               408
MS Step 21     38.8%               408
MS Step 22     38.8%               408
MS Step 23     38.7%               408
MS Step 24     38.6%               408
MS Step 25     38.6%               408
MS Step 26     38.4%               408
MS Step 27     38.5%               408
MS Step 28     38.4%               408
MS Step 29     38.4%               408
MS Step 30     38.3%               408
MS Step 31     38.2%               408
MS Step 32     38.1%               408
MS Step 33     38.1%               408
MS Step 34     37.9%               408
MS Step 35     37.7%               408
MS Step 36     37.6%               408
MS Step 37     37.5%               408
MS Step 38     37.4%               408
MS Step 39     37.3%               408
MS Step 40     37.0%               408
MS Step 41     36.9%               408
MS Step 42     36.8%               408
MS Step 43     36.7%               408
MS Step 44     36.5%               408
MS Step 45     36.4%               408
MS Step 46     37.4%               408

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
• (*) Bottlenecks found: Consider weakening or removing constraints, or increasing the population tolerance. If the acceptance rate drops quickly in
the final splits, try increasing `pop_temper` by 0.01. If the weight variance (Log wgt. sd) increases steadily or is particularly large for the
"Resample" step, consider increasing `seq_alpha`. To visualize what geographic areas may be causing problems, try running the following code.
Highlighted areas are those that may be causing the bottleneck.
    plot(<map object>, rowMeans(as.matrix(plans) == <bottleneck iteration>))
```

### State House
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/2068aed1-9631-4fe9-be8c-1c24d30add04" />

```
SMC: 10,000 sampled plans of 49
                 districts on 534 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.47 to 0.62
34 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20      atg_18_dem_tho 
              1.016               1.014               1.021               1.015               1.010               1.014               1.015 
     atg_18_rep_ste     comp_bbox_reock           comp_edge         comp_polsby       county_splits               e_dem               e_dvs 
              1.010               1.011               1.008               1.014               1.001               1.009               1.025 
               egap      gov_16_dem_nel      gov_16_rep_bur      gov_20_dem_len      gov_20_rep_bur         muni_splits             ndshare 
              1.004               1.018               1.015               1.019               1.021               1.004               1.025 
                ndv                 nrv               pbias            plan_dev            pop_aian           pop_asian           pop_black 
              1.014               1.010               1.006               1.003               1.013               1.010               1.019 
           pop_hisp            pop_nhpi           pop_other         pop_overlap             pop_two           pop_white              pr_dem 
              1.021               1.011               1.020               1.019               1.016               1.011               1.018 
     pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru      sos_18_dem_bos total_county_splits   total_muni_splits 
              1.015               1.016               1.022               1.015               1.024               1.002               1.003 
          total_vap      uss_16_dem_gla      uss_16_rep_hoe      uss_18_dem_hei      uss_18_rep_cra            vap_aian           vap_asian 
              1.011               1.014               1.013               1.019               1.018               1.022               1.014 
          vap_black            vap_hisp            vap_nhpi           vap_other             vap_two           vap_white 
              1.022               1.017               1.015               1.015               1.017               1.015 
• R-hat ≤ 1.05: 2661
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2661
•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low
numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan 