### PR TITLE
2020 Maryland State House/Senate Districts

### DIFF
--- a/analyses/MD_leg_2020/01_prep_MD_leg_2020.R
+++ b/analyses/MD_leg_2020/01_prep_MD_leg_2020.R
@@ -1,0 +1,264 @@
+###############################################################################
+# Download and prepare data for `MD_leg_2020` analysis
+# © ALARM Project, August 2026
+###############################################################################
+suppressMessages({
+    library(dplyr)
+    library(readr)
+    library(sf)
+    library(redist)
+    library(geomander)
+    library(cli)
+    library(here)
+    library(tinytiger)
+    devtools::load_all() # load utilities
+})
+
+stopifnot(utils::packageVersion("redist") >= "5.0.0.1")
+
+# Download necessary files for analysis -----
+cli_process_start("Downloading files for {.pkg MD_leg_2020}")
+
+path_data <- download_redistricting_file("MD", "data-raw/MD", year = 2020)
+
+cli_process_done()
+
+# Compile raw data into a final shapefile for analysis -----
+shp_path <- "data-out/MD_2020/shp_vtd.rds"
+perim_path <- "data-out/MD_2020/perim.rds"
+
+if (!file.exists(here(shp_path))) {
+    cli_process_start("Preparing {.strong MD} shapefile")
+    # block-level redistricting data
+    md_shp <- PL94171::pl_read(PL94171::pl_url("MD", year = 2020)) |>
+        PL94171::pl_subset(sumlev = "750") |>
+        PL94171::pl_select_standard() |>
+        rename(GEOID20 = GEOID) |>
+        left_join(y = tigris::blocks("MD", year = 2020), by = "GEOID20") |>
+        st_as_sf() |>
+        st_transform(EPSG$MD) |>
+        rename_with(function(x) gsub("[0-9.]", "", x), starts_with("GEOID"))
+
+    # add block-level geographic assignments from 2020 BAFs
+    baf_2020 <- PL94171::pl_get_baf("MD", cache_to = here("data-raw/MD/MD_baf.rds"))
+    d_muni <- baf_2020$INCPLACE_CDP |>
+        transmute(GEOID = BLOCKID, muni = PLACEFP)
+    d_ssd <- baf_2020$SLDU |>
+        transmute(GEOID = BLOCKID, ssd_2010 = as.integer(na_if(DISTRICT, "ZZZ")))
+    d_shd <- baf_2020$SLDL |>
+        transmute(GEOID = BLOCKID, shd_2010 = na_if(DISTRICT, "ZZZ"))
+    d_vtd <- baf_2020$VTD |>
+        transmute(GEOID = BLOCKID,
+            vtd_2020 = paste0(censable::match_fips("MD"), COUNTYFP, DISTRICT))
+
+    md_shp <- md_shp |>
+        left_join(d_muni, by = "GEOID") |>
+        left_join(d_ssd, by = "GEOID") |>
+        left_join(d_shd, by = "GEOID") |>
+        left_join(d_vtd, by = "GEOID")
+
+    # add the enacted plan
+    d_ssd_2020 <- baf::baf(state = "MD", year = 2023, geographies = "ssd")$SSD2022 |>
+        transmute(GEOID = as.character(GEOID), ssd_2020 = as.integer(SLDUST))
+    d_shd_2020 <- baf::baf(state = "MD", year = 2023, geographies = "shd")$SHD2022 |>
+        transmute(GEOID = as.character(GEOID), shd_2020 = as.character(SLDLST))
+
+    md_shp <- md_shp |>
+        left_join(d_ssd_2020, by = "GEOID") |>
+        left_join(d_shd_2020, by = "GEOID")
+
+    # Create units for VTDs that cross enacted SSD or SHD boundaries
+    split_vtds <- md_shp |>
+        st_drop_geometry() |>
+        group_by(vtd_2020) |>
+        summarise(split_vtd = n_distinct(ssd_2020) > 1L |
+            n_distinct(shd_2020) > 1L, .groups = "drop")
+
+    vtd_elections <- read_csv(here(path_data), col_types = cols(GEOID20 = "c")) |>
+        rename(vtd_2020 = GEOID20) |>
+        select(vtd_2020, pre_16_rep_tru:ndv)
+    election_cols <- setdiff(names(vtd_elections), "vtd_2020")
+
+    md_shp <- md_shp |>
+        left_join(split_vtds, by = "vtd_2020") |>
+        group_by(vtd_2020) |>
+        mutate(vtd_block_pop = sum(pop, na.rm = TRUE)) |>
+        ungroup() |>
+        left_join(vtd_elections, by = "vtd_2020") |>
+        mutate(
+            unit_id = if_else(
+                split_vtd,
+                stringr::str_c(vtd_2020, "_",
+                    stringr::str_pad(ssd_2020, 2, "left", "0"), "_",
+                    shd_2020),
+                vtd_2020
+            ),
+            block_pop_share = if_else(
+                vtd_block_pop > 0, pop/vtd_block_pop, 0)
+        ) |>
+        mutate(across(all_of(election_cols), ~ coalesce(.x, 0)*block_pop_share))
+
+    md_shp <- md_shp |>
+        group_by(unit_id) |>
+        summarize(
+            vtd_2020 = Mode(vtd_2020),
+            split_vtd = any(split_vtd),
+            ssd_2010 = Mode(ssd_2010),
+            shd_2010 = Mode(shd_2010),
+            ssd_2020 = Mode(ssd_2020),
+            shd_2020 = Mode(shd_2020),
+            muni = Mode(muni),
+            state = Mode(state),
+            county = Mode(county),
+            across(any_of(c(
+                "pop", "pop_hisp", "pop_white", "pop_black", "pop_aian",
+                "pop_asian", "pop_nhpi", "pop_other", "pop_two",
+                "vap", "vap_hisp", "vap_white", "vap_black", "vap_aian",
+                "vap_asian", "vap_nhpi", "vap_other", "vap_two",
+                "ALAND20", "AWATER20", election_cols
+            )), \(x) sum(x, na.rm = TRUE)),
+            geometry = st_union(geometry),
+            .groups = "drop"
+        ) |>
+        rename(GEOID = unit_id,
+            area_land = ALAND20,
+            area_water = AWATER20
+        ) |>
+        mutate(
+            county_muni = if_else(
+                is.na(muni), county, stringr::str_c(county, muni)
+            )
+        ) |>
+        relocate(
+            muni, county_muni, vtd_2020, split_vtd,
+            ssd_2010, shd_2010, ssd_2020, shd_2020,
+            .after = county
+        )
+
+    # Create perimeters in case shapes are simplified
+    redistmetrics::prep_perims(shp = md_shp,
+        perim_path = here(perim_path)) |>
+        invisible()
+
+    # simplifies geometry for faster processing, plotting, and smaller shapefiles
+    if (requireNamespace("rmapshaper", quietly = TRUE)) {
+        md_shp <- rmapshaper::ms_simplify(md_shp, keep = 0.05, keep_shapes = TRUE) |>
+            suppressWarnings()
+    }
+
+    # create adjacency graph
+    md_shp$adj <- adjacency(md_shp)
+
+    # prevent Bay water units from connecting opposite shores
+    bay_vtds <- c("24009ZZZZZZ", "24015ZZZZZZ", "24017ZZZZZZ",
+        "24025ZZZZZZ", "24037ZZZZZZ", "24039ZZZZZZ",
+        "24041ZZZZZZ", "24047ZZZZZZ", "24510ZZZZZZ")
+
+    bay_ids <- md_shp$GEOID[md_shp$vtd_2020 %in% bay_vtds]
+
+    # remove all existing edges from every Bay atom
+    for (bid in bay_ids) {
+        i <- match(bid, md_shp$GEOID)
+        nbr_ids <- md_shp$GEOID[md_shp$adj[[i]] + 1L]
+
+        for (nid in nbr_ids) {
+            md_shp$adj <- subtract_edge(
+                md_shp$adj, bid, nid, ids = md_shp$GEOID
+            )
+        }
+    }
+
+    # connect each Bay atom to the nearest non-Bay atom
+    # in the same county, enacted SSD, and enacted SHD
+    bay_edge_additions <- tibble::tibble(
+        from = character(),
+        to = character()
+    )
+
+    for (bid in bay_ids) {
+        i <- match(bid, md_shp$GEOID)
+
+        candidates <- which(
+            !(md_shp$GEOID %in% bay_ids) &
+                md_shp$county == md_shp$county[[i]] &
+                md_shp$ssd_2020 == md_shp$ssd_2020[[i]] &
+                md_shp$shd_2020 == md_shp$shd_2020[[i]]
+        )
+
+        nearest <- st_nearest_feature(
+            md_shp[i, ],
+            md_shp[candidates, ]
+        )
+
+        bay_edge_additions <- bind_rows(
+            bay_edge_additions,
+            tibble::tibble(
+                from = bid,
+                to = md_shp$GEOID[candidates[[nearest]]]
+            )
+        )
+    }
+
+    for (k in seq_len(nrow(bay_edge_additions))) {
+        md_shp$adj <- add_edge(
+            md_shp$adj,
+            bay_edge_additions$from[[k]],
+            bay_edge_additions$to[[k]],
+            ids = md_shp$GEOID
+        )
+    }
+
+    # remove additional cross-Bay edges identified by visual review
+    md_shp$adj <- md_shp$adj |>
+        subtract_edge(547, 1132) |>
+        subtract_edge(549, 1132) |>
+        subtract_edge(547, 1131) |>
+        subtract_edge(549, 1131) |>
+        subtract_edge(550, 1131) |>
+        subtract_edge(111, 1131) |>
+        subtract_edge(161, 1131) |>
+        subtract_edge(115, 1131) |>
+        subtract_edge(111, 1776) |>
+        subtract_edge(160, 1776) |>
+        subtract_edge(161, 1776) |>
+        subtract_edge(115, 1776) |>
+        subtract_edge(160, 1778) |>
+        subtract_edge(181, 1778) |>
+        subtract_edge(223, 1778) |>
+        subtract_edge(223, 1779) |>
+        subtract_edge(237, 1779) |>
+        subtract_edge(241, 1779) |>
+        subtract_edge(234, 1779)
+
+    # add land and island connections identified by visual review
+    # (restore enacted-district contiguity)
+    md_shp$adj <- md_shp$adj |>
+        add_edge(664, 984) |>
+        add_edge(555, 1820) |>
+        add_edge(1786, 1829) |>
+        add_edge(1841, 1846) |>
+        add_edge(1845, 1846) |>
+        add_edge(2008, 2020) |>
+        add_edge(635, 636) |>
+
+        # repair SSD 27 / SHD 27B
+        add_edge("2400903-006", "2403304-001_27_27B", ids = md_shp$GEOID) |>
+
+        # repair SSD 46 / SHD 046
+        add_edge("2451025-008", "2451025-011", ids = md_shp$GEOID)
+
+
+    # check max number of connected components
+    # 1 is one fully connected component, more is worse
+    ccm(md_shp$adj, md_shp$ssd_2020)
+    ccm(md_shp$adj, md_shp$shd_2020)
+
+    md_shp <- md_shp |>
+        fix_geo_assignment(muni)
+
+    write_rds(md_shp, here(shp_path), compress = "gz")
+    cli_process_done()
+} else {
+    md_shp <- read_rds(here(shp_path))
+    cli_alert_success("Loaded {.strong MD} shapefile")
+}

--- a/analyses/MD_leg_2020/02_setup_MD_leg_2020.R
+++ b/analyses/MD_leg_2020/02_setup_MD_leg_2020.R
@@ -1,0 +1,38 @@
+###############################################################################
+# Set up redistricting simulation for `MD_leg_2020`
+# © ALARM Project, August 2026
+###############################################################################
+cli_process_start("Creating {.cls redist_map} object for {.pkg MD_leg_2020}")
+
+# Recode the enacted House labels to numeric IDs
+shd_lookup <- md_shp |>
+    st_drop_geometry() |>
+    distinct(shd_2020) |>
+    arrange(shd_2020) |>
+    mutate(shd_2020_id = row_number())
+
+md_shp <- md_shp |>
+    left_join(shd_lookup, by = "shd_2020")
+
+map_ssd <- redist_map(md_shp, pop_tol = 0.05,
+    existing_plan = ssd_2020, adj = md_shp$adj)
+
+map_shd <- redist_map(md_shp, pop_tol = 0.05,
+    existing_plan = shd_2020_id, adj = md_shp$adj)
+
+# make pseudo counties with default settings
+map_ssd <- map_ssd |>
+    mutate(pseudo_county = pick_county_muni(map_ssd, counties = county, munis = muni,
+        pop_muni = get_target(map_ssd)))
+map_shd <- map_shd |>
+    mutate(pseudo_county = pick_county_muni(map_shd, counties = county, munis = muni,
+        pop_muni = get_target(map_shd)))
+
+# Add an analysis name attribute
+attr(map_ssd, "analysis_name") <- "MD_SSD_2020"
+attr(map_shd, "analysis_name") <- "MD_SHD_2020"
+
+# Output the redist_map object. Do not edit this path.
+write_rds(map_ssd, "data-out/MD_2020/MD_leg_2020_map_ssd.rds", compress = "xz")
+write_rds(map_shd, "data-out/MD_2020/MD_leg_2020_map_shd.rds", compress = "xz")
+cli_process_done()

--- a/analyses/MD_leg_2020/03_sim_MD_shd_2020.R
+++ b/analyses/MD_leg_2020/03_sim_MD_shd_2020.R
@@ -1,0 +1,314 @@
+###############################################################################
+# Simulate plans for `MD_shd_2020` SHD
+# © ALARM Project, August 2026
+###############################################################################
+plans <- read_rds(here("data-out/MD_2020/MD_ssd_2020_plans_full.rds"))
+
+n_ssd <- n_distinct(md_shp$ssd_2020)
+inner_nsims <- 50
+inner_runs <- 1
+outer_runs <- 5
+max_split_tries <- 100000
+
+year <- 2020
+ssd_col <- paste0("ssd_", year)
+shd_col <- paste0("shd_", year)
+
+# Identify the enacted House structure within Senate districts
+ssd_split_structure <- md_shp |>
+    st_drop_geometry() |>
+    as_tibble() |>
+    distinct(ssd_2020, shd_2020) |>
+    count(ssd_2020, name = "n_shd") |>
+    arrange(ssd_2020)
+
+triple_split_ssds <- ssd_split_structure |>
+    filter(n_shd == 3) |>
+    pull(ssd_2020)
+
+two_one_split_ssds <- ssd_split_structure |>
+    filter(n_shd == 2) |>
+    pull(ssd_2020)
+
+mmd_ssds <- ssd_split_structure |>
+    filter(n_shd == 1) |>
+    pull(ssd_2020)
+
+# Generate district assignment matrix
+sample_ssd_matrix <- get_plans_matrix(subset_sampled(plans))
+final_sims <- ncol(sample_ssd_matrix)
+
+# Create shd map object
+map_shd_iterate <- redist_map(md_shp, pop_tol = 0.05,
+    ndists = 141, adj = md_shp$adj)
+
+# Unique ID for each row, will use later to reconnect pieces
+map_shd_iterate$row_id <- 1:nrow(map_shd_iterate)
+
+map_shd_iterate_dummy <- map_shd_iterate
+
+# Assign arbitrary bounds
+# (districts elect one, two, or three members.
+# Bounds prevent redist from rejecting the combined map)
+attr(map_shd_iterate_dummy, "pop_bounds") <- c(1, 43810, 6177224)
+
+# Run the nested simulation
+cli_process_start("Running simulations for {.pkg MD_shd_2020}")
+
+set.seed(2020)
+
+# For each sampled Senate plan, split districts following the enacted structure
+# and recombine them into one statewide House plan
+for (i in 1:final_sims) {
+    # Add Senate district assignment from simulation i
+    map_shd_iterate$ssd_sim <- as.numeric(sample_ssd_matrix[, i])
+
+    # Completed House plan combines 47 Senate district pieces
+    plan_list <- vector("list", 47)
+
+    failed <- FALSE
+
+    # Split 1+1+1 Senate districts into three single-member districts
+    for (ssd in triple_split_ssds) {
+
+        m <- map_shd_iterate |>
+            filter(ssd_sim == ssd)
+
+        map_j <- redist_map(m,
+            pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+            ndists = 3, adj = m$adj)
+
+        output <- capture.output(
+            {
+                result <- tryCatch(
+                    {
+                        plans_j <- redist_smc(
+                            map_j,
+                            nsims = inner_nsims, runs = inner_runs,
+                            counties = county,
+                            sampling_space = "linking_edge",
+                            split_params = list(splitting_schedule = "any_valid_sizes"),
+                            verbose = TRUE,
+                            control = list(max_split_tries = max_split_tries))
+                    },
+                    error = function(e) {
+                        NULL
+                    })
+            },
+            type = "output")
+
+        # Catch failed splits
+        if (is.null(result) || any(grepl("Failed to split", output))) {
+            failed <- TRUE
+            cat("\nFAILURE at outer i =", i, "inner SSD =", ssd, "\n")
+            break
+        }
+
+        plans_j <- plans_j |> filter(draw == inner_nsims*inner_runs)
+        plans_j$dist_keep <- TRUE
+        plan_list[[ssd]] <- list(map = map_j, plans = plans_j)
+    }
+
+    # Split 2+1 Senate districts into one two-member and one
+    # single-member district
+    if (!failed) {
+        for (ssd in two_one_split_ssds) {
+
+            m <- map_shd_iterate |>
+                filter(ssd_sim == ssd)
+
+            # first split the Senate district into three single-seat pieces
+            map_three <- redist_map(m,
+                pop_bounds = attr(map_shd_iterate, "pop_bounds"),
+                ndists = 3, adj = m$adj)
+
+            output <- capture.output(
+                {
+                    result <- tryCatch(
+                        {
+                            plans_three <- redist_smc(
+                                map_three,
+                                nsims = inner_nsims, runs = inner_runs,
+                                counties = county,
+                                sampling_space = "linking_edge",
+                                split_params = list(splitting_schedule = "any_valid_sizes"),
+                                verbose = TRUE,
+                                control = list(max_split_tries = max_split_tries))
+                        },
+                        error = function(e) {
+                            NULL
+                        })
+                },
+                type = "output")
+
+            # Catch failed splits
+            if (is.null(result) || any(grepl("Failed to split", output))) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner SSD =", ssd, "\n")
+                break
+            }
+
+            plans_three <- plans_three |> filter(draw == inner_nsims*inner_runs)
+
+            assignment <- get_plans_matrix(subset_sampled(plans_three))[, 1]
+
+            # create adjacency among the three simulated House districts
+            district_adj <- redist.coarsen.adjacency(map_three$adj, assignment)
+
+            # select one adjacent pair to form the two-member district
+            merge_from_candidates <- which(lengths(district_adj) > 0L)
+
+            merge_from <- merge_from_candidates[
+                sample.int(length(merge_from_candidates), 1L)
+            ]
+
+            merge_to_candidates <- district_adj[[merge_from]] + 1L
+
+            merge_to <- merge_to_candidates[
+                sample.int(length(merge_to_candidates), 1L)
+            ]
+
+            merge_pair <- c(merge_from, merge_to)
+
+            collapsed_assignment <- ifelse(assignment %in% merge_pair, 1L, 2L)
+
+            m$inner_plan <- collapsed_assignment
+
+            map_j <- redist_map(m, existing_plan = inner_plan,
+                pop_bounds = c(1, 43810, sum(m$pop)), adj = m$adj)
+
+            plans_j <- redist_plans(plans = matrix(collapsed_assignment),
+                map = map_j, algorithm = "smc")
+
+            plans_j$dist_keep <- TRUE
+            plan_list[[ssd]] <- list(map = map_j, plans = plans_j)
+        }
+    }
+
+    # Preserve the remaining Senate districts as three-member districts
+    if (!failed) {
+        for (ssd in mmd_ssds) {
+
+            m <- map_shd_iterate |> filter(ssd_sim == ssd)
+
+            m$inner_plan <- 1L
+
+            mmd_result <- tryCatch(
+                {
+                    map_j <- redist_map(m, existing_plan = inner_plan,
+                        pop_tol = 0.05, adj = m$adj)
+
+                    plans_j <- redist_plans(plans = matrix(m$inner_plan),
+                        map = map_j, algorithm = "smc")
+
+                    plans_j$dist_keep <- TRUE
+
+                    list(map = map_j, plans = plans_j)
+                },
+                error = function(e) {
+                    NULL
+                })
+
+            if (is.null(mmd_result)) {
+                failed <- TRUE
+                cat("\nFAILURE at outer i =", i, "inner SSD =", ssd, "\n")
+                break
+            }
+
+            plan_list[[ssd]] <- mmd_result
+        }
+    }
+
+    # Combine all simulated plans and unchanged districts
+    if (!failed) {
+        prep_mat <- prep_particles(map = map_shd_iterate, map_plan_list = plan_list,
+            uid = row_id, dist_keep = dist_keep, nsims = 1)
+    }
+
+    if (failed) {
+        # Return dummy plan
+        prep_mat <- rep(1:n_distinct(map_shd$shd_2020), length.out = nrow(map_shd_iterate))
+        plans_dummy <- redist_plans(plans = prep_mat, map_shd_iterate_dummy, algorithm = "smc")
+        plans_dummy$draw <- as.factor(99999)
+
+        plans_i <- plans_dummy
+    }
+
+    if (!failed) {
+        plans_i <- redist_plans(plans = prep_mat, map_shd_iterate_dummy, algorithm = "smc")
+
+        cat("\nFINISHED HOUSE DISTRICT ", i, " OF ", final_sims)
+    }
+
+    if (i == 1) {
+        plans_shd <- plans_i
+    } else {
+        plans_shd <- rbind(plans_shd, plans_i)
+    }
+}
+
+# Survival rate
+survive <- plans_shd |>
+    as.data.frame() |>
+    filter(district == 1) |>
+    mutate(survive = ifelse(draw == 1, TRUE, FALSE)) |>
+    dplyr::select(survive)
+
+# Sample size
+sum(survive$survive)
+
+survive_all <- plans_shd |>
+    as.data.frame() |>
+    mutate(survive_all = ifelse(draw == 1, TRUE, FALSE)) |>
+    dplyr::select(survive_all)
+
+# retain successful outer simulations only
+plans_shd_matrix <- get_plans_matrix(plans_shd)
+plans_shd_matrix <- plans_shd_matrix[, survive$survive, drop = FALSE]
+
+plans_shd <- redist_plans(plans = plans_shd_matrix,
+    map = map_shd,
+    algorithm = "smc")
+
+# Add draw and chain numbering
+plans_shd$draw <- as.factor(rep(1:sum(survive$survive), each = n_distinct(map_shd[[shd_col]])))
+
+full_chain <- rep(1:outer_runs, each = n_distinct(map_shd[[shd_col]])*final_sims/outer_runs)
+
+plans_shd$chain <- full_chain[survive_all$survive_all]
+
+# Add enacted plan
+plans_shd <- add_reference(plans_shd, ref_plan = as.integer(factor(map_shd[[shd_col]])), name = shd_col)
+
+plans <- plans_shd |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "shd_2020")
+
+cli_process_done()
+
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path
+write_rds(plans, "data-out/MD_2020/MD_shd_2020_plans.rds", compress = "xz")
+
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MD_shd_2020}")
+
+plans <- add_summary_stats(plans, map_shd)
+
+# Output the summary statistics. Do not edit this path
+save_summary_stats(plans, "data-out/MD_2020/MD_shd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_shd)
+    summary(plans)
+}

--- a/analyses/MD_leg_2020/03_sim_MD_ssd_2020.R
+++ b/analyses/MD_leg_2020/03_sim_MD_ssd_2020.R
@@ -1,0 +1,59 @@
+###############################################################################
+# Simulate plans for `MD_ssd_2020` SSD
+# © ALARM Project, August 2026
+###############################################################################
+
+# Run the simulation -----
+cli_process_start("Running simulations for {.pkg MD_ssd_2020}")
+
+set.seed(2020)
+
+mh_accept_per_smc <- ceiling(n_distinct(map_ssd$ssd_2020)/3) + 80
+
+constr <- redist_constr(map_ssd) |>
+    add_constr_total_splits(2.1, admin = county)
+
+plans_full <- redist_smc(
+    map_ssd,
+    nsims = 6500, runs = 5,
+    counties = county,
+    constraints = constr,
+    ncores = 0,
+    sampling_space = "linking_edge",
+    ms_params = list(frequency = 1L, mh_accept_per_smc = mh_accept_per_smc),
+    split_params = list(splitting_schedule = "any_valid_sizes"),
+    verbose = TRUE
+)
+
+plans <- plans_full |>
+    group_by(chain) |>
+    filter(as.integer(draw) < min(as.integer(draw)) + 2000) |> # thin samples
+    ungroup()
+plans <- match_numbers(plans, "ssd_2020")
+plans_full <- match_numbers(plans_full, "ssd_2020")
+
+cli_process_done()
+cli_process_start("Saving {.cls redist_plans} object")
+
+# Output the redist_map object. Do not edit this path.
+write_rds(plans_full, here("data-out/MD_2020/MD_ssd_2020_plans_full.rds"), compress = "xz")
+write_rds(plans, here("data-out/MD_2020/MD_ssd_2020_plans.rds"), compress = "xz")
+cli_process_done()
+
+# Compute summary statistics -----
+cli_process_start("Computing summary statistics for {.pkg MD_ssd_2020}")
+
+plans <- add_summary_stats(plans, map_ssd)
+
+# Output the summary statistics. Do not edit this path.
+save_summary_stats(plans, "data-out/MD_2020/MD_ssd_2020_stats.csv")
+
+cli_process_done()
+
+if (interactive()) {
+    library(ggplot2)
+    library(patchwork)
+
+    validate_analysis(plans, map_ssd)
+    summary(plans)
+}

--- a/analyses/MD_leg_2020/doc_MD_leg_2020.md
+++ b/analyses/MD_leg_2020/doc_MD_leg_2020.md
@@ -29,5 +29,5 @@ Because the Constitution permits delegate districts electing one, two, or three 
 For each of the 32,500 sampled Senate plans, we run 50 inner SMC simulations within each of the 18 Senate districts that are subdivided under the enacted plan and retain one successful split per district. 
 Of these, 6 Senate districts (1, 27, 29, 33, 38, 42) are divided into three single-member House districts, and the other 12 (2, 7, 9, 11, 12, 30, 34, 35, 37, 43, 44, 47) are divided into one single-member pieces, after which a randomly selected adjacent pair is combined to form one two-member district.
 The remaining 29 Senate districts are carried forward as three-member House districts without an additional inner simulation. 
-11,801 districting plans remaining in the surviving sample.
+11,801 districting plans remain in the surviving sample.
 We then thinned the number of samples to 10,000.

--- a/analyses/MD_leg_2020/doc_MD_leg_2020.md
+++ b/analyses/MD_leg_2020/doc_MD_leg_2020.md
@@ -1,0 +1,33 @@
+# 2020 Maryland State House/Senate Districts
+
+## Redistricting requirements
+In Maryland, state legislative districts must, under [Article III of the Maryland Constitution](https://msa.maryland.gov/msa/mdmanual/43const/html/03art3.html):
+
+1. consist of adjoining territory (§ 4)
+2. be compact in form (§ 4)
+3. be of substantially equal population (§ 4)
+4. give due regard to natural boundaries and the boundaries of political subdivisions (§ 4)
+5. contain one senator and three delegates. A legislative district may be subdivided into three single-member delegate districts or one single-member delegate district and one multi-member delegate district (§ 2-3).
+
+### Algorithmic Constraints
+We enforce a maximum population deviation of 5.0%.
+
+## Data Sources
+Data for Maryland comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).
+
+## Pre-processing Notes
+We edited the adjacency graph to prevent districts from crossing the Bay. 
+Bay water precincts were reconnected to nearby same-side precincts, remaining cross-Bay edges were removed, and necessary land and island connections were restored to preserve enacted-district contiguity.
+
+## Simulation Notes
+We sample 32,500 districting plans for Maryland's upper house across 5 independent runs of the SMC algorithm. 
+We then thinned the number of samples to 10,000. 
+We impose total county constraints and increase the number of merge-split proposals per SMC step to 96.
+
+We use the top-down nested procedure to sample Maryland's lower house districts. 
+Because the Constitution permits delegate districts electing one, two, or three members, we follow the subdivision structure of the enacted plan within each simulated Senate district.
+For each of the 32,500 sampled Senate plans, we run 50 inner SMC simulations within each of the 18 Senate districts that are subdivided under the enacted plan and retain one successful split per district. 
+Of these, 6 Senate districts (1, 27, 29, 33, 38, 42) are divided into three single-member House districts, and the other 12 (2, 7, 9, 11, 12, 30, 34, 35, 37, 43, 44, 47) are divided into one single-member pieces, after which a randomly selected adjacent pair is combined to form one two-member district.
+The remaining 29 Senate districts are carried forward as three-member House districts without an additional inner simulation. 
+11,801 districting plans remaining in the surviving sample.
+We then thinned the number of samples to 10,000.


### PR DESCRIPTION
## Redistricting requirements
In Maryland, state legislative districts must, under [Article III of the Maryland Constitution](https://msa.maryland.gov/msa/mdmanual/43const/html/03art3.html):

1. consist of adjoining territory (§ 4)
2. be compact in form (§ 4)
3. be of substantially equal population (§ 4)
4. give due regard to natural boundaries and the boundaries of political subdivisions (§ 4)
5. contain one senator and three delegates. A legislative district may be subdivided into three single-member delegate districts or one single-member delegate district and one multi-member delegate district (§ 2-3).

### Algorithmic Constraints
We enforce a maximum population deviation of 5.0%.

## Data Sources
Data for Maryland comes from the ALARM Project's [2020 Redistricting Data Files](https://alarm-redist.github.io/posts/2021-08-10-census-2020/).

## Pre-processing Notes
We edited the adjacency graph to prevent districts from crossing the Bay. 
Bay water precincts were reconnected to nearby same-side precincts, remaining cross-Bay edges were removed, and necessary land and island connections were restored to preserve enacted-district contiguity.

## Simulation Notes
We sample 32,500 districting plans for Maryland's upper house across 5 independent runs of the SMC algorithm. 
We then thinned the number of samples to 10,000. 
We impose total county constraints and increase the number of merge-split proposals per SMC step to 96.

We use the top-down nested procedure to sample Maryland's lower house districts. 
Because the Constitution permits delegate districts electing one, two, or three members, we follow the subdivision structure of the enacted plan within each simulated Senate district.
For each of the 32,500 sampled Senate plans, we run 50 inner SMC simulations within each of the 18 Senate districts that are subdivided under the enacted plan and retain one successful split per district. 
Of these, 6 Senate districts (1, 27, 29, 33, 38, 42) are divided into three single-member House districts, and the other 12 (2, 7, 9, 11, 12, 30, 34, 35, 37, 43, 44, 47) are divided into one single-member pieces, after which a randomly selected adjacent pair is combined to form one two-member district.
The remaining 29 Senate districts are carried forward as three-member House districts without an additional inner simulation. 
11,801 districting plans remain in the surviving sample.
We then thinned the number of samples to 10,000.

## Validation
### State Senate
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/40e7964d-a116-42ac-95f2-1217541c7b18" />

```
SMC with Merge-Split MCMC Steps: 10,000 sampled plans of 47
                 districts on 2,350 units
Plans sampled on Linking Edge Forest Space using the Uniform Valid Edge forward kernel.
SMC Parameters:
• `weight_type` = optimal
• `seq_alpha` = 1
• `pop_temper` = 0
Mergesplit Parameters:
• `total_ms_steps` = 46
• `mh_accept_per_smc` = 96
• `pair_rule` = uniform
Plan diversity 80% range: 0.77 to 0.86
27 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20 
              1.001               1.001               1.001               1.001               1.001               1.001 
     atg_18_dem_fro      atg_18_rep_wol     comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.001               1.001               1.001               1.000               1.001               1.000 
              e_dem               e_dvs                egap      gov_18_dem_jea      gov_18_rep_hog         muni_splits 
              1.001               1.001               1.001               1.001               1.001               1.000 
            ndshare                 ndv                 nrv               pbias            plan_dev            pop_aian 
              1.001               1.001               1.001               1.001               1.000               1.002 
          pop_asian           pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.002               1.002               1.001               1.001               1.001               1.001 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.001               1.001               1.001               1.001               1.001               1.001 
     pre_20_rep_tru total_county_splits   total_muni_splits           total_vap      uss_16_dem_van      uss_16_rep_sze 
              1.001               1.000               1.000               1.002               1.001               1.001 
     uss_18_dem_car      uss_18_rep_cam            vap_aian           vap_asian           vap_black            vap_hisp 
              1.001               1.001               1.002               1.002               1.002               1.001 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.001               1.001               1.001               1.001 
• R-hat ≤ 1.05: 2417
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 2417
Sampling diagnostics for SMC run 1 of 5 (10,000 samples)
         Eff. samples (%) Acc. rate Log wgt. sd  Max. unique 
Split 1     2,119 (32.6%)    100.0%        0.85 4,085 ( 99%) 
Split 2     1,595 (24.5%)     97.9%        0.94 3,155 ( 77%) 
Split 3     2,000 (30.8%)     95.9%        1.01 2,995 ( 73%) 
Split 4     2,385 (36.7%)     93.0%        0.98 3,026 ( 74%) 
Split 5     2,849 (43.8%)     90.5%        0.93 3,172 ( 77%) 
Split 6     3,353 (51.6%)     87.1%        0.86 3,304 ( 80%) 
Split 7     3,588 (55.2%)     84.7%        0.82 3,421 ( 83%) 
Split 8     3,807 (58.6%)     82.2%        0.78 3,452 ( 84%) 
Split 9     4,099 (63.1%)     80.0%        0.75 3,554 ( 86%) 
Split 10    4,322 (66.5%)     78.7%        0.69 3,594 ( 87%) 
Split 11    4,542 (69.9%)     75.3%        0.65 3,638 ( 89%) 
Split 12    4,803 (73.9%)     73.8%        0.61 3,662 ( 89%) 
Split 13    4,875 (75.0%)     71.1%        0.59 3,774 ( 92%) 
Split 14    5,102 (78.5%)     70.6%        0.55 3,746 ( 91%) 
Split 15    5,180 (79.7%)     68.2%        0.53 3,806 ( 93%) 
Split 16    5,326 (81.9%)     67.0%        0.50 3,868 ( 94%) 
Split 17    5,389 (82.9%)     63.6%        0.48 3,825 ( 93%) 
Split 18    5,489 (84.4%)     62.5%        0.45 3,864 ( 94%) 
Split 19    5,564 (85.6%)     60.0%        0.44 3,869 ( 94%) 
Split 20    5,625 (86.5%)     58.6%        0.42 3,877 ( 94%) 
Split 21    5,679 (87.4%)     57.0%        0.40 3,901 ( 95%) 
Split 22    5,729 (88.1%)     55.4%        0.38 3,939 ( 96%) 
Split 23    5,802 (89.3%)     53.8%        0.37 3,965 ( 97%) 
Split 24    5,844 (89.9%)     52.3%        0.35 3,959 ( 96%) 
Split 25    5,878 (90.4%)     50.9%        0.34 3,924 ( 96%) 
Split 26    5,913 (91.0%)     48.8%        0.33 3,957 ( 96%) 
Split 27    5,930 (91.2%)     46.6%        0.32 3,915 ( 95%) 
Split 28    5,963 (91.7%)     45.4%        0.31 3,966 ( 97%) 
Split 29    5,994 (92.2%)     45.0%        0.30 3,967 ( 97%) 
Split 30    6,054 (93.1%)     43.0%        0.28 3,957 ( 96%) 
Split 31    6,054 (93.1%)     41.3%        0.28 4,000 ( 97%) 
Split 32    6,046 (93.0%)     40.2%        0.28 4,018 ( 98%) 
Split 33    6,092 (93.7%)     39.4%        0.27 4,022 ( 98%) 
Split 34    6,109 (94.0%)     38.5%        0.26 4,009 ( 98%) 
Split 35    6,110 (94.0%)     37.2%        0.26 4,020 ( 98%) 
Split 36    6,139 (94.4%)     36.2%        0.25 3,986 ( 97%) 
Split 37    6,154 (94.7%)     34.9%        0.24 3,987 ( 97%) 
Split 38    6,175 (95.0%)     33.6%        0.23 3,954 ( 96%) 
Split 39    6,191 (95.3%)     33.6%        0.23 3,975 ( 97%) 
Split 40    6,204 (95.4%)     31.3%        0.22 3,982 ( 97%) 
Split 41    6,222 (95.7%)     30.7%        0.22 3,952 ( 96%) 
Split 42    6,249 (96.1%)     30.3%        0.21 3,946 ( 96%) 
Split 43    6,275 (96.5%)     29.7%        0.20 3,996 ( 97%) 
Split 44    6,301 (96.9%)     29.1%        0.18 3,897 ( 95%) 
Split 45    6,329 (97.4%)     28.3%        0.17 3,841 ( 93%) 
Split 46    6,368 (98.0%)     27.0%        0.15 3,629 ( 88%) 
Resample    6,368 (98.0%)       NA%          NA 6,106 (149%) 

Sampling diagnostics for Mergesplit Steps of SMC run 1 of 5 (10,000 samples)
           Acc. rate MS Steps per Plan
MS Step 1      48.8%                96
MS Step 2      43.4%               288
MS Step 3      40.5%               288
MS Step 4      39.6%               288
MS Step 5      39.6%               288
MS Step 6      39.9%               288
MS Step 7      40.2%               288
MS Step 8      41.0%               288
MS Step 9      41.6%               288
MS Step 10     42.3%               288
MS Step 11     43.0%               288
MS Step 12     43.5%               288
MS Step 13     44.0%               288
MS Step 14     44.6%               288
MS Step 15     44.9%               288
MS Step 16     45.2%               288
MS Step 17     45.4%               288
MS Step 18     45.5%               288
MS Step 19     45.6%               288
MS Step 20     45.4%               288
MS Step 21     45.4%               288
MS Step 22     45.1%               288
MS Step 23     44.8%               288
MS Step 24     44.6%               288
MS Step 25     44.1%               288
MS Step 26     43.8%               288
MS Step 27     43.5%               288
MS Step 28     43.0%               288
MS Step 29     42.4%               288
MS Step 30     42.0%               288
MS Step 31     41.5%               288
MS Step 32     40.9%               288
MS Step 33     40.3%               288
MS Step 34     39.7%               288
MS Step 35     39.2%               288
MS Step 36     38.6%               288
MS Step 37     38.0%               288
MS Step 38     37.4%               288
MS Step 39     36.9%               288
MS Step 40     36.3%               288
MS Step 41     35.7%               288
MS Step 42     35.2%               288
MS Step 43     34.7%               288
MS Step 44     34.2%               288
MS Step 45     33.7%               288
MS Step 46     33.3%               288

•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

### State House
<img width="3000" height="5400" alt="image" src="https://github.com/user-attachments/assets/82abd0f2-dd1c-4adf-85b9-1274fd5c4b15" />

```
SMC: 10,000 sampled plans of 71
                 districts on 2,350 units
Plans sampled on graph_plan using the top_k forward kernel.
Forward kernel parameters: `adapt_k_thresh`=NULL
SMC Parameters:
• `weight_type` = simple
• `seq_alpha` = NULL
• `pop_temper` = NULL
Plan diversity 80% range: 0.82 to 0.90
39 rhat values are `NA`
Largest R-hat values for ordered summary statistics:

             adv_16              adv_18              adv_20              arv_16              arv_18              arv_20 
              1.001               1.001               1.001               1.001               1.002               1.001 
     atg_18_dem_fro      atg_18_rep_wol     comp_bbox_reock           comp_edge         comp_polsby       county_splits 
              1.001               1.001               1.001               1.000               1.001               1.000 
              e_dem               e_dvs                egap      gov_18_dem_jea      gov_18_rep_hog         muni_splits 
              1.000               1.001               1.000               1.001               1.002               1.000 
            ndshare                 ndv                 nrv               pbias            plan_dev            pop_aian 
              1.001               1.001               1.001               1.000               1.000               1.001 
          pop_asian           pop_black            pop_hisp            pop_nhpi           pop_other         pop_overlap 
              1.001               1.001               1.001               1.001               1.001               1.000 
            pop_two           pop_white              pr_dem      pre_16_dem_cli      pre_16_rep_tru      pre_20_dem_bid 
              1.001               1.001               1.000               1.001               1.001               1.001 
     pre_20_rep_tru total_county_splits   total_muni_splits           total_vap      uss_16_dem_van      uss_16_rep_sze 
              1.001               1.000               1.000               1.001               1.001               1.001 
     uss_18_dem_car      uss_18_rep_cam            vap_aian           vap_asian           vap_black            vap_hisp 
              1.001               1.001               1.001               1.001               1.001               1.001 
           vap_nhpi           vap_other             vap_two           vap_white 
              1.001               1.001               1.001               1.001 
• R-hat ≤ 1.05: 3653
• 1.05 < R-hat ≤ 1.1: 0
• R-hat > 1.1: 0
• Total R-hats: 3653
•  Watch out for low effective samples, very low acceptance rates (less than 1%), large std. devs. of the log weights
(more than 3 or so), and low numbers of unique plans. R-hat values for summary statistics should be between 1 and 1.05.
```

## Checklist

- [x] I have followed the [instructions](https://github.com/alarm-redist/fifty-states/blob/main/CONTRIBUTING.md)
- [x] I have updated the [tracker](https://docs.google.com/spreadsheets/d/1k_tYLoE49W_DCK1tcWbouoYZFI9WD76oayEt5TOmJg4/edit#gid=453387933)
- [x] All `TODO` lines from the template code have been removed
- [x] I have merged in the main branch and then recalculated summary statistics
- [x] I have run `enforce_style()` to format my code
- [x] The documentation copied above is up-to-date 
- [x] There are no data files in this pull request
- [x] None of the file output paths (for the `redist_map` and `redist_plans` objects, and summary statistics) have been edited