### PR TITLE
2000 & 1990 Oregon Congressional Districts Update

### DIFF
--- a/analyses/OR_cd_1990/01_prep_OR_cd_1990.R
+++ b/analyses/OR_cd_1990/01_prep_OR_cd_1990.R
@@ -56,27 +56,18 @@ if (!file.exists(here(shp_path))) {
   # create adjacency graph
   or_shp$adj <- redist.adjacency(or_shp)
   
-  # Disconnect counties not connected by state or federal highways
-  disconn_cty <- function(adj, cty1, cty2) {
-    v1 <- which(or_shp$county == cty1)
-    if (length(v1) == 0) stop(cty1, " not found")
-    v2 <- which(or_shp$county == cty2)
-    if (length(v2) == 0) stop(cty2, " not found")
-    vs <- tidyr::crossing(v1, v2)
-    remove_edge(adj, vs$v1, vs$v2)
-  }
-  
+  # Remove adjacency between neighboring counties not connected by state or federal highways
   or_shp$adj <- or_shp$adj %>%
-    disconn_cty("015", "033") %>%  # Curry – Josephine
-    disconn_cty("053", "041") %>%  # Polk – Lincoln
-    disconn_cty("003", "039") %>%  # Benton – Lane
-    disconn_cty("047", "031") %>%  # Marion – Jefferson
-    disconn_cty("047", "065") %>%  # Marion – Wasco
-    disconn_cty("063", "001") %>%  # Wallowa – Baker
-    disconn_cty("049", "023") %>%  # Morrow – Grant
-    disconn_cty("013", "023") %>%  # Crook – Grant
-    disconn_cty("017", "025") %>%  # Deschutes – Harney
-    disconn_cty("017", "043")      # Deschutes – Linn
+    seam_rip(shp = or_shp, admin = "county", seam = c("015", "033")) %>%  # Curry – Josephine
+    seam_rip(shp = or_shp, admin = "county", seam = c("053", "041")) %>%  # Polk – Lincoln
+    seam_rip(shp = or_shp, admin = "county", seam = c("003", "039")) %>%  # Benton – Lane
+    seam_rip(shp = or_shp, admin = "county", seam = c("047", "031")) %>%  # Marion – Jefferson
+    seam_rip(shp = or_shp, admin = "county", seam = c("047", "065")) %>%  # Marion – Wasco
+    seam_rip(shp = or_shp, admin = "county", seam = c("063", "001")) %>%  # Wallowa – Baker
+    seam_rip(shp = or_shp, admin = "county", seam = c("049", "023")) %>%  # Morrow – Grant
+    seam_rip(shp = or_shp, admin = "county", seam = c("013", "023")) %>%  # Crook – Grant
+    seam_rip(shp = or_shp, admin = "county", seam = c("017", "025")) %>%  # Deschutes – Harney
+    seam_rip(shp = or_shp, admin = "county", seam = c("017", "043"))      # Deschutes – Linn
   
   write_rds(or_shp, here(shp_path), compress = "gz")
   cli_process_done()

--- a/analyses/OR_cd_2000/01_prep_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/01_prep_OR_cd_2000.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Download and prepare data for `OR_cd_2000` analysis
-# © ALARM Project, July 2025
+# © ALARM Project, August 2026
 ###############################################################################
 
 suppressMessages({
@@ -52,6 +52,19 @@ if (!file.exists(here(shp_path))) {
 
     # create adjacency graph
     or_shp$adj <- redist.adjacency(or_shp)
+
+    # Remove adjacency between neighboring counties not connected by state or federal highways
+    or_shp$adj <- or_shp$adj %>%
+    seam_rip(shp = or_shp, admin = "county", seam = c("015", "033")) %>%  # Curry – Josephine
+    seam_rip(shp = or_shp, admin = "county", seam = c("053", "041")) %>%  # Polk – Lincoln
+    seam_rip(shp = or_shp, admin = "county", seam = c("003", "039")) %>%  # Benton – Lane
+    seam_rip(shp = or_shp, admin = "county", seam = c("047", "031")) %>%  # Marion – Jefferson
+    seam_rip(shp = or_shp, admin = "county", seam = c("047", "065")) %>%  # Marion – Wasco
+    seam_rip(shp = or_shp, admin = "county", seam = c("063", "001")) %>%  # Wallowa – Baker
+    seam_rip(shp = or_shp, admin = "county", seam = c("049", "023")) %>%  # Morrow – Grant
+    seam_rip(shp = or_shp, admin = "county", seam = c("013", "023")) %>%  # Crook – Grant
+    seam_rip(shp = or_shp, admin = "county", seam = c("017", "025")) %>%  # Deschutes – Harney
+    seam_rip(shp = or_shp, admin = "county", seam = c("017", "043"))      # Deschutes – Linn
 
     or_shp <- or_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/OR_cd_2000/01_prep_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/01_prep_OR_cd_2000.R
@@ -55,16 +55,16 @@ if (!file.exists(here(shp_path))) {
 
     # Remove adjacency between neighboring counties not connected by state or federal highways
     or_shp$adj <- or_shp$adj %>%
-    seam_rip(shp = or_shp, admin = "county", seam = c("015", "033")) %>%  # Curry – Josephine
-    seam_rip(shp = or_shp, admin = "county", seam = c("053", "041")) %>%  # Polk – Lincoln
-    seam_rip(shp = or_shp, admin = "county", seam = c("003", "039")) %>%  # Benton – Lane
-    seam_rip(shp = or_shp, admin = "county", seam = c("047", "031")) %>%  # Marion – Jefferson
-    seam_rip(shp = or_shp, admin = "county", seam = c("047", "065")) %>%  # Marion – Wasco
-    seam_rip(shp = or_shp, admin = "county", seam = c("063", "001")) %>%  # Wallowa – Baker
-    seam_rip(shp = or_shp, admin = "county", seam = c("049", "023")) %>%  # Morrow – Grant
-    seam_rip(shp = or_shp, admin = "county", seam = c("013", "023")) %>%  # Crook – Grant
-    seam_rip(shp = or_shp, admin = "county", seam = c("017", "025")) %>%  # Deschutes – Harney
-    seam_rip(shp = or_shp, admin = "county", seam = c("017", "043"))      # Deschutes – Linn
+        seam_rip(shp = or_shp, admin = "county", seam = c("015", "033")) %>%  # Curry – Josephine
+        seam_rip(shp = or_shp, admin = "county", seam = c("053", "041")) %>%  # Polk – Lincoln
+        seam_rip(shp = or_shp, admin = "county", seam = c("003", "039")) %>%  # Benton – Lane
+        seam_rip(shp = or_shp, admin = "county", seam = c("047", "031")) %>%  # Marion – Jefferson
+        seam_rip(shp = or_shp, admin = "county", seam = c("047", "065")) %>%  # Marion – Wasco
+        seam_rip(shp = or_shp, admin = "county", seam = c("063", "001")) %>%  # Wallowa – Baker
+        seam_rip(shp = or_shp, admin = "county", seam = c("049", "023")) %>%  # Morrow – Grant
+        seam_rip(shp = or_shp, admin = "county", seam = c("013", "023")) %>%  # Crook – Grant
+        seam_rip(shp = or_shp, admin = "county", seam = c("017", "025")) %>%  # Deschutes – Harney
+        seam_rip(shp = or_shp, admin = "county", seam = c("017", "043"))      # Deschutes – Linn
 
     or_shp <- or_shp %>%
         fix_geo_assignment(muni)

--- a/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/02_setup_OR_cd_2000.R
@@ -1,6 +1,6 @@
 ###############################################################################
 # Set up redistricting simulation for `OR_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, August 2026
 ###############################################################################
 cli_process_start("Creating {.cls redist_map} object for {.pkg OR_cd_2000}")
 

--- a/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
+++ b/analyses/OR_cd_2000/03_sim_OR_cd_2000.R
@@ -1,22 +1,13 @@
 ###############################################################################
 # Simulate plans for `OR_cd_2000`
-# © ALARM Project, July 2025
+# © ALARM Project, August 2026
 ###############################################################################
 
 # Run the simulation -----
 cli_process_start("Running simulations for {.pkg OR_cd_2000}")
 
 set.seed(2000)
-plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = county)
-# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
-# make sure to call `pullback()` on this plans object!
-
-target_plans <- 5000L
-chains <- sort(unique(plans$chain))
-n_keep <- rep(target_plans %/% length(chains), length(chains))
-n_keep[seq_len(target_plans %% length(chains))] <-
-    n_keep[seq_len(target_plans %% length(chains))] + 1L
-names(n_keep) <- as.character(chains)
+plans <- redist_smc(map, nsims = 2e3, runs = 10, counties = pseudo_county)
 
 plans <- plans %>%
     group_by(chain) %>%
@@ -27,7 +18,7 @@ plans <- match_numbers(plans, "cd_2000")
 cli_process_done()
 cli_process_start("Saving {.cls redist_plans} object")
 
-# Output the redist_map object. Do not edit this path.
+# Output the redist_plans object. Do not edit this path.
 write_rds(plans, here("data-out/OR_2000/OR_cd_2000_plans.rds"), compress = "xz")
 cli_process_done()
 
@@ -41,7 +32,7 @@ save_summary_stats(plans, "data-out/OR_2000/OR_cd_2000_stats.csv")
 
 cli_process_done()
 
-# Extra validation plots for custom constraints -----
+# Validation plots -----
 if (interactive()) {
     library(ggplot2)
     library(patchwork)

--- a/analyses/OR_cd_2000/doc_OR_cd_2000.md
+++ b/analyses/OR_cd_2000/doc_OR_cd_2000.md
@@ -1,26 +1,29 @@
 # 2000 Oregon Congressional Districts
 
 ## Redistricting requirements
-In ``Oregon `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must:
+In ``Oregon `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must, as nearly as practicable:
 
 1. be contiguous
-1. have equal populations
-1. be geographically compact
-1. preserve county and municipality boundaries as much as possible
-1. not favor any political party or incumbent legislator or individual
-1. not dilute the voting strength of any linguistic or ethnic minority group
+1. be of equal population
+1. utilize existing geographic or political boundaries
+1. not divide communities of common interest
+1. be connected by transportation links
 
+Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.
 
 ### Algorithmic Constraints
 We enforce a maximum population deviation of 0.5%.
+We apply a county/municipality constraint, as described below.
+To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway. 
 
 ## Data Sources
 Data for Oregon comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+As described above, counties lacking state or federal highway links were manually disconnected. Given the stability of major highway connectivity over time, we apply the same county disconnections as in prior analyses.
+The full list of these counties can be found in the `01_prep_OR_cd_1990.R` file.
 
 ## Simulation Notes
-We sample 20,000 districting plans for Oregon across 10 independent runs of the SMC algorithm.
-We then thinned the number of samples to 5,000.
-No special techniques were needed to produce the sample.
+We sample 20,000 districting plans for Oregon across 10 independent runs and retain 500 plans from each run, yielding a final sample
+of 5,000 plans.
+To balance county and municipality splits, we create pseudocounties for use in the county constraint.

--- a/analyses/OR_cd_2000/doc_OR_cd_2000.md
+++ b/analyses/OR_cd_2000/doc_OR_cd_2000.md
@@ -24,6 +24,5 @@ As described above, counties lacking state or federal highway links were manuall
 The full list of these counties can be found in the `01_prep_OR_cd_1990.R` file.
 
 ## Simulation Notes
-We sample 20,000 districting plans for Oregon across 10 independent runs and retain 500 plans from each run, yielding a final sample
-of 5,000 plans.
+We sample 20,000 districting plans for Oregon across 10 independent runs and retain 500 plans from each run, yielding a final sample of 5,000 plans.
 To balance county and municipality splits, we create pseudocounties for use in the county constraint.

--- a/analyses/OR_cd_2000/doc_OR_cd_2000.md
+++ b/analyses/OR_cd_2000/doc_OR_cd_2000.md
@@ -1,7 +1,7 @@
 # 2000 Oregon Congressional Districts
 
 ## Redistricting requirements
-In ``Oregon `, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must, as nearly as practicable:
+In Oregon, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must, as nearly as practicable:
 
 1. be contiguous
 1. be of equal population


### PR DESCRIPTION
## Redistricting requirements
In Oregon, according to [NCSL Redistricting Law 2000](https://web.archive.org/web/20041216185957/https://www.senate.mn/departments/scr/redist/red2000/Tab5appx.htm), districts must, as nearly as practicable:

1. be contiguous
1. be of equal population
1. utilize existing geographic or political boundaries
1. not divide communities of common interest
1. be connected by transportation links

Additionally, districts may not favor any political party or incumbent, and may not dilute the voting strength of any language or ethnic minority group.

### Algorithmic Constraints
We enforce a maximum population deviation of 0.5%.
We apply a county/municipality constraint, as described below.
To reflect the transportation links constraint, we remove edges in the adjacency graph for counties not connected by a state or federal highway. 

## Data Sources
Data for Oregon comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).

## Pre-processing Notes
As described above, counties lacking state or federal highway links were manually disconnected. Given the stability of major highway connectivity over time, we apply the same county disconnections as in prior analyses.
The full list of these counties can be found in the `01_prep_OR_cd_1990.R` file.

## Simulation Notes
We sample 20,000 districting plans for Oregon across 10 independent runs and retain 500 plans from each run, yielding a final sample of 5,000 plans.
To balance county and municipality splits, we create pseudocounties for use in the county constraint.

## Validation
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/9cc9b4af-5c58-4152-b9b5-31b916a186c8" />

```
SMC: 5,000 sampled plans of 5 districts on 755 units
Plans sampled on Graph Space using the Naive Top K forward kernel.
Forward kernel parameters: `adapt_k_thresh`=0.99
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Plan diversity 80% range: 0.17 to 0.67
✖ WARNING: Low plan diversity
Largest R-hat values for ordered summary statistics:
    comp_bbox_reock           comp_edge         comp_polsby       county_splits         muni_splits             ndshare                 ndv                 nrv 
              1.010               1.013               1.009               1.004               1.005               1.008               1.010               1.007 
           plan_dev            pop_aian           pop_asian           pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.001               1.007               1.009               1.009               1.009               1.010               1.005               1.010 
            pop_two           pop_white total_county_splits   total_muni_splits           total_vap            vap_aian           vap_asian           vap_black 
              1.008               1.010               1.001               1.004               1.009               1.008               1.009               1.005 
           vap_hisp            vap_nhpi           vap_other             vap_two           vap_white 
              1.008               1.007               1.008               1.008               1.007 
  • R-hat ≤ 1.05: 145
  • 1.05 < R-hat ≤ 1.1: 0
  • R-hat > 1.1: 0
  • Total R-hats: 145
Sampling diagnostics for SMC run 1 of 10 (5,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique Est. k 
Split 1       858 (42.9%)      9.3%        0.91 1,246 ( 99%)      6 
Split 2       989 (49.5%)      9.2%        0.76   908 ( 72%)      5 
Split 3       901 (45.0%)     13.0%        0.76   974 ( 77%)      3 
Split 4     1,414 (70.7%)      7.1%        0.60   845 ( 67%)      2 
Resample    1,414 (70.7%)       NA%          NA 1,502 (119%)     NA 

  •  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights (more than 3 or so), and low numbers of
  unique plans. R-hat values for summary statistics should be between 1 and 1.05.
  • Low diversity: Check for potential bottlenecks. Increase the number of samples. Examine the diversity plot with `hist(plans_diversity(plans), breaks=24)`.
  Consider weakening or removing constraints, or increasing the population tolerance. If the acceptance rate drops quickly in the final splits, try increasing
  `pop_temper` by 0.01.
```