### PR TITLE
HI_cd_2000&1990 update

### DIFF
--- a/analyses/HI_cd_1990/01_prep_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/01_prep_HI_cd_1990.R
@@ -61,7 +61,7 @@ if (!file.exists(here(shp_path))) {
   # create adjacency graph
   hi_shp$adj <- redist.adjacency(hi_shp)
   
-  # Connect precicnts
+  # Connect precincts
   island_codes <- tribble(
     ~v1,            ~v2,
     "15001000201",  "15001000202",

--- a/analyses/HI_cd_1990/01_prep_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/01_prep_HI_cd_1990.R
@@ -139,10 +139,15 @@ if (!file.exists(here(shp_path))) {
     mutate(
       v1 = match(v1, hi_shp$GEOID),
       v2 = match(v2, hi_shp$GEOID)
-    ) |>
-    filter(!is.na(v1), !is.na(v2), v1 != v2)
+    )
   
-  # Enforce symmetry automatically
+  stopifnot(
+    !anyNA(island_codes$v1),
+    !anyNA(island_codes$v2),
+    all(island_codes$v1 != island_codes$v2)
+  )
+  
+  # make adjacency symmetric
   island_codes_sym <- island_codes |>
     bind_rows(island_codes |> transmute(v1 = v2, v2 = v1)) |>
     distinct(v1, v2)

--- a/analyses/HI_cd_1990/02_setup_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/02_setup_HI_cd_1990.R
@@ -11,7 +11,7 @@ map <- redist_map(
   adj = hi_shp$adj
 )
 
-attr(map, "analysis_name") <- "HI_cd_1990"
+attr(map, "analysis_name") <- "HI_1990"
 
 map$state <- "HI"
 

--- a/analyses/HI_cd_1990/02_setup_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/02_setup_HI_cd_1990.R
@@ -4,9 +4,6 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg HI_cd_1990}")
 
-# assumes `hi_shp` is in memory from your first script (or loaded from shp_path)
-# and that `hi_shp$adj` exists.
-
 map <- redist_map(
   hi_shp,
   pop_tol = 0.005,
@@ -14,12 +11,6 @@ map <- redist_map(
   adj = hi_shp$adj
 )
 
-# Create sub-map for Honolulu County (keep same pattern as HI_cd_2010)
-map_honolulu <- map |>
-  dplyr::filter(county == "003") |>
-  `attr<-`("pop_bounds", attr(map, "pop_bounds"))
-
-# REQUIRED for add_summary_stats() in your utilities
 attr(map, "analysis_name") <- "HI_cd_1990"
 
 map$state <- "HI"

--- a/analyses/HI_cd_1990/03_sim_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/03_sim_HI_cd_1990.R
@@ -92,7 +92,7 @@ cli_process_done()
 
 cli_process_start("Saving {.cls redist_plans} object")
 
-# Output the redist_map object. Do not edit this path.
+# Output the redist_plans object. Do not edit this path.
 write_rds(plans, here("data-out/HI_1990/HI_cd_1990_plans.rds"), compress = "xz")
 cli_process_done()
 

--- a/analyses/HI_cd_1990/03_sim_HI_cd_1990.R
+++ b/analyses/HI_cd_1990/03_sim_HI_cd_1990.R
@@ -8,11 +8,9 @@ cli_process_start("Running simulations for {.pkg HI_cd_1990}")
 
 set.seed(1990)
 
-# Target output
+# Simulation settings
 target_per_chain <- 2500L
 runs <- 2L
-
-# Start reasonably large
 nsims <- 30000L   
 
 plans_raw <- redist_smc(
@@ -27,11 +25,16 @@ cli_process_done()
 cli_process_start("HI_cd_1990: filter draws")
 
 mat_all <- get_plans_matrix(plans_raw)
-mat_sim <- if (ncol(mat_all) == nsims * runs + 1L) mat_all[, -1, drop = FALSE] else mat_all
-
 w_all <- get_plans_weights(plans_raw)
-w_sim <- if (length(w_all) == ncol(mat_sim) + 1L) w_all[-1] else w_all
-if (length(w_sim) != ncol(mat_sim)) stop("weights/cols mismatch")
+
+stopifnot(
+  ncol(mat_all) == nsims * runs + 1L,
+  identical(colnames(mat_all)[1], "cd_1990"),
+  length(w_all) == ncol(mat_all)
+)
+
+mat_sim <- mat_all[, -1, drop = FALSE]
+w_sim <- w_all[-1]
 
 non_hnl <- map$county != "003"
 
@@ -43,7 +46,7 @@ w_keep <- w_sim[keep]
 
 cli_alert_info("Kept {ncol(mat_keep)} / {ncol(mat_sim)}")
 
-chain_all  <- rep(seq_len(runs), each = nsims)
+chain_all <- rep(seq_len(runs), each = nsims)
 chain_keep <- chain_all[keep]
 
 # take first `target_per_chain` kept per chain
@@ -54,7 +57,7 @@ pick <- unlist(lapply(seq_len(runs), function(ch) {
 }))
 
 mat_final <- mat_keep[, pick, drop = FALSE]
-w_final   <- w_keep[pick]
+w_final <- w_keep[pick]
 chain_cols <- chain_keep[pick]
 
 cli_process_done()
@@ -73,28 +76,14 @@ plans <- redist_plans(
   wgt       = w_final
 )
 
-# chain column: redist_plans sometimes has 1 row per draw or 2 rows per draw
-n <- nrow(plans)
-if (n == length(chain_cols)) {
-  plans <- plans |> dplyr::mutate(chain = chain_cols, .after = draw)
-} else if (n == 2L * length(chain_cols)) {
-  plans <- plans |> dplyr::mutate(chain = rep(chain_cols, each = 2L), .after = draw)
-} else {
-  cli_abort("chain length mismatch")
-}
+# Add chain labels
+stopifnot(nrow(plans) == 2L * length(chain_cols))
+
+plans <- plans |>
+  dplyr::mutate(chain = rep(chain_cols, each = 2L), .after = draw)
 
 plans <- plans |>
   add_reference(ref_plan = map$cd_1990, name = "cd_1990")
-
-# if reference got added once, copy for chain 2
-if ("is_reference" %in% names(plans)) {
-  ref_rows <- dplyr::filter(plans, is_reference)
-  if (nrow(ref_rows) == 1L && runs == 2L) {
-    ref2 <- ref_rows
-    ref2$chain <- setdiff(seq_len(runs), ref_rows$chain)[1]
-    plans <- dplyr::bind_rows(plans, ref2)
-  }
-}
 
 # relabel to match the enacted plan
 plans <- match_numbers(plans, "cd_1990")

--- a/analyses/HI_cd_2000/02_setup_HI_cd_2000.R
+++ b/analyses/HI_cd_2000/02_setup_HI_cd_2000.R
@@ -7,11 +7,6 @@ cli_process_start("Creating {.cls redist_map} object for {.pkg HI_cd_2000}")
 map <- redist_map(hi_shp, pop_tol = 0.005,
     existing_plan = cd_2000, adj = hi_shp$adj)
 
-# Create sub-map for Honolulu County
-map_honolulu <- map %>%
-    filter(county == "003") %>%
-    `attr<-`("pop_bounds", attr(map, "pop_bounds"))
-
 attr(map, "analysis_name") <- "HI_2000"
 
 map$state <- "HI"

--- a/analyses/HI_cd_2000/03_sim_HI_cd_2000.R
+++ b/analyses/HI_cd_2000/03_sim_HI_cd_2000.R
@@ -92,7 +92,7 @@ cli_process_done()
 
 cli_process_start("Saving {.cls redist_plans} object")
 
-# Output the redist_map object. Do not edit this path.
+# Output the redist_plans object. Do not edit this path.
 write_rds(plans, here("data-out/HI_2000/HI_cd_2000_plans.rds"), compress = "xz")
 cli_process_done()
 

--- a/analyses/HI_cd_2000/03_sim_HI_cd_2000.R
+++ b/analyses/HI_cd_2000/03_sim_HI_cd_2000.R
@@ -8,11 +8,9 @@ cli_process_start("Running simulations for {.pkg HI_cd_2000}")
 
 set.seed(2000)
 
-# Target output
+# Simulation settings
 target_per_chain <- 2500L
 runs <- 2L
-
-# Start reasonably large
 nsims <- 30000L
 
 plans_raw <- redist_smc(
@@ -27,11 +25,16 @@ cli_process_done()
 cli_process_start("HI_cd_2000: filter draws")
 
 mat_all <- get_plans_matrix(plans_raw)
-mat_sim <- if (ncol(mat_all) == nsims*runs + 1L) mat_all[, -1, drop = FALSE] else mat_all
-
 w_all <- get_plans_weights(plans_raw)
-w_sim <- if (length(w_all) == ncol(mat_sim) + 1L) w_all[-1] else w_all
-if (length(w_sim) != ncol(mat_sim)) stop("weights/cols mismatch")
+
+stopifnot(
+    ncol(mat_all) == nsims*runs + 1L,
+    identical(colnames(mat_all)[1], "cd_2000"),
+    length(w_all) == ncol(mat_all)
+)
+
+mat_sim <- mat_all[, -1, drop = FALSE]
+w_sim <- w_all[-1]
 
 non_hnl <- map$county != "003"
 
@@ -64,6 +67,7 @@ cli_process_start("Building redist_plans object")
 
 stopifnot(all(mat_final %in% c(1L, 2L)))
 storage.mode(mat_final) <- "integer"
+
 colnames(mat_final) <- NULL
 
 plans <- redist_plans(
@@ -73,28 +77,13 @@ plans <- redist_plans(
     wgt       = w_final
 )
 
-# chain column: redist_plans sometimes has 1 row per draw or 2 rows per draw
-n <- nrow(plans)
-if (n == length(chain_cols)) {
-    plans <- plans |> dplyr::mutate(chain = chain_cols, .after = draw)
-} else if (n == 2L*length(chain_cols)) {
-    plans <- plans |> dplyr::mutate(chain = rep(chain_cols, each = 2L), .after = draw)
-} else {
-    cli_abort("chain length mismatch")
-}
+# Add chain labels
+stopifnot(nrow(plans) == 2L*length(chain_cols))
+plans <- plans |>
+    dplyr::mutate(chain = rep(chain_cols, each = 2L), .after = draw)
 
 plans <- plans |>
     add_reference(ref_plan = map$cd_2000, name = "cd_2000")
-
-# if reference got added once, copy for chain 2
-if ("is_reference" %in% names(plans)) {
-    ref_rows <- dplyr::filter(plans, is_reference)
-    if (nrow(ref_rows) == 1L && runs == 2L) {
-        ref2 <- ref_rows
-        ref2$chain <- setdiff(seq_len(runs), ref_rows$chain)[1]
-        plans <- dplyr::bind_rows(plans, ref2)
-    }
-}
 
 # relabel to match the enacted plan
 plans <- match_numbers(plans, "cd_2000")


### PR DESCRIPTION
This update simplifies the HI 1990 and HI 2000 implementations and makes them easier to follow while preserving the documented analysis design. The state-specific adjacency rules, statewide SMC setup, Honolulu filtering rule, and simulation parameters are unchanged.