### PR TITLE
Cleanup UT 1990 and 2000 simulation scripts

### DIFF
--- a/analyses/UT_cd_1990/03_sim_UT_cd_1990.R
+++ b/analyses/UT_cd_1990/03_sim_UT_cd_1990.R
@@ -4,38 +4,36 @@
 ###############################################################################
 
 # Run the simulation -----
-if (interactive()) {
-  cli_process_start("Running simulations for {.pkg UT_cd_1990}")
+cli_process_start("Running simulations for {.pkg UT_cd_1990}")
 
-  # Add a stronger county constraint.
-  constr <- redist_constr(map)
-  constr <- add_constr_splits(constr, strength = 2, admin = county)
-  
-  set.seed(1990)
-  plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county, constraints = constr)
-  plans <- plans %>%
-    group_by(chain) %>%
-    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
-    ungroup()
-  plans <- match_numbers(plans, "cd_1990")
-  
-  cli_process_done()
-  cli_process_start("Saving {.cls redist_plans} object")
-  
-  # Output the redist_map object. Do not edit this path.
-  write_rds(plans, here("data-out/UT_1990/UT_cd_1990_plans.rds"), compress = "xz")
-  cli_process_done()
-  
-  # Compute summary statistics -----
-  cli_process_start("Computing summary statistics for {.pkg UT_cd_1990}")
-  
-  plans <- add_summary_stats(plans, map)
-  
-  # Output the summary statistics. Do not edit this path.
-  save_summary_stats(plans, "data-out/UT_1990/UT_cd_1990_stats.csv")
-  
-  cli_process_done()
-}
+# Add a stronger county constraint.
+constr <- redist_constr(map)
+constr <- add_constr_splits(constr, strength = 2, admin = county)
+
+set.seed(1990)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county, constraints = constr)
+plans <- plans %>%
+  group_by(chain) %>%
+  filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+  ungroup()
+plans <- match_numbers(plans, "cd_1990")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/UT_1990/UT_cd_1990_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg UT_cd_1990}")
+
+plans <- add_summary_stats(plans, map)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/UT_1990/UT_cd_1990_stats.csv")
+
+cli_process_done()
 
 # Validation
 if (interactive()) {

--- a/analyses/UT_cd_2000/03_sim_UT_cd_2000.R
+++ b/analyses/UT_cd_2000/03_sim_UT_cd_2000.R
@@ -4,32 +4,29 @@
 ###############################################################################
 
 # Run the simulation -----
-if (interactive()) {
-    cli_process_start("Running simulations for {.pkg UT_cd_2000}")
+cli_process_start("Running simulations for {.pkg UT_cd_2000}")
 
-    set.seed(2000)
-    plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
-    plans <- plans %>%
-        group_by(chain) %>%
-        filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
-        ungroup()
-    plans <- match_numbers(plans, "cd_2000")
+set.seed(2000)
+plans <- redist_smc(map, nsims = 2e3, runs = 5, counties = county)
+plans <- plans %>%
+    group_by(chain) %>%
+    filter(as.integer(draw) < min(as.integer(draw)) + 1000) %>% # thin samples
+    ungroup()
+plans <- match_numbers(plans, "cd_2000")
 
-    cli_process_done()
-    cli_process_start("Saving {.cls redist_plans} object")
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
 
-    # Output the redist_map object. Do not edit this path.
-    write_rds(plans, here("data-out/UT_2000/UT_cd_2000_plans.rds"), compress = "xz")
-    cli_process_done()
+# Output the redist_map object. Do not edit this path.
+write_rds(plans, here("data-out/UT_2000/UT_cd_2000_plans.rds"), compress = "xz")
+cli_process_done()
 
-    # Compute summary statistics -----
-    cli_process_start("Computing summary statistics for {.pkg UT_cd_2000}")
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg UT_cd_2000}")
 
-    plans <- add_summary_stats(plans, map)
+plans <- add_summary_stats(plans, map)
 
-    # Output the summary statistics. Do not edit this path.
-    save_summary_stats(plans, "data-out/UT_2000/UT_cd_2000_stats.csv")
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/UT_2000/UT_cd_2000_stats.csv")
 
-    cli_process_done()
-
-}
+cli_process_done()


### PR DESCRIPTION
This PR removes the `if (interactive())` wrappers from the UT 1990 and UT 2000 simulation scripts so that the full analyses can run in non-interactive/batch environments.
No sampling parameters or constraints are changed in this PR.