### PR TITLE
2020 Oregon State House/Senate Districts

### DIFF
--- a/analyses/OR_leg_2020/01_prep_OR_leg_2020.R
+++ b/analyses/OR_leg_2020/01_prep_OR_leg_2020.R
@@ -4,14 +4,14 @@
 ###############################################################################
 
 suppressMessages({
-  library(dplyr)
-  library(readr)
-  library(sf)
-  library(redist)
-  library(geomander)
-  library(cli)
-  library(here)
-  devtools::load_all() # load utilities
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    devtools::load_all() # load utilities
 })
 
 # Download necessary files for analysis -----
@@ -35,112 +35,112 @@ shp_path <- "data-out/OR_2020/shp_vtd.rds"
 perim_path <- "data-out/OR_2020/perim.rds"
 
 if (!file.exists(here(shp_path))) {
-  cli_process_start("Preparing {.strong OR} shapefile")
-  # read in redistricting data
-  or_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c"))
-  or_enacted_ssd <-  read_csv(here(path_baf_ssd), col_types = "ci", col_names = c("GEOID20", "ssd_2020"))
-  or_enacted_shd <-  read_csv(here(path_baf_shd), col_types = "ci", col_names = c("GEOID20", "shd_2020"))
-  or_enacted <- full_join(or_enacted_ssd, or_enacted_shd, by = "GEOID20")
-  or_shp <- left_join(or_shp, or_enacted, by = "GEOID20") %>%
-    relocate(c(ssd_2020, shd_2020), .after = county)
-  # add shapefile
-  geom_d <- tigris::blocks("OR", year = 2020) %>%
-    select(GEOID20 = GEOID20, area_land = ALAND20, area_water = AWATER20, geometry)
-  # add municipalities
-  baf <- PL94171::pl_get_baf("OR", cache_to = here(str_glue("data-raw/OR/or_baf.rds")))
-  d_muni <- baf$INCPLACE_CDP %>%
-    transmute(GEOID20 = BLOCKID,
-              muni =  if_else(is.na(PLACEFP), NA_character_,
-                              paste0(censable::match_fips("OR"), PLACEFP)))
+    cli_process_start("Preparing {.strong OR} shapefile")
+    # read in redistricting data
+    or_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c"))
+    or_enacted_ssd <-  read_csv(here(path_baf_ssd), col_types = "ci", col_names = c("GEOID20", "ssd_2020"))
+    or_enacted_shd <-  read_csv(here(path_baf_shd), col_types = "ci", col_names = c("GEOID20", "shd_2020"))
+    or_enacted <- full_join(or_enacted_ssd, or_enacted_shd, by = "GEOID20")
+    or_shp <- left_join(or_shp, or_enacted, by = "GEOID20") %>%
+        relocate(c(ssd_2020, shd_2020), .after = county)
+    # add shapefile
+    geom_d <- tigris::blocks("OR", year = 2020) %>%
+        select(GEOID20 = GEOID20, area_land = ALAND20, area_water = AWATER20, geometry)
+    # add municipalities
+    baf <- PL94171::pl_get_baf("OR", cache_to = here(str_glue("data-raw/OR/or_baf.rds")))
+    d_muni <- baf$INCPLACE_CDP %>%
+        transmute(GEOID20 = BLOCKID,
+            muni =  if_else(is.na(PLACEFP), NA_character_,
+                paste0(censable::match_fips("OR"), PLACEFP)))
 
-  # join everything
-  or_shp <- left_join(or_shp, geom_d, by = "GEOID20") %>%
-    left_join(d_muni, by = "GEOID20") %>%
-    relocate(muni, .after = county) %>%
-    sf::st_as_sf() %>%
-    st_transform(EPSG$OR) %>%
-    rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID")) %>%
-    mutate(GEOID = str_sub(GEOID, 1, 11)) %>% # trim to tracts
-    group_by(GEOID) %>%
-    summarize(state = state[1], county = county[1],
-              ssd_2020 = Mode(ssd_2020), shd_2020 = Mode(shd_2020),
-              muni = muni[1],
-              across(pop:ndv, function(x) sum(x, na.rm = TRUE)),
-              across(area_land:area_water, sum),
-              is_coverage = TRUE) %>%
-    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
-    relocate(county_muni, .after = muni)
+    # join everything
+    or_shp <- left_join(or_shp, geom_d, by = "GEOID20") %>%
+        left_join(d_muni, by = "GEOID20") %>%
+        relocate(muni, .after = county) %>%
+        sf::st_as_sf() %>%
+        st_transform(EPSG$OR) %>%
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID")) %>%
+        mutate(GEOID = str_sub(GEOID, 1, 11)) %>% # trim to tracts
+        group_by(GEOID) %>%
+        summarize(state = state[1], county = county[1],
+            ssd_2020 = Mode(ssd_2020), shd_2020 = Mode(shd_2020),
+            muni = muni[1],
+            across(pop:ndv, function(x) sum(x, na.rm = TRUE)),
+            across(area_land:area_water, sum),
+            is_coverage = TRUE) %>%
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+        relocate(county_muni, .after = muni)
 
-  d_ssd_2010 <- tigris::state_legislative_districts("OR", house = "upper", year = 2021)
-  d_shd_2010 <- tigris::state_legislative_districts("OR", house = "lower", year = 2021)
-  or_shp <- or_shp %>%
-    mutate(ssd_2010 = as.integer(d_ssd_2010$SLDUST)[
-      geo_match(or_shp, d_ssd_2010, method = "area")],
-      .before = ssd_2020) %>%
-    mutate(shd_2010 = as.integer(d_shd_2010$SLDLST)[
-      geo_match(or_shp, d_shd_2010, method = "area")],
-      .before = shd_2020)
+    d_ssd_2010 <- tigris::state_legislative_districts("OR", house = "upper", year = 2021)
+    d_shd_2010 <- tigris::state_legislative_districts("OR", house = "lower", year = 2021)
+    or_shp <- or_shp %>%
+        mutate(ssd_2010 = as.integer(d_ssd_2010$SLDUST)[
+            geo_match(or_shp, d_ssd_2010, method = "area")],
+        .before = ssd_2020) %>%
+        mutate(shd_2010 = as.integer(d_shd_2010$SLDLST)[
+            geo_match(or_shp, d_shd_2010, method = "area")],
+        .before = shd_2020)
 
-  # Create perimeters in case shapes are simplified
-  redistmetrics::prep_perims(shp = or_shp,
-                             perim_path = here(perim_path)) %>%
-    invisible()
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = or_shp,
+        perim_path = here(perim_path)) %>%
+        invisible()
 
-  # simplifies geometry for faster processing, plotting, and smaller shapefiles
-  if (requireNamespace("rmapshaper", quietly = TRUE)) {
-    or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
-                                      keep_shapes = TRUE) %>%
-      suppressWarnings()
-  }
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
+            keep_shapes = TRUE) %>%
+            suppressWarnings()
+    }
 
-  # Highway plot for geographical links constraint
-  if (FALSE) {
-    library(ggplot2)
-    d_roads <- tigris::primary_secondary_roads("OR", 2024) %>%
-      st_transform(EPSG$OR)
+    # Highway plot for geographical links constraint
+    if (FALSE) {
+        library(ggplot2)
+        d_roads <- tigris::primary_secondary_roads("OR", 2024) %>%
+            st_transform(EPSG$OR)
 
-    ggplot(or_shp, aes(fill = county)) +
-      geom_sf(size = 0.2, color = "white") +
-      geom_sf(size = 0.7, color = "red", fill = NA, inherit.aes = FALSE,
-              data = summarize(group_by(or_shp, ssd_2020), is_coverage = TRUE)) +
-      geom_sf(size = 0.4, color = "black", inherit.aes = FALSE,
-              data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
-      geom_sf_text(aes(label = county), size = 2.2, color = "black",
-                   data = filter(or_shp, area_land >= 1e8)) +
-      scale_fill_manual(values = sf.colors(36, categorical = TRUE), guide = "none") +
-      theme_void()
-  }
+        ggplot(or_shp, aes(fill = county)) +
+            geom_sf(size = 0.2, color = "white") +
+            geom_sf(size = 0.7, color = "red", fill = NA, inherit.aes = FALSE,
+                data = summarize(group_by(or_shp, ssd_2020), is_coverage = TRUE)) +
+            geom_sf(size = 0.4, color = "black", inherit.aes = FALSE,
+                data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
+            geom_sf_text(aes(label = county), size = 2.2, color = "black",
+                data = filter(or_shp, area_land >= 1e8)) +
+            scale_fill_manual(values = sf.colors(36, categorical = TRUE), guide = "none") +
+            theme_void()
+    }
 
-  # create adjacency graph
-  or_shp$adj <- redist.adjacency(or_shp)
+    # create adjacency graph
+    or_shp$adj <- redist.adjacency(or_shp)
 
-  # Disconnect counties not connected by state or federal highways
-  disconn_cty <- function(adj, cty1, cty2) {
-    v1 <- which(or_shp$county == str_c(cty1, " County"))
-    if (length(v1) == 0) stop(cty1, "not found")
-    v2 <- which(or_shp$county == str_c(cty2, " County"))
-    if (length(v2) == 0) stop(cty1, "not found")
-    vs <- tidyr::crossing(v1, v2)
-    remove_edge(adj, vs$v1, vs$v2)
-  }
-  or_shp$adj <- or_shp$adj %>%
-    disconn_cty("Curry", "Josephine") %>%
-    disconn_cty("Benton", "Lane") %>%
-    disconn_cty("Polk", "Lincoln") %>%
-    disconn_cty("Marion", "Jefferson") %>%
-    disconn_cty("Marion", "Wasco") %>%
-    disconn_cty("Wallowa", "Baker") %>%
-    disconn_cty("Morrow", "Grant") %>%
-    disconn_cty("Crook", "Grant") %>%
-    disconn_cty("Deschutes", "Harney") %>%
-    disconn_cty("Deschutes", "Linn")
+    # Disconnect counties not connected by state or federal highways
+    disconn_cty <- function(adj, cty1, cty2) {
+        v1 <- which(or_shp$county == str_c(cty1, " County"))
+        if (length(v1) == 0) stop(cty1, "not found")
+        v2 <- which(or_shp$county == str_c(cty2, " County"))
+        if (length(v2) == 0) stop(cty1, "not found")
+        vs <- tidyr::crossing(v1, v2)
+        remove_edge(adj, vs$v1, vs$v2)
+    }
+    or_shp$adj <- or_shp$adj %>%
+        disconn_cty("Curry", "Josephine") %>%
+        disconn_cty("Benton", "Lane") %>%
+        disconn_cty("Polk", "Lincoln") %>%
+        disconn_cty("Marion", "Jefferson") %>%
+        disconn_cty("Marion", "Wasco") %>%
+        disconn_cty("Wallowa", "Baker") %>%
+        disconn_cty("Morrow", "Grant") %>%
+        disconn_cty("Crook", "Grant") %>%
+        disconn_cty("Deschutes", "Harney") %>%
+        disconn_cty("Deschutes", "Linn")
 
-  or_shp <- or_shp %>%
-    fix_geo_assignment(muni)
+    or_shp <- or_shp %>%
+        fix_geo_assignment(muni)
 
-  write_rds(or_shp, here(shp_path), compress = "gz")
-  cli_process_done()
+    write_rds(or_shp, here(shp_path), compress = "gz")
+    cli_process_done()
 } else {
-  or_shp <- read_rds(here(shp_path))
-  cli_alert_success("Loaded {.strong OR} shapefile")
+    or_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong OR} shapefile")
 }

--- a/analyses/OR_leg_2020/01_prep_OR_leg_2020.R
+++ b/analyses/OR_leg_2020/01_prep_OR_leg_2020.R
@@ -1,0 +1,146 @@
+###############################################################################
+# Download and prepare data for `OR_cd_2020` analysis
+# © ALARM Project, October 2021
+###############################################################################
+
+suppressMessages({
+  library(dplyr)
+  library(readr)
+  library(sf)
+  library(redist)
+  library(geomander)
+  library(cli)
+  library(here)
+  devtools::load_all() # load utilities
+})
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg OR_cd_2020}")
+
+url <- "https://raw.githubusercontent.com/alarm-redist/census-2020/main/census-vest-2020/or_2020_block.csv"
+path_data <- "data-raw/OR/or_2020_block.csv"
+download(url, here(path_data))
+
+# Manually download the zip file from
+# https://geo.maps.arcgis.com/home/item.html?id=b43a1bf5997d4863a45023bfe7a047b1
+# Extract to 'data-raw/OR/'. Congress block assignment file is:
+# "Congress SB 881A (Block Assignment File).txt"
+path_baf_ssd <- "data-raw/OR/Senate SB 882 (Block Assignment File).txt"
+path_baf_shd <- "data-raw/OR/House SB 882 (Block Assignment File).txt"
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/OR_2020/shp_vtd.rds"
+perim_path <- "data-out/OR_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+  cli_process_start("Preparing {.strong OR} shapefile")
+  # read in redistricting data
+  or_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c"))
+  or_enacted_ssd <-  read_csv(here(path_baf_ssd), col_types = "ci", col_names = c("GEOID20", "ssd_2020"))
+  or_enacted_shd <-  read_csv(here(path_baf_shd), col_types = "ci", col_names = c("GEOID20", "shd_2020"))
+  or_enacted <- full_join(or_enacted_ssd, or_enacted_shd, by = "GEOID20")
+  or_shp <- left_join(or_shp, or_enacted, by = "GEOID20") %>%
+    relocate(c(ssd_2020, shd_2020), .after = county)
+  # add shapefile
+  geom_d <- tigris::blocks("OR", year = 2020) %>%
+    select(GEOID20 = GEOID20, area_land = ALAND20, area_water = AWATER20, geometry)
+  # add municipalities
+  baf <- PL94171::pl_get_baf("OR", cache_to = here(str_glue("data-raw/OR/or_baf.rds")))
+  d_muni <- baf$INCPLACE_CDP %>%
+    transmute(GEOID20 = BLOCKID,
+              muni =  if_else(is.na(PLACEFP), NA_character_,
+                              paste0(censable::match_fips("OR"), PLACEFP)))
+
+  # join everything
+  or_shp <- left_join(or_shp, geom_d, by = "GEOID20") %>%
+    left_join(d_muni, by = "GEOID20") %>%
+    relocate(muni, .after = county) %>%
+    sf::st_as_sf() %>%
+    st_transform(EPSG$OR) %>%
+    rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID")) %>%
+    mutate(GEOID = str_sub(GEOID, 1, 11)) %>% # trim to tracts
+    group_by(GEOID) %>%
+    summarize(state = state[1], county = county[1],
+              ssd_2020 = Mode(ssd_2020), shd_2020 = Mode(shd_2020),
+              muni = muni[1],
+              across(pop:ndv, function(x) sum(x, na.rm = TRUE)),
+              across(area_land:area_water, sum),
+              is_coverage = TRUE) %>%
+    mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) %>%
+    relocate(county_muni, .after = muni)
+
+  d_ssd_2010 <- tigris::state_legislative_districts("OR", house = "upper", year = 2021)
+  d_shd_2010 <- tigris::state_legislative_districts("OR", house = "lower", year = 2021)
+  or_shp <- or_shp %>%
+    mutate(ssd_2010 = as.integer(d_ssd_2010$SLDUST)[
+      geo_match(or_shp, d_ssd_2010, method = "area")],
+      .before = ssd_2020) %>%
+    mutate(shd_2010 = as.integer(d_shd_2010$SLDLST)[
+      geo_match(or_shp, d_shd_2010, method = "area")],
+      .before = shd_2020)
+
+  # Create perimeters in case shapes are simplified
+  redistmetrics::prep_perims(shp = or_shp,
+                             perim_path = here(perim_path)) %>%
+    invisible()
+
+  # simplifies geometry for faster processing, plotting, and smaller shapefiles
+  if (requireNamespace("rmapshaper", quietly = TRUE)) {
+    or_shp <- rmapshaper::ms_simplify(or_shp, keep = 0.05,
+                                      keep_shapes = TRUE) %>%
+      suppressWarnings()
+  }
+
+  # Highway plot for geographical links constraint
+  if (FALSE) {
+    library(ggplot2)
+    d_roads <- tigris::primary_secondary_roads("OR", 2024) %>%
+      st_transform(EPSG$OR)
+
+    ggplot(or_shp, aes(fill = county)) +
+      geom_sf(size = 0.2, color = "white") +
+      geom_sf(size = 0.7, color = "red", fill = NA, inherit.aes = FALSE,
+              data = summarize(group_by(or_shp, ssd_2020), is_coverage = TRUE)) +
+      geom_sf(size = 0.4, color = "black", inherit.aes = FALSE,
+              data = filter(d_roads, RTTYP %in% c("I", "U", "S"))) +
+      geom_sf_text(aes(label = county), size = 2.2, color = "black",
+                   data = filter(or_shp, area_land >= 1e8)) +
+      scale_fill_manual(values = sf.colors(36, categorical = TRUE), guide = "none") +
+      theme_void()
+  }
+
+  # create adjacency graph
+  or_shp$adj <- redist.adjacency(or_shp)
+
+  # Disconnect counties not connected by state or federal highways
+  disconn_cty <- function(adj, cty1, cty2) {
+    v1 <- which(or_shp$county == str_c(cty1, " County"))
+    if (length(v1) == 0) stop(cty1, "not found")
+    v2 <- which(or_shp$county == str_c(cty2, " County"))
+    if (length(v2) == 0) stop(cty1, "not found")
+    vs <- tidyr::crossing(v1, v2)
+    remove_edge(adj, vs$v1, vs$v2)
+  }
+  or_shp$adj <- or_shp$adj %>%
+    disconn_cty("Curry", "Josephine") %>%
+    disconn_cty("Benton", "Lane") %>%
+    disconn_cty("Polk", "Lincoln") %>%
+    disconn_cty("Marion", "Jefferson") %>%
+    disconn_cty("Marion", "Wasco") %>%
+    disconn_cty("Wallowa", "Baker") %>%
+    disconn_cty("Morrow", "Grant") %>%
+    disconn_cty("Crook", "Grant") %>%
+    disconn_cty("Deschutes", "Harney") %>%
+    disconn_cty("Deschutes", "Linn")
+
+  or_shp <- or_shp %>%
+    fix_geo_assignment(muni)
+
+  write_rds(or_shp, here(shp_path), compress = "gz")
+  cli_process_done()
+} else {
+  or_shp <- read_rds(here(shp_path))
+  cli_alert_success("Loaded {.strong OR} shapefile")
+}

--- a/analyses/OR_leg_2020/02_setup_OR_leg_2020.R
+++ b/analyses/OR_leg_2020/02_setup_OR_leg_2020.R
@@ -4,24 +4,19 @@
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg OR_leg_2020}")
 
-# TODO any pre-computation (usually not necessary)
-
 map_ssd <- redist_map(or_shp, pop_tol = 0.05,
     existing_plan = ssd_2020, adj = or_shp$adj)
 
 map_shd <- redist_map(or_shp, pop_tol = 0.05,
     existing_plan = shd_2020, adj = or_shp$adj)
 
-# TODO any filtering, cores, merging, etc.
-
-# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
 # make pseudo counties with default settings
 map_ssd <- map_ssd |>
     mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_ssd)))
+        pop_muni = get_target(map_ssd)))
 map_shd <- map_shd |>
     mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
-                                            pop_muni = get_target(map_shd)))
+        pop_muni = get_target(map_shd)))
 # IF MERGING CORES OR OTHER UNITS:
 # make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
 

--- a/analyses/OR_leg_2020/02_setup_OR_leg_2020.R
+++ b/analyses/OR_leg_2020/02_setup_OR_leg_2020.R
@@ -1,0 +1,35 @@
+###############################################################################
+# Set up redistricting simulation for `OR_leg_2020`
+# © ALARM Project, January 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg OR_leg_2020}")
+
+# TODO any pre-computation (usually not necessary)
+
+map_ssd <- redist_map(or_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = or_shp$adj)
+
+map_shd <- redist_map(or_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = or_shp$adj)
+
+# TODO any filtering, cores, merging, etc.
+
+# TODO remove if not necessary. Adjust pop_muni as needed to balance county/muni splits
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+                                            pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "OR_SSD_2020"
+attr(map_shd, "analysis_name") <- "OR_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/OR_2020/OR_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/OR_2020/OR_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/OR_leg_2020/03_sim_OR_shd_2020.R
+++ b/analyses/OR_leg_2020/03_sim_OR_shd_2020.R
@@ -5,177 +5,165 @@
 
 nested_smc <- function(plans, map_ssd, map_shd, shp, inner_nsims = 50, inner_runs = 1, outer_runs = 5, year = 2020, state, max_split_tries = 100000, ncores = 8) {
 
-  library(foreach)
-  library(doParallel)
-  library(doRNG)
+    library(foreach)
+    library(doParallel)
+    library(doRNG)
 
-  shd_col <- paste0("shd_", year)
-  ssd_col <- paste0("ssd_", year)
+    shd_col <- paste0("shd_", year)
+    ssd_col <- paste0("ssd_", year)
 
-  # Generate district assignment matrix
-  sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+    # Generate district assignment matrix
+    sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
 
-  # Create shd map object
-  map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
-                                ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
+    # Create shd map object
+    map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
+        ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
 
-  # Unique ID for each row, will use later to reconnect pieces
-  map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+    # Unique ID for each row, will use later to reconnect pieces
+    map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
 
-  # Simulation hyperparameters
-  inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
-  final_sims <- ncol(sample_ssd_matrix)
+    # Simulation hyperparameters
+    inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
+    final_sims <- ncol(sample_ssd_matrix)
 
-  # Set up log file
-  logfile <- sprintf("data-out/OR_2020/nested_log.txt", state, year)
-  file.create(logfile)
+    # Set up log file
+    logfile <- sprintf("data-out/OR_2020/nested_log.txt", state, year)
+    file.create(logfile)
 
-  # Set up parallelization
-  cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
-                              useXDR = .Platform$endian != "little")
+    # Set up parallelization
+    cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
+        useXDR = .Platform$endian != "little")
 
-  registerDoParallel(cl)
+    registerDoParallel(cl)
 
-  # Outer loop: senate simulations
-  plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
-                       .export = c("prep_particles", "rep_cols", "rep_col"),
-                       .packages = c("tidyverse", "redist")) %dorng% {
-                         # mh_accept_per_smc <- 1
-                         devtools::load_all()
+    # Outer loop: senate simulations
+    plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
+        .export = c("prep_particles", "rep_cols", "rep_col"),
+        .packages = c("tidyverse", "redist")) %dorng% {
+        # mh_accept_per_smc <- 1
+        devtools::load_all()
 
-                         # Add senate district assignment from simulation i
-                         map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+        # Add senate district assignment from simulation i
+        map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
 
-                         plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
+        plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
 
-                         failed <- FALSE
+        failed <- FALSE
 
-                         # Inner loop: simulated senate districts
-                         for (j in 1:max(map_shd_iterate$ssd_sim)) {
-                           m <- map_shd_iterate %>%
-                             filter(ssd_sim == j)
-                           map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
-                                               ndists = inner_splits, adj = m$adj)
+        # Inner loop: simulated senate districts
+        for (j in 1:max(map_shd_iterate$ssd_sim)) {
+            m <- map_shd_iterate %>%
+                filter(ssd_sim == j)
+            map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+                ndists = inner_splits, adj = m$adj)
 
 
-                           # Constraints here
+            # Constraints here
 
-                           output <- capture.output(
-                             {
-                               result <- tryCatch(
-                                 {
-                                   plans_j <- redist_smc(
-                                     map_j,
-                                     nsims = inner_nsims, runs = inner_runs,
-                                     counties = county,
-                                     sampling_space = "linking_edge",
-                                     # constraints = constr,
-                                     pop_temper = 0.02,
-                                     # ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-                                     split_params = list(splitting_schedule = "any_valid_sizes"),
-                                     verbose = TRUE,
-                                     control = list(max_split_tries = max_split_tries)
-                                   )
+            output <- capture.output(
+                {
+                    result <- tryCatch(
+                        {
+                            plans_j <- redist_smc(
+                                map_j,
+                                nsims = inner_nsims, runs = inner_runs,
+                                counties = county,
+                                sampling_space = "linking_edge",
+                                # constraints = constr,
+                                pop_temper = 0.02,
+                                # ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+                                split_params = list(splitting_schedule = "any_valid_sizes"),
+                                verbose = TRUE,
+                                control = list(max_split_tries = max_split_tries)
+                            )
 
-                                   # Catch error
-                                 },
-                                 error = function(e) {
+                            # Catch error
+                        },
+                        error = function(e) {
 
-                                   NULL
-                                 })
-                             },
-                             type = "output")
+                            NULL
+                        })
+                },
+                type = "output")
 
-                           # Catch fail to split warning
-                           if (is.null(result) || any(grepl("Failed to split", output))) {
-                             failed <- TRUE
-                             cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
-                             break
-                           }
+            # Catch fail to split warning
+            if (is.null(result) || any(grepl("Failed to split", output))) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
+                break
+            }
 
-                           plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
-                           plans_j$dist_keep <- TRUE
-                           plan_list[[j]] <- list(map = map_j, plans = plans_j)
-                         }
+            plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+            plans_j$dist_keep <- TRUE
+            plan_list[[j]] <- list(map = map_j, plans = plans_j)
+        }
 
-                         if (failed) {
-                           # Return dummy plan
-                           prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
-                           plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
-                           plans_dummy$draw <- as.factor(99999)
+        if (failed) {
+            # Return dummy plan
+            prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+            plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+            plans_dummy$draw <- as.factor(99999)
 
-                           return(plans_dummy)
-                         }
+            return(plans_dummy)
+        }
 
-                         # Combine into single state-wide plan
-                         prep_mat <- prep_particles(map = map_shd_iterate,
-                                                    map_plan_list = plan_list,
-                                                    uid = row_id, dist_keep = dist_keep, nsims = 1)
+        # Combine into single state-wide plan
+        prep_mat <- prep_particles(map = map_shd_iterate,
+            map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
 
-                         plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
 
-                         # Counter for log file
-                         cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims, file = logfile, append = TRUE)
+        # Counter for log file
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims, file = logfile, append = TRUE)
 
-                         plans_i
+        plans_i
 
-                       }
+    }
 
-  stopCluster(cl)
+    stopCluster(cl)
 
-  # Determine effective sample size
-  survive <- plans_shd %>%
-    as.data.frame() %>%
-    filter(district == 1) %>%
-    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
-    dplyr::select(survive)
+    # Determine effective sample size
+    survive <- plans_shd %>%
+        as.data.frame() %>%
+        filter(district == 1) %>%
+        mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive)
 
-  survive_all <- plans_shd %>%
-    as.data.frame() %>%
-    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
-    dplyr::select(survive_all)
+    survive_all <- plans_shd %>%
+        as.data.frame() %>%
+        mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive_all)
 
-  saveRDS(survive_all, "data-out/OR_2020/survive_all.rds")
+    saveRDS(survive_all, "data-out/OR_2020/survive_all.rds")
 
-  plans_shd_matrix <- get_plans_matrix(plans_shd)
-  plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+    plans_shd_matrix <- get_plans_matrix(plans_shd)
+    plans_shd_matrix <- plans_shd_matrix[, survive$survive]
 
-  plans_shd <- redist_plans(plans = plans_shd_matrix,
-                            map = map_shd,
-                            algorithm = "smc")
+    plans_shd <- redist_plans(plans = plans_shd_matrix,
+        map = map_shd,
+        algorithm = "smc")
 
-  # Add draw and chain numbering
-  plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+    # Add draw and chain numbering
+    plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
 
-  full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+    full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
 
-  plans_shd$chain <- full_chain[survive_all$survive_all]
+    plans_shd$chain <- full_chain[survive_all$survive_all]
 
-  # Add enacted plan
-  plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
+    # Add enacted plan
+    plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
 
-  return(plans_shd)
+    return(plans_shd)
 
 }
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_shd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2020)
 
-# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
-#mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3)
+# mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3)
 
 plans <- readRDS("data-raw/OR/OR_ssd_2020_plans_oversample.rds")
 
@@ -186,15 +174,13 @@ plans <- nested_smc(plans, map_ssd, map_shd, shp = or_shp, state = "OR", ncores 
 # make sure to call `pullback()` on this plans object!
 
 plans <- plans |>
-  group_by(chain) |>
-  filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
-  ungroup()
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
 plans <- match_numbers(plans, "shd_2020")
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/OR_2020/OR_shd_2020_plans.rds"), compress = "xz")
@@ -211,12 +197,10 @@ save_summary_stats(plans, "data-out/OR_2020/OR_shd_2020_stats.csv")
 cli_process_done()
 
 if (interactive()) {
-  library(ggplot2)
-  library(patchwork)
+    library(ggplot2)
+    library(patchwork)
 
-  validate_analysis(plans, map_shd)
-  summary(plans)
+    validate_analysis(plans, map_shd)
+    summary(plans)
 
-  # Extra validation plots for custom constraints -----
-  # TODO remove this section if no custom constraints
 }

--- a/analyses/OR_leg_2020/03_sim_OR_shd_2020.R
+++ b/analyses/OR_leg_2020/03_sim_OR_shd_2020.R
@@ -1,0 +1,222 @@
+###############################################################################
+# Simulate plans for `OR_shd_2020` SHD
+# © ALARM Project, January 2026
+###############################################################################
+
+nested_smc <- function(plans, map_ssd, map_shd, shp, inner_nsims = 50, inner_runs = 1, outer_runs = 5, year = 2020, state, max_split_tries = 100000, ncores = 8) {
+
+  library(foreach)
+  library(doParallel)
+  library(doRNG)
+
+  shd_col <- paste0("shd_", year)
+  ssd_col <- paste0("ssd_", year)
+
+  # Generate district assignment matrix
+  sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+
+  # Create shd map object
+  map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
+                                ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
+
+  # Unique ID for each row, will use later to reconnect pieces
+  map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+  # Simulation hyperparameters
+  inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
+  final_sims <- ncol(sample_ssd_matrix)
+
+  # Set up log file
+  logfile <- sprintf("data-out/OR_2020/nested_log.txt", state, year)
+  file.create(logfile)
+
+  # Set up parallelization
+  cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
+                              useXDR = .Platform$endian != "little")
+
+  registerDoParallel(cl)
+
+  # Outer loop: senate simulations
+  plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
+                       .export = c("prep_particles", "rep_cols", "rep_col"),
+                       .packages = c("tidyverse", "redist")) %dorng% {
+                         # mh_accept_per_smc <- 1
+                         devtools::load_all()
+
+                         # Add senate district assignment from simulation i
+                         map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+
+                         plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
+
+                         failed <- FALSE
+
+                         # Inner loop: simulated senate districts
+                         for (j in 1:max(map_shd_iterate$ssd_sim)) {
+                           m <- map_shd_iterate %>%
+                             filter(ssd_sim == j)
+                           map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+                                               ndists = inner_splits, adj = m$adj)
+
+
+                           # Constraints here
+
+                           output <- capture.output(
+                             {
+                               result <- tryCatch(
+                                 {
+                                   plans_j <- redist_smc(
+                                     map_j,
+                                     nsims = inner_nsims, runs = inner_runs,
+                                     counties = county,
+                                     sampling_space = "linking_edge",
+                                     # constraints = constr,
+                                     pop_temper = 0.02,
+                                     # ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+                                     split_params = list(splitting_schedule = "any_valid_sizes"),
+                                     verbose = TRUE,
+                                     control = list(max_split_tries = max_split_tries)
+                                   )
+
+                                   # Catch error
+                                 },
+                                 error = function(e) {
+
+                                   NULL
+                                 })
+                             },
+                             type = "output")
+
+                           # Catch fail to split warning
+                           if (is.null(result) || any(grepl("Failed to split", output))) {
+                             failed <- TRUE
+                             cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
+                             break
+                           }
+
+                           plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+                           plans_j$dist_keep <- TRUE
+                           plan_list[[j]] <- list(map = map_j, plans = plans_j)
+                         }
+
+                         if (failed) {
+                           # Return dummy plan
+                           prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+                           plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+                           plans_dummy$draw <- as.factor(99999)
+
+                           return(plans_dummy)
+                         }
+
+                         # Combine into single state-wide plan
+                         prep_mat <- prep_particles(map = map_shd_iterate,
+                                                    map_plan_list = plan_list,
+                                                    uid = row_id, dist_keep = dist_keep, nsims = 1)
+
+                         plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+
+                         # Counter for log file
+                         cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims, file = logfile, append = TRUE)
+
+                         plans_i
+
+                       }
+
+  stopCluster(cl)
+
+  # Determine effective sample size
+  survive <- plans_shd %>%
+    as.data.frame() %>%
+    filter(district == 1) %>%
+    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+    dplyr::select(survive)
+
+  survive_all <- plans_shd %>%
+    as.data.frame() %>%
+    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+    dplyr::select(survive_all)
+
+  saveRDS(survive_all, "data-out/OR_2020/survive_all.rds")
+
+  plans_shd_matrix <- get_plans_matrix(plans_shd)
+  plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+
+  plans_shd <- redist_plans(plans = plans_shd_matrix,
+                            map = map_shd,
+                            algorithm = "smc")
+
+  # Add draw and chain numbering
+  plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+  full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+
+  plans_shd$chain <- full_chain[survive_all$survive_all]
+
+  # Add enacted plan
+  plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
+
+  return(plans_shd)
+
+}
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OR_shd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+#mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3)
+
+plans <- readRDS("data-raw/OR/OR_ssd_2020_plans_oversample.rds")
+
+plans <- nested_smc(plans, map_ssd, map_shd, shp = or_shp, state = "OR", ncores = 64)
+
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+  ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OR_2020/OR_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OR_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OR_2020/OR_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+
+  validate_analysis(plans, map_shd)
+  summary(plans)
+
+  # Extra validation plots for custom constraints -----
+  # TODO remove this section if no custom constraints
+}

--- a/analyses/OR_leg_2020/03_sim_OR_ssd_2020.R
+++ b/analyses/OR_leg_2020/03_sim_OR_ssd_2020.R
@@ -1,0 +1,75 @@
+###############################################################################
+# Simulate plans for `OR_ssd_2020` SSD
+# © ALARM Project, January 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg OR_ssd_2020}")
+
+# TODO any pre-computation (VRA targets, etc.)
+
+# TODO customize as needed. Recommendations:
+#  - For many districts / tighter population tolerances, try setting
+#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
+#  efficiency!
+#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
+#  - Don't change the number of simulations unless you have a good reason
+#  - If the sampler freezes, try turning off the county split constraint to see
+#  if that's the problem.
+#  - Ask for help!
+set.seed(2020)
+
+# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
+
+plans <- redist_smc(
+  map_ssd,
+  nsims = 11000, runs = 5,
+  counties = pseudo_county,
+  sampling_space = "linking_edge",
+  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+  split_params = list(splitting_schedule = "any_valid_sizes"),
+  verbose = TRUE
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- match_numbers(plans, "ssd_2020")
+
+write_rds(plans, here("data-raw/OR/OR_ssd_2020_plans_oversample.rds"), compress = "xz")
+
+plans <- plans |>
+  group_by(chain) |>
+  filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+  ungroup()
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# TODO add any reference plans that aren't already included
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/OR_2020/OR_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg OR_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/OR_2020/OR_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+  library(ggplot2)
+  library(patchwork)
+
+  validate_analysis(plans, map_ssd)
+  summary(plans)
+
+  # Extra validation plots for custom constraints -----
+  # TODO remove this section if no custom constraints
+}

--- a/analyses/OR_leg_2020/03_sim_OR_ssd_2020.R
+++ b/analyses/OR_leg_2020/03_sim_OR_ssd_2020.R
@@ -6,30 +6,18 @@
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_ssd_2020}")
 
-# TODO any pre-computation (VRA targets, etc.)
-
-# TODO customize as needed. Recommendations:
-#  - For many districts / tighter population tolerances, try setting
-#  `pop_temper=0.01` and nudging upward from there. Monitor the output for
-#  efficiency!
-#  - Monitor the output (i.e. leave `verbose=TRUE`) to ensure things aren't breaking
-#  - Don't change the number of simulations unless you have a good reason
-#  - If the sampler freezes, try turning off the county split constraint to see
-#  if that's the problem.
-#  - Ask for help!
 set.seed(2020)
 
-# TODO set equal to one third of number of districts, increase by 10-15 if no convergence
 mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 20
 
 plans <- redist_smc(
-  map_ssd,
-  nsims = 11000, runs = 5,
-  counties = pseudo_county,
-  sampling_space = "linking_edge",
-  ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
-  split_params = list(splitting_schedule = "any_valid_sizes"),
-  verbose = TRUE
+    map_ssd,
+    nsims = 11000, runs = 5,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
 )
 
 # IF CORES OR OTHER UNITS HAVE BEEN MERGED:
@@ -40,14 +28,12 @@ plans <- match_numbers(plans, "ssd_2020")
 write_rds(plans, here("data-raw/OR/OR_ssd_2020_plans_oversample.rds"), compress = "xz")
 
 plans <- plans |>
-  group_by(chain) |>
-  filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
-  ungroup()
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
 
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
-
-# TODO add any reference plans that aren't already included
 
 # Output the redist_map object. Do not edit this path.
 write_rds(plans, here("data-out/OR_2020/OR_ssd_2020_plans.rds"), compress = "xz")
@@ -64,12 +50,10 @@ save_summary_stats(plans, "data-out/OR_2020/OR_ssd_2020_stats.csv")
 cli_process_done()
 
 if (interactive()) {
-  library(ggplot2)
-  library(patchwork)
+    library(ggplot2)
+    library(patchwork)
 
-  validate_analysis(plans, map_ssd)
-  summary(plans)
+    validate_analysis(plans, map_ssd)
+    summary(plans)
 
-  # Extra validation plots for custom constraints -----
-  # TODO remove this section if no custom constraints
 }

--- a/analyses/OR_leg_2020/doc_OR_leg_2020.md
+++ b/analyses/OR_leg_2020/doc_OR_leg_2020.md
@@ -25,10 +25,10 @@ As described above, counties not linked by a state or federal highway were manua
 The full list of these counties can be found in the `01_prep_OR_leg_2020.R` file.
 
 ## Simulation Notes
-We sample 55,000 districting plans for Minnesota's upper house across 5 independent runs of the SMC algorithm.
+We sample 55,000 districting plans for Oregon's upper house across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 10,000.
 We increase the number of merge-split proposals per SMC step (30).
 
-We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 55,000 upper house districts.
+We use the top-down nested procedure to sample Oregon's lower house districts, with 50 inner-simulations for each of the 55,000 upper house districts.
 11,373 districting plans remain in the surviving sample.
 We then thinned the number of samples to 10,000.

--- a/analyses/OR_leg_2020/doc_OR_leg_2020.md
+++ b/analyses/OR_leg_2020/doc_OR_leg_2020.md
@@ -27,7 +27,7 @@ The full list of these counties can be found in the `01_prep_OR_leg_2020.R` file
 ## Simulation Notes
 We sample 55,000 districting plans for Minnesota's upper house across 5 independent runs of the SMC algorithm.
 We then thinned the number of samples to 10,000.
-We impose a total municipality splits constraint, and increase the number of merge-split proposals per SMC step (30).
+We increase the number of merge-split proposals per SMC step (30).
 
 We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 55,000 upper house districts.
 11,373 districting plans remain in the surviving sample.

--- a/analyses/OR_leg_2020/doc_OR_leg_2020.md
+++ b/analyses/OR_leg_2020/doc_OR_leg_2020.md
@@ -1,0 +1,34 @@
+# 2020 Oregon State House/Senate Districts
+
+## Redistricting requirements
+In Oregon, districts must, under [Or. Rev. Stat. § 188.010](https://www.oregonlegislature.gov/bills_laws/ors/ors188.html):
+
+1. be contiguous
+1. have equal populations
+1. utilize existing geographic or political boundaries
+1. not divide communities of common interest
+1. be connected by transportation links
+1. not favor any political party, incumbent legislator or other person
+1. not dilute the voting strength of any language or ethnic minority group
+1. have House districts nested inside Senate districts
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway.
+
+## Data Sources
+Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+Oregon does not submit precinct boundaries to the Census Bureau, so the base shapefile consists of census tracts.
+As described above, counties not linked by a state or federal highway were manually disconnected.
+The full list of these counties can be found in the `01_prep_OR_leg_2020.R` file.
+
+## Simulation Notes
+We sample 55,000 districting plans for Minnesota's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000.
+We impose a total municipality splits constraint, and increase the number of merge-split proposals per SMC step (30).
+
+We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 55,000 upper house districts.
+11,373 districting plans remain in the surviving sample.
+We then thinned the number of samples to 10,000.


### PR DESCRIPTION
## Redistricting requirements
In Oregon, districts must, under [Or. Rev. Stat. § 188.010](https://www.oregonlegislature.gov/bills_laws/ors/ors188.html):

1. be contiguous
1. have equal populations
1. utilize existing geographic or political boundaries
1. not divide communities of common interest
1. be connected by transportation links
1. not favor any political party, incumbent legislator or other person
1. not dilute the voting strength of any language or ethnic minority group
1. have House districts nested inside Senate districts

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.
To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway.

## Data Sources
Data for Oregon comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
Oregon does not submit precinct boundaries to the Census Bureau, so the base shapefile consists of census tracts.
As described above, counties not linked by a state or federal highway were manually disconnected.
The full list of these counties can be found in the `01_prep_OR_leg_2020.R` file.

## Simulation Notes
We sample 55,000 districting plans for Oregon's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000.
We increase the number of merge-split proposals per SMC step (30).

We use the top-down nested procedure to sample Oregon's lower house districts, with 50 inner-simulations for each of the 55,000 upper house districts.
11,373 districting plans remain in the surviving sample.
We then thinned the number of samples to 10,000.

## Validation

**State Senate**

<img width="3000" height="5400" alt="validation_20260812_1149" src="https://github.com/user-attachments/assets/9f142fe4-d215-4247-a7ba-b0b271fc7903" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 30
                 districts on 1,001 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 29
• `mh_accept_per_smc` = 30
• `pair_rule` = uniform
Plan diversity 80% range: 0.67 to 0.82
10 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16 
              1.001               1.002               1.001               1.001 
             arv_18              arv_20      atg_16_dem_ros      atg_16_rep_cro 
              1.002               1.001               1.001               1.001 
     atg_20_dem_ros      atg_20_rep_cro     comp_bbox_reock           comp_edge 
              1.001               1.001               1.001               1.001 
        comp_polsby       county_splits               e_dem               e_dvs 
              1.001               1.001               1.001               1.002 
               egap      gov_16_dem_bro      gov_16_rep_pie      gov_18_dem_bro 
              1.001               1.001               1.001               1.002 
     gov_18_rep_bue         muni_splits             ndshare                 ndv 
              1.002               1.001               1.002               1.001 
                nrv               pbias            plan_dev            pop_aian 
              1.001               1.000               1.000               1.004 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.002               1.002               1.001               1.002 
          pop_other         pop_overlap             pop_two           pop_white 
              1.001               1.000               1.001               1.001 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.001               1.001               1.002               1.001 
     pre_20_rep_tru      sos_16_dem_ava      sos_16_rep_ric      sos_20_dem_fag 
              1.002               1.001               1.001               1.001 
     sos_20_rep_tha total_county_splits   total_muni_splits           total_vap 
              1.001               1.001               1.001               1.001 
     uss_16_dem_wyd      uss_16_rep_cal      uss_20_dem_mer      uss_20_rep_per 
              1.001               1.002               1.001               1.002 
           vap_aian           vap_asian           vap_black            vap_hisp 
              1.004               1.002               1.002               1.001 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.002               1.001               1.001               1.002 
• R-hat ≤ 1.05: 1790
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1790
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique 
Split 1     4,486 (40.8%)    100.0%        1.19  6,982 (100%) 
Split 2     5,228 (47.5%)     97.6%        1.07  5,136 ( 74%) 
Split 3     5,908 (53.7%)     93.9%        0.95  5,467 ( 79%) 
Split 4     6,508 (59.2%)     90.6%        0.84  5,694 ( 82%) 
Split 5     7,102 (64.6%)     86.4%        0.77  5,849 ( 84%) 
Split 6     7,557 (68.7%)     83.2%        0.71  6,092 ( 88%) 
Split 7     7,966 (72.4%)     79.6%        0.65  6,186 ( 89%) 
Split 8     8,142 (74.0%)     76.1%        0.61  6,248 ( 90%) 
Split 9     8,420 (76.5%)     73.3%        0.57  6,351 ( 91%) 
Split 10    8,648 (78.6%)     70.5%        0.54  6,379 ( 92%) 
Split 11    8,892 (80.8%)     68.2%        0.51  6,411 ( 92%) 
Split 12    9,134 (83.0%)     64.1%        0.47  6,504 ( 94%) 
Split 13    9,238 (84.0%)     61.8%        0.45  6,477 ( 93%) 
Split 14    9,370 (85.2%)     58.5%        0.42  6,481 ( 93%) 
Split 15    9,547 (86.8%)     56.5%        0.40  6,571 ( 95%) 
Split 16    9,637 (87.6%)     53.0%        0.38  6,540 ( 94%) 
Split 17    9,750 (88.6%)     51.1%        0.37  6,560 ( 94%) 
Split 18    9,805 (89.1%)     48.7%        0.35  6,620 ( 95%) 
Split 19    9,936 (90.3%)     46.2%        0.34  6,627 ( 95%) 
Split 20    9,995 (90.9%)     44.8%        0.32  6,653 ( 96%) 
Split 21   10,069 (91.5%)     42.6%        0.31  6,604 ( 95%) 
Split 22   10,143 (92.2%)     40.1%        0.30  6,542 ( 94%) 
Split 23   10,209 (92.8%)     38.7%        0.29  6,595 ( 95%) 
Split 24   10,295 (93.6%)     36.6%        0.26  6,565 ( 94%) 
Split 25   10,337 (94.0%)     35.2%        0.26  6,513 ( 94%) 
Split 26   10,411 (94.6%)     33.1%        0.24  6,448 ( 93%) 
Split 27   10,500 (95.5%)     31.4%        0.23  6,383 ( 92%) 
Split 28   10,571 (96.1%)     29.8%        0.21  6,272 ( 90%) 
Split 29   10,651 (96.8%)     26.8%        0.19  5,875 ( 84%) 
Resample   10,651 (96.8%)       NA%          NA 10,185 (146%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      46.6%                30
MS Step 2      45.5%                90
MS Step 3      45.7%                90
MS Step 4      45.8%                90
MS Step 5      45.4%                90
MS Step 6      45.1%                90
MS Step 7      44.8%                90
MS Step 8      44.3%                90
MS Step 9      43.9%                90
MS Step 10     43.3%                90
MS Step 11     42.6%                90
MS Step 12     41.9%                90
MS Step 13     41.4%                90
MS Step 14     40.7%                90
MS Step 15     40.0%                90
MS Step 16     39.2%                90
MS Step 17     38.5%                90
MS Step 18     37.9%                90
MS Step 19     36.9%                90
MS Step 20     36.4%                90
MS Step 21     35.6%                90
MS Step 22     34.9%                90
MS Step 23     34.1%                90
MS Step 24     33.5%                90
MS Step 25     32.7%                90
MS Step 26     31.9%               120
MS Step 27     31.2%               120
MS Step 28     30.4%               120
MS Step 29     29.5%               120
```

**State House**

<img width="3000" height="5400" alt="validation_20260812_1139" src="https://github.com/user-attachments/assets/08a847fd-0dec-48ad-b1d1-4897a808eec3" />

```
SMC: 10,000 sampled plans of 60
                 districts on 1,001 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.79 to 0.88
26 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16 
              1.003               1.003               1.002               1.001 
             arv_18              arv_20      atg_16_dem_ros      atg_16_rep_cro 
              1.001               1.001               1.003               1.001 
     atg_20_dem_ros      atg_20_rep_cro     comp_bbox_reock           comp_edge 
              1.002               1.001               1.002               1.000 
        comp_polsby       county_splits               e_dem               e_dvs 
              1.001               1.004               1.000               1.001 
               egap      gov_16_dem_bro      gov_16_rep_pie      gov_18_dem_bro 
              1.000               1.002               1.001               1.003 
     gov_18_rep_bue         muni_splits             ndshare                 ndv 
              1.001               1.000               1.001               1.003 
                nrv               pbias            plan_dev            pop_aian 
              1.001               1.000               1.000               1.004 
          pop_asian           pop_black            pop_hisp            pop_nhpi 
              1.002               1.002               1.002               1.001 
          pop_other         pop_overlap             pop_two           pop_white 
              1.001               1.001               1.001               1.001 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.001               1.003               1.001               1.002 
     pre_20_rep_tru      sos_16_dem_ava      sos_16_rep_ric      sos_20_dem_fag 
              1.001               1.003               1.001               1.003 
     sos_20_rep_tha total_county_splits   total_muni_splits           total_vap 
              1.001               1.001               1.000               1.001 
     uss_16_dem_wyd      uss_16_rep_cal      uss_20_dem_mer      uss_20_rep_per 
              1.001               1.001               1.002               1.001 
           vap_aian           vap_asian           vap_black            vap_hisp 
              1.004               1.001               1.002               1.001 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.001               1.001               1.001               1.002 
• R-hat ≤ 1.05: 3574
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3574
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@CoryMcCartan 