### PR TITLE
Correct logit-shift comments in 1990 analyses

### DIFF
--- a/analyses/AL_cd_1990/01_prep_AL_cd_1990.R
+++ b/analyses/AL_cd_1990/01_prep_AL_cd_1990.R
@@ -69,7 +69,7 @@ if (!file.exists(here(shp_path))) {
 
     names(al_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     al_shp <- al_shp |>
         group_by(county_fips) |>
         group_split() |>

--- a/analyses/GA_cd_1990/01_prep_GA_cd_1990.R
+++ b/analyses/GA_cd_1990/01_prep_GA_cd_1990.R
@@ -74,7 +74,7 @@ if (!file.exists(here(shp_path))) {
 
     names(ga_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     ga_shp <- ga_shp |>
       group_by(county_fips) |>
       group_split() |>

--- a/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
+++ b/analyses/MO_cd_1990/01_prep_MO_cd_1990.R
@@ -70,7 +70,7 @@ if (!file.exists(here(shp_path))) {
 
     names(mo_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     mo_shp <- mo_shp |>
       group_by(county_fips) |>
       group_split() |>

--- a/analyses/MS_cd_1990/01_prep_MS_cd_1990.R
+++ b/analyses/MS_cd_1990/01_prep_MS_cd_1990.R
@@ -79,7 +79,7 @@ if (!file.exists(here(shp_path))) {
 
     names(ms_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     ms_shp <- ms_shp |>
         group_by(county_fips) |>
         group_split() |>

--- a/analyses/NC_cd_1990/01_prep_NC_cd_1990.R
+++ b/analyses/NC_cd_1990/01_prep_NC_cd_1990.R
@@ -74,7 +74,7 @@ if (!file.exists(here(shp_path))) {
 
     names(nc_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     nc_shp <- nc_shp |>
         group_by(county_fips) |>
         group_split() |>

--- a/analyses/SC_cd_1990/01_prep_SC_cd_1990.R
+++ b/analyses/SC_cd_1990/01_prep_SC_cd_1990.R
@@ -75,7 +75,7 @@ if (!file.exists(here(shp_path))) {
 
     names(sc_shp)
 
-    # 3. For each county, logit-shift ndv/nrv to the 2000 target from MEDSL ----
+    # 3. For each county, logit-shift ndv/nrv to the 1992 target from LEIP ----
     sc_shp <- sc_shp |>
         group_by(county_fips) |>
         group_split() |>


### PR DESCRIPTION
This PR corrects the logit-shift comments in the AL, GA, MO, MS, NC, and SC 1990 analyses. The code uses the 1992 LEIP baseline, but the comments incorrectly referred to the 2000 MEDSL target. No analysis code or outputs are changed.