### PR TITLE
Cleanup 02_setup_TN_cd_1990.R

### DIFF
--- a/analyses/TN_cd_1990/02_setup_TN_cd_1990.R
+++ b/analyses/TN_cd_1990/02_setup_TN_cd_1990.R
@@ -17,6 +17,14 @@ map <- map %>%
     )
   )
 
+# Add a stronger county constraint
+constr <- redist_constr(map)
+constr <- add_constr_splits(
+  constr,
+  strength = 2,
+  admin = county
+)
+
 # Add an analysis name attribute
 attr(map, "analysis_name") <- "TN_1990"
 


### PR DESCRIPTION
This PR restores the missing county-split constraint in `02_setup_TN_cd_1990.R`:
```
constr <- redist_constr(map)
constr <- add_constr_splits(constr, strength = 2, admin = county)
```
This is consistent with the existing documentation, which states that the TN 1990 analysis uses a stronger county constraint.
It also matches the constraint actually used to generate the existing simulation results. The stored `TN_cd_1990_plans.rds` records a splits constraint with `strength = 2` across 95 counties, and its admin vector exactly matches `map$county`.
