### PR TITLE
Document logit-shift preprocessing across analyses

### DIFF
--- a/analyses/AL_cd_2000/doc_AL_cd_2000.md
+++ b/analyses/AL_cd_2000/doc_AL_cd_2000.md
@@ -19,7 +19,7 @@ We enforce a maximum population deviation of 0.5%.
 Data for Alabama comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We apply a county-level logit shift to recalibrate ndv/nrv so that county-level Democratic two-party vote shares match the 2000 MEDSL presidential results, while preserving total two-party turnout.
 
 ## Simulation Notes
 We sample 18,000 districting plans for Alabama across 6 independent runs of the SMC algorithm.

--- a/analyses/GA_cd_1990/doc_GA_cd_1990.md
+++ b/analyses/GA_cd_1990/doc_GA_cd_1990.md
@@ -17,7 +17,7 @@ We enforce a maximum population deviation of 0.5%.
 Data for Georgia comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We apply a county-level logit shift to recalibrate ndv/nrv so that county-level Democratic two-party vote shares match the 1992 LEIP presidential results, while preserving total two-party turnout.
 
 ## Simulation Notes
 We sample 10,000 districting plans for Georgia across 5 independent runs of the SMC algorithm.

--- a/analyses/MO_cd_1990/doc_MO_cd_1990.md
+++ b/analyses/MO_cd_1990/doc_MO_cd_1990.md
@@ -16,7 +16,7 @@ We enforce a maximum population deviation of 0.5%. We add a hinge Gibbs constrai
 Data for Missouri comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We apply a county-level logit shift to recalibrate ndv/nrv so that county-level Democratic two-party vote shares match the 1992 LEIP presidential results, while preserving total two-party turnout.
 
 ## Simulation Notes
 We sample 25,000 districting plans for Missouri across 5 independent runs of the SMC algorithm to aid with convergence.

--- a/analyses/NC_cd_2000/doc_NC_cd_2000.md
+++ b/analyses/NC_cd_2000/doc_NC_cd_2000.md
@@ -21,7 +21,7 @@ We enforce a maximum population deviation of 0.5%.
 Data for North Carolina comes from the [ALARM Project's update](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZV5KF3) to [The Record of American Democracy](https://road.hmdc.harvard.edu/).
 
 ## Pre-processing Notes
-No manual pre-processing decisions were necessary.
+We apply a county-level logit shift to recalibrate ndv/nrv so that county-level Democratic two-party vote shares match the 2000 MEDSL presidential results, while preserving total two-party turnout.
 
 ## Simulation Notes
 We sample 18,000 districting plans for North Carolina across 6 independent runs of the SMC algorithm.

--- a/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
+++ b/analyses/NJ_cd_2000/doc_NJ_cd_2000.md
@@ -15,7 +15,7 @@ Data for ``New Jersey`` comes from the [ALARM Project's update](https://datavers
 
 ## Pre-processing Notes
 Because ``New Jersey`` contains an unusually large number of discontiguous precincts, we used a helper function to identify 20 discontiguity merge-groups, involving 46 precincts (0.75% of all VTDs). These units were merged prior to simulation.
-We apply a county-level logit shift to recalibrate ``ndv/nrv``. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval [-1, 1] was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to [-1.5, 1.5] to accommodate the larger correction.
+We apply a county-level logit shift to recalibrate ``ndv/nrv``　so that county-level Democratic two-party vote shares match the 2000 MEDSL presidential results. The adjustment needed to correct the vote shares was fairly large in several counties: Essex required a logit shift of about 1.39, Hudson about 1.33, Passaic about 0.98, and Union about 1.07. Because some of these values exceed 1, the original search interval [-1, 1] was too narrow for ``uniroot()`` to find the solution, so we widened the search interval to [-1.5, 1.5] to accommodate the larger correction.
 
 ## Simulation Notes
 We sample 5,000 districting plans for ``New Jersey`` across 5 independent runs of the SMC algorithm.


### PR DESCRIPTION
This PR updates the preprocessing documentation for analyses where the logit shift was not fully documented:
GA_1990 / MO_1990 — document the county-level logit shift to the 1992 LEIP presidential results.
AL_2000 / NC_2000 — document the county-level logit shift to the 2000 MEDSL presidential results.
NJ_2000 — clarify that the existing logit shift uses the 2000 MEDSL presidential results.
These are documentation-only changes; no analysis code or outputs are changed.