### PR TITLE
2020 Alaska State House/Senate Districts

### DIFF
--- a/analyses/AK_leg_2020/01_prep_AK_leg_2020.R
+++ b/analyses/AK_leg_2020/01_prep_AK_leg_2020.R
@@ -1,0 +1,117 @@
+###############################################################################
+# Download and prepare data for `AK_leg_2020` analysis
+# © ALARM Project, February 2026
+###############################################################################
+
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg AK_leg_2020}")
+
+path_data <- download_redistricting_file("AK", "data-raw/AK", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/AK_2020/shp_vtd.rds"
+perim_path <- "data-out/AK_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong AK} shapefile")
+    # read in redistricting data
+    ak_shp <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        join_vtd_shapefile(year = 2020) |>
+        st_transform(EPSG$AK)  |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add municipalities
+    d_muni <- make_from_baf("AK", "INCPLACE_CDP", "VTD", year = 2020)  |>
+        mutate(GEOID = paste0(censable::match_fips("AK"), vtd)) |>
+        select(-vtd)
+    d_ssd <- make_from_baf("AK", "SLDU", "VTD", year = 2020) |>
+        mutate(sldu_num = vctrs::vec_group_id(sldu)) |>
+        transmute(GEOID = paste0(censable::match_fips("AK"), vtd),
+            ssd_2010 = as.integer(sldu_num))
+    d_shd <- make_from_baf("AK", "SLDL", "VTD", year = 2020)  |>
+        transmute(GEOID = paste0(censable::match_fips("AK"), vtd),
+            shd_2010 = as.integer(sldl))
+
+    # Fix missing counties
+    ak_shp$county[164:169] <- "Chugach Census Area"
+    ak_shp$county[170:177] <- "Copper River Census Area"
+
+    ak_shp <- ak_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        mutate(county_muni = if_else(is.na(muni), county, str_c(county, muni))) |>
+        relocate(muni, county_muni, ssd_2010, .after = county) |>
+        relocate(muni, county_muni, shd_2010, .after = county)
+
+    # add the enacted plan
+    ak_shp <- ak_shp |>
+        left_join(y = leg_from_baf(state = "AK"), by = "GEOID")
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = ak_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        ak_shp <- rmapshaper::ms_simplify(ak_shp, keep = 0.05,
+            keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    ak_shp$adj <- adjacency(ak_shp)
+
+    ak_shp$adj <- ak_shp$adj |>
+        add_edge(138, 149) |>
+        add_edge(149, 156) |>
+        add_edge(149, 153) |>
+        add_edge(7, 8) |>
+        add_edge(368, 373) |>
+        add_edge(301, 368) |>
+        add_edge(307, 368) |>
+        add_edge(366, 368) |>
+        add_edge(303, 368) |>
+        subtract_edge(7, 291) |>
+        add_edge(2, 8) |>
+        add_edge(6, 8) |>
+        add_edge(1, 8) |>
+        add_edge(361, 375) |>
+        add_edge(281, 297) |>
+        add_edge(280, 297)
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(ak_shp$adj, ak_shp$ssd_2020)
+    ccm(ak_shp$adj, ak_shp$shd_2020)
+
+    ak_shp <- ak_shp |>
+        fix_geo_assignment(muni)
+
+    # Fix ssd district numbering
+    ak_shp <- ak_shp |>
+        mutate(ssd_2020 = dense_rank(ssd_2020))
+
+    write_rds(ak_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    ak_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong AK} shapefile")
+}

--- a/analyses/AK_leg_2020/02_setup_AK_leg_2020.R
+++ b/analyses/AK_leg_2020/02_setup_AK_leg_2020.R
@@ -1,0 +1,30 @@
+###############################################################################
+# Set up redistricting simulation for `AK_leg_2020`
+# © ALARM Project, February 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg AK_leg_2020}")
+
+map_ssd <- redist_map(ak_shp, pop_tol = 0.025,
+    existing_plan = ssd_2020, adj = ak_shp$adj)
+
+map_shd <- redist_map(ak_shp, pop_tol = 0.05,
+    existing_plan = shd_2020, adj = ak_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+# IF MERGING CORES OR OTHER UNITS:
+# make a new `map_cores` object that is merged & used for simulating. You can set `drop_geom=TRUE` for this.
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "AK_SSD_2020"
+attr(map_shd, "analysis_name") <- "AK_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/AK_2020/AK_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/AK_2020/AK_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/AK_leg_2020/03_sim_AK_shd_2020.R
+++ b/analyses/AK_leg_2020/03_sim_AK_shd_2020.R
@@ -1,0 +1,208 @@
+###############################################################################
+# Simulate plans for `AK_shd_2020` SHD
+# © ALARM Project, August 2026
+###############################################################################
+
+nested_smc <- function(plans, map_ssd, map_shd, shp, inner_nsims = 50, inner_runs = 1, outer_runs = 5, year = 2020, state, max_split_tries = 100000, ncores = 8) {
+
+    library(foreach)
+    library(doParallel)
+    library(doRNG)
+
+    shd_col <- paste0("shd_", year)
+    ssd_col <- paste0("ssd_", year)
+
+    # Generate district assignment matrix
+    sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+
+    # Create shd map object
+    map_shd_iterate <- redist_map(shp, pop_tol = 0.05,
+        ndists = n_distinct(map_shd[[shd_col]]), adj = shp$adj)
+
+    # Unique ID for each row, will use later to reconnect pieces
+    map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+    # Simulation hyperparameters
+    inner_splits <- n_distinct(map_shd[[shd_col]])/n_distinct(map_ssd[[ssd_col]])
+    final_sims <- ncol(sample_ssd_matrix)
+
+    # Set up log file
+    logfile <- sprintf("data-out/AK_2020/nested_log.txt", state, year)
+    file.create(logfile)
+
+    # Set up parallelization
+    cl <- parallel::makeCluster(ncores, outfile = logfile, methods = FALSE,
+        useXDR = .Platform$endian != "little")
+
+    registerDoParallel(cl)
+
+    # Outer loop: senate simulations
+    plans_shd <- foreach(i = 1:final_sims, .combine = "rbind",
+        .export = c("prep_particles", "rep_cols", "rep_col"),
+        .packages = c("tidyverse", "redist")) %dorng% {
+        # mh_accept_per_smc <- 1
+        devtools::load_all()
+
+        # Add senate district assignment from simulation i
+        map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+
+        plan_list <- vector("list", max(map_shd_iterate$ssd_sim))
+
+        failed <- FALSE
+
+        # Inner loop: simulated senate districts
+        for (j in 1:max(map_shd_iterate$ssd_sim)) {
+            m <- map_shd_iterate %>%
+                filter(ssd_sim == j)
+            map_j <- redist_map(m, pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+                ndists = inner_splits, adj = m$adj)
+
+
+            # Constraints here
+            constr <- redist_constr(map_j) %>%
+                add_constr_total_splits(strength = 3.5, admin = county_muni) %>%
+                add_constr_polsby(strength = 8)
+
+            output <- capture.output(
+                {
+                    result <- tryCatch(
+                        {
+                            plans_j <- redist_smc(
+                                map_j,
+                                nsims = inner_nsims, runs = inner_runs,
+                                counties = county,
+                                sampling_space = "linking_edge",
+                                constraints = constr,
+                                pop_temper = 0.02,
+                                # ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+                                split_params = list(splitting_schedule = "any_valid_sizes"),
+                                verbose = TRUE,
+                                control = list(max_split_tries = max_split_tries)
+                            )
+
+                            # Catch error
+                        },
+                        error = function(e) {
+
+                            NULL
+                        })
+                },
+                type = "output")
+
+            # Catch fail to split warning
+            if (is.null(result) || any(grepl("Failed to split", output))) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner j =", j, "\n", file = logfile, append = TRUE)
+                break
+            }
+
+            plans_j <- plans_j %>% filter(draw == inner_nsims*inner_runs)
+            plans_j$dist_keep <- TRUE
+            plan_list[[j]] <- list(map = map_j, plans = plans_j)
+        }
+
+        if (failed) {
+            # Return dummy plan
+            prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+            plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+            plans_dummy$draw <- as.factor(99999)
+
+            return(plans_dummy)
+        }
+
+        # Combine into single state-wide plan
+        prep_mat <- prep_particles(map = map_shd_iterate,
+            map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
+
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate, algorithm = "smc")
+
+        # Counter for log file
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims, file = logfile, append = TRUE)
+
+        plans_i
+
+    }
+
+    stopCluster(cl)
+
+    # Determine effective sample size
+    survive <- plans_shd %>%
+        as.data.frame() %>%
+        filter(district == 1) %>%
+        mutate(survive = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive)
+
+    survive_all <- plans_shd %>%
+        as.data.frame() %>%
+        mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) %>%
+        dplyr::select(survive_all)
+
+    saveRDS(survive_all, "data-out/AK_2020/survive_all.rds")
+
+    plans_shd_matrix <- get_plans_matrix(plans_shd)
+    plans_shd_matrix <- plans_shd_matrix[, survive$survive]
+
+    plans_shd <- redist_plans(plans = plans_shd_matrix,
+        map = map_shd,
+        algorithm = "smc")
+
+    # Add draw and chain numbering
+    plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+    full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+
+    plans_shd$chain <- full_chain[survive_all$survive_all]
+
+    # Add enacted plan
+    plans_shd <- add_reference(plans_shd, ref_plan = map_shd[[shd_col]], name = shd_col)
+
+    return(plans_shd)
+
+}
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AK_shd_2020}")
+
+set.seed(2020)
+
+# mh_accept_per_smc <- ceiling(n_distinct(map_shd$shd_2020)/3)
+
+plans <- readRDS("data-raw/AK/AK_ssd_2020_plans_oversample.rds")
+
+plans <- nested_smc(plans, map_ssd, map_shd, shp = ak_shp, state = "AK", ncores = 64)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AK_2020/AK_shd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AK_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AK_2020/AK_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+
+}

--- a/analyses/AK_leg_2020/03_sim_AK_ssd_2020.R
+++ b/analyses/AK_leg_2020/03_sim_AK_ssd_2020.R
@@ -1,0 +1,64 @@
+###############################################################################
+# Simulate plans for `AK_ssd_2020` SSD
+# © ALARM Project, February 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg AK_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- 35
+
+constr <- redist_constr(map_ssd) %>%
+    add_constr_total_splits(strength = 2, admin = county) %>%
+    add_constr_polsby(strength = 8)
+
+plans <- redist_smc(
+    map_ssd,
+    nsims = 10*2e3, runs = 5,
+    constraints = constr,
+    counties = pseudo_county,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE,
+    ncores = 64
+)
+
+# IF CORES OR OTHER UNITS HAVE BEEN MERGED:
+# make sure to call `pullback()` on this plans object!
+plans <- match_numbers(plans, "ssd_2020")
+
+write_rds(plans, here("data-raw/AK/AK_ssd_2020_plans_oversample.rds"), compress = "xz")
+
+plans <- plans |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/AK_2020/AK_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg AK_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/AK_2020/AK_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+
+}

--- a/analyses/AK_leg_2020/doc_AK_leg_2020.md
+++ b/analyses/AK_leg_2020/doc_AK_leg_2020.md
@@ -1,0 +1,31 @@
+# 2020 Alaska State House/Senate Districts
+
+## Redistricting requirements
+In Alaska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Alaska must:
+
+1. be contiguous [NCSL 184]
+1. have equal populations [NCSL 24]
+1. preserve county and municipality boundaries as much as possible [NCSL 184]
+1. be compact [NCSL 184]
+1. preserve communities of interest [NCSL 184]
+1. have House districts nested inside Senate districts [NCSL 185]
+
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 2.5% for State Senate districts and 5.0% for State House districts..
+
+## Data Sources
+Data for Alaska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+To make the adjacency graph contiguous, a few remote island precincts are connected with neighboring islands and the nearest precincts on the mainland.
+
+## Simulation Notes
+We sample 100,000 districting plans for Alaska's upper house across 5 independent runs of the SMC algorithm.
+We then thinned the number of samples to 10,000,
+We impose a total county splits constraint and a Polsby-Popper compactness constraint on the inner-simulations.
+
+We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 100,000 upper house districts.
+16,516 districting plans remain in the surviving sample.
+We then thinned the number of samples to 10,000.
+We impose a total municipality splits constraint and a Polsby-Popper compactness constraint on the inner-simulations.


### PR DESCRIPTION
## Redistricting requirements
In Alaska, we consult [NCSL Redistricting Law 2020](https://documents.ncsl.org/wwwncsl/Redistricting-Census/Redistricting-Law-2020_NCSL%20FINAL.pdf). State legislative districts in Alaska must:

1. be contiguous [NCSL 184]
1. have equal populations [NCSL 24]
1. preserve county and municipality boundaries as much as possible [NCSL 184]
1. be compact [NCSL 184]
1. preserve communities of interest [NCSL 184]
1. have House districts nested inside Senate districts [NCSL 185]

### Algorithmic Constraints
We enforce a maximum population deviation of 2.5% for State Senate districts and 5.0% for State House districts..

## Data Sources
Data for Alaska comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
To make the adjacency graph contiguous, a few remote island precincts are connected with neighboring islands and the nearest precincts on the mainland.

## Simulation Notes
We sample 100,000 districting plans for Alaska's upper house across 5 independent runs of the SMC algorithm.
We then thinned the number of samples to 10,000,
We impose a total county splits constraint and a Polsby-Popper compactness constraint on the inner-simulations.

We use the top-down nested procedure to sample Minnesota's lower house districts, with 50 inner-simulations for each of the 100,000 upper house districts.
16,516 districting plans remain in the surviving sample.
We then thinned the number of samples to 10,000.
We impose a total municipality splits constraint and a Polsby-Popper compactness constraint on the inner-simulations.

## Validation

**State Senate**

<img width="3000" height="5400" alt="validation_20260818_2241" src="https://github.com/user-attachments/assets/8dfc4822-09e3-406a-a4b6-a6e3aa401a97" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 20
                 districts on 456 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 19
• `mh_accept_per_smc` = 35
• `pair_rule` = uniform
Plan diversity 80% range: 0.57 to 0.76
10 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.005               1.004               1.004               1.008               1.005 
             arv_20     comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.007               1.012               1.002               1.005               1.003 
              e_dem               e_dvs                egap      gov_18_dem_beg      gov_18_rep_dun 
              1.001               1.011               1.001               1.004               1.005 
        muni_splits             ndshare                 ndv                 nrv               pbias 
              1.009               1.009               1.004               1.006               1.009 
           plan_dev            pop_aian           pop_asian           pop_black            pop_hisp 
              1.002               1.010               1.007               1.005               1.008 
           pop_nhpi           pop_other         pop_overlap             pop_two           pop_white 
              1.004               1.005               1.004               1.004               1.009 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru 
              1.003               1.004               1.005               1.005               1.007 
total_county_splits   total_muni_splits           total_vap      uss_16_dem_met      uss_16_rep_mur 
              1.007               1.005               1.003               1.006               1.003 
     uss_20_dem_gro      uss_20_rep_sul            vap_aian           vap_asian           vap_black 
              1.004               1.006               1.009               1.006               1.005 
           vap_hisp            vap_nhpi           vap_other             vap_two           vap_white 
              1.006               1.005               1.006               1.006               1.009 
• R-hat ≤ 1.05: 990
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 990
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd   Max. unique    
Split 1      1,592 (8.0%)    100.0%        2.89 12,672 (100%)    
Split 2        654 (3.3%)     81.2%        3.53  3,550 ( 28%)  * 
Split 3        926 (4.6%)     75.4%        3.00  4,086 ( 32%)  * 
Split 4     2,661 (13.3%)     65.9%        2.28  5,296 ( 42%)    
Split 5     4,483 (22.4%)     58.1%        1.93  6,974 ( 55%)    
Split 6     6,030 (30.1%)     50.6%        1.69  7,776 ( 62%)    
Split 7     7,610 (38.0%)     44.0%        1.51  8,608 ( 68%)    
Split 8     8,759 (43.8%)     37.6%        1.40  9,185 ( 73%)    
Split 9     9,749 (48.7%)     32.6%        1.28  9,408 ( 74%)    
Split 10   10,421 (52.1%)     28.3%        1.21  9,701 ( 77%)    
Split 11   11,148 (55.7%)     24.6%        1.13  9,914 ( 78%)    
Split 12   11,732 (58.7%)     21.8%        1.06  9,985 ( 79%)    
Split 13   12,310 (61.5%)     19.1%        1.02  9,987 ( 79%)    
Split 14   12,950 (64.8%)     16.4%        0.96  9,965 ( 79%)    
Split 15   13,170 (65.8%)     14.2%        0.93 10,046 ( 79%)    
Split 16   13,689 (68.4%)     12.1%        0.88  9,861 ( 78%)    
Split 17   14,295 (71.5%)     10.2%        0.80  9,540 ( 75%)    
Split 18   14,606 (73.0%)      8.2%        0.77  8,761 ( 69%)    
Split 19   15,292 (76.5%)      6.3%        0.70  6,997 ( 55%)    
Resample   15,292 (76.5%)       NA%          NA 15,522 (123%)    

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      17.8%                35
MS Step 2      14.7%               210
MS Step 3      17.6%               245
MS Step 4      20.4%               210
MS Step 5      22.6%               175
MS Step 6      24.0%               175
MS Step 7      24.8%               175
MS Step 8      25.1%               175
MS Step 9      25.2%               140
MS Step 10     24.9%               140
MS Step 11     24.6%               175
MS Step 12     24.1%               175
MS Step 13     23.9%               175
MS Step 14     23.5%               175
MS Step 15     23.2%               175
MS Step 16     23.1%               175
MS Step 17     23.0%               175
MS Step 18     23.0%               175
MS Step 19     23.0%               175
```

**State House**

<img width="3000" height="5400" alt="validation_20260818_2248" src="https://github.com/user-attachments/assets/2a1c24fb-2ea6-40a1-ac5b-9aef06a3c76c" />

```
SMC: 10,000 sampled plans of 40
                 districts on 456 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.65 to 0.79
23 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18 
              1.009               1.003               1.008               1.009               1.008 
             arv_20     comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.008               1.006               1.003               1.006               1.001 
              e_dem               e_dvs                egap      gov_18_dem_beg      gov_18_rep_dun 
              1.001               1.009               1.001               1.003               1.008 
        muni_splits             ndshare                 ndv                 nrv               pbias 
              1.002               1.010               1.007               1.009               1.002 
           plan_dev            pop_aian           pop_asian           pop_black            pop_hisp 
              1.001               1.012               1.015               1.011               1.016 
           pop_nhpi           pop_other         pop_overlap             pop_two           pop_white 
              1.014               1.006               1.001               1.004               1.014 
             pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid      pre_20_rep_tru 
              1.003               1.008               1.008               1.009               1.011 
total_county_splits   total_muni_splits           total_vap      uss_16_dem_met      uss_16_rep_mur 
              1.003               1.002               1.004               1.006               1.007 
     uss_20_dem_gro      uss_20_rep_sul            vap_aian           vap_asian           vap_black 
              1.008               1.008               1.010               1.018               1.010 
           vap_hisp            vap_nhpi           vap_other             vap_two           vap_white 
              1.010               1.017               1.006               1.007               1.009 
• R-hat ≤ 1.05: 1977
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 1977
•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log
weights (more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between
1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited

@tylersimko  